### PR TITLE
Feature/v6.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,51 @@ All notable changes to OrionGuard will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.4.0] - 2026-05-20
+
+### Added
+
+#### Business Rule ergonomics (`Moongazing.OrionGuard`)
+- `BusinessRule` and `AsyncBusinessRule` abstract base classes implementing `IBusinessRule` / `IAsyncBusinessRule`. `MessageKey` defaults to the CLR type name.
+- `Guard.AgainstBrokenRule(IBusinessRule)` and `Guard.AgainstBrokenRuleAsync(IAsyncBusinessRule, CancellationToken)` static helpers. `Entity.CheckRule` / `CheckRuleAsync` now delegate to these helpers (behaviour unchanged).
+
+#### ASP.NET Core ProblemDetails (`Moongazing.OrionGuard.AspNetCore`)
+- `OrionGuardExceptionHandler` now produces a 422 `ValidationProblemDetails` for `BusinessRuleValidationException` (previously fell through to the framework default 500).
+- New `OrionGuardAspNetCoreOptions.BusinessRuleStatusCode` (default 422) for clients that require 400.
+- New `OrionGuardProblemDetailsFactory.Create(BusinessRuleValidationException)` overload — `errors` keyed by `RuleName`, `Type` = `https://moongazing.dev/orionguard/problems/business-rule-violation`.
+
+#### Outbox production-hardening (`Moongazing.OrionGuard.EntityFrameworkCore`)
+- `IDistributedLock` / `IDistributedLockHandle` abstractions. Default `SkipLockedDistributedLock` uses an `OutboxLock` row per key in `OrionGuard_OutboxLocks` (provider-agnostic via EF Core raw SQL). Multi-instance outbox workers no longer double-dispatch.
+- `NullDistributedLock` no-op implementation for single-instance consumers who do not want to apply the new migration. Wire with `opts.UseOutbox().UseDistributedLock<NullDistributedLock>()`.
+- `OutboxTypeMapRegistry` — opt-in logical-name to CLR type mapping. The `SaveChanges` interceptor prefers logical names when registered; the dispatcher resolves them on read. Falls back to AQN when no mapping exists (toggle via `OutboxTypeMapOptions.AllowAssemblyQualifiedNameFallback`).
+- `OutboxArchivalHostedService` — opt-in periodic deletion of processed outbox rows. Default 30-day retention, 1-hour polling, dead-letter rows preserved.
+- `OutboxOptions.LockKey` (default `"orion_guard_outbox_dispatcher"`) and `OutboxOptions.LockLeaseDuration` (default 30s).
+- `OrionGuardEfCoreOptions.UseDistributedLock<T>()`, `UseOutboxTypeMap(...)`, `UseOutboxArchival(...)`.
+
+### Changed
+- `Entity.CheckRule` / `Entity.CheckRuleAsync` internally delegate to `Guard.AgainstBrokenRule` / `Guard.AgainstBrokenRuleAsync`. Public behaviour unchanged.
+- `OutboxDispatcherHostedService` constructor expanded with `IDistributedLock`, `OutboxTypeMapRegistry`, and `OutboxTypeMapOptions` parameters (optional, defaulted). The DI factory in `AddOrionGuardEfCore` updates accordingly; consumers using only DI are unaffected.
+
+### Migration from v6.3.0
+
+- **No breaking source changes.**
+- **Distributed locking (recommended for multi-instance deployments):**
+  Add an EF Core migration that creates `OrionGuard_OutboxLocks` — see `docs/migrations/v6.4.0-outbox-locks.md`.
+  No code change needed when using `AddOrionGuardEfCore` — `SkipLockedDistributedLock` is wired automatically.
+- **Single-instance consumers who do NOT want to apply the migration:**
+  `opts.UseOutbox(...).UseDistributedLock<NullDistributedLock>()`.
+- **Type-safe outbox payloads (optional):**
+  `opts.UseOutbox(...).UseOutboxTypeMap(r => r.Map<UserRegistered>("user.registered"));`
+- **Outbox archival (optional):**
+  `opts.UseOutbox(...).UseOutboxArchival(a => a.RetentionPeriod = TimeSpan.FromDays(60));`
+- **`BusinessRule` base class (optional):** existing `IBusinessRule` implementations work unchanged.
+- **`Guard.AgainstBrokenRule` (additive):** `Guard.AgainstBrokenRule(new OrderMustHaveItems(order));`
+- **`BusinessRuleValidationException` to 422 ProblemDetails (automatic):** customize via `OrionGuardAspNetCoreOptions.BusinessRuleStatusCode`.
+
+### Roadmap
+
+- v6.5+: Redis / Consul `IDistributedLock` implementations as extension packages. Push-based outbox dispatch (`LISTEN/NOTIFY`, `SqlDependency`). Audit-trail copy-before-delete for archival.
+
 ## [6.2.0] - 2026-04-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Entity.CheckRule` / `Entity.CheckRuleAsync` internally delegate to `Guard.AgainstBrokenRule` / `Guard.AgainstBrokenRuleAsync`. Public behaviour unchanged.
 - `OutboxDispatcherHostedService` constructor expanded with `IDistributedLock`, `OutboxTypeMapRegistry`, and `OutboxTypeMapOptions` parameters (optional, defaulted). The DI factory in `AddOrionGuardEfCore` updates accordingly; consumers using only DI are unaffected.
 
+### Deprecated
+
+- The `[StronglyTypedId<TValue>]` source generator is soft-deprecated in favour of the standalone **OrionKey** package (`[OrionId<TValue>]` / `[OrionId<TValue, TStrategy>]`). Existing usages keep compiling and the generator keeps emitting; each `[StronglyTypedId]` usage now raises a CS0618 warning with migration guidance. The generator will be removed in v7.0.0. The manual `StronglyTypedId<TValue>` record, `IStronglyTypedId<TValue>`, and the related guards are unaffected. See `docs/migrations/stronglytypedid-to-orionkey.md`.
+
 ### Migration from v6.3.0
 
 - **No breaking source changes.**

--- a/Moongazing.OrionGuard.sln
+++ b/Moongazing.OrionGuard.sln
@@ -51,6 +51,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Moongazing.OrionGuard.Testi
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Moongazing.OrionGuard.EntityFrameworkCore.Tests", "tests\Moongazing.OrionGuard.EntityFrameworkCore.Tests\Moongazing.OrionGuard.EntityFrameworkCore.Tests.csproj", "{E47B2C8A-91D3-4F65-B208-15C8FA60D139}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Moongazing.OrionGuard.AspNetCore.Tests", "tests\Moongazing.OrionGuard.AspNetCore.Tests\Moongazing.OrionGuard.AspNetCore.Tests.csproj", "{9DB6CD9F-B22B-482E-B660-76D58184D406}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -265,6 +267,18 @@ Global
 		{E47B2C8A-91D3-4F65-B208-15C8FA60D139}.Release|x64.Build.0 = Release|Any CPU
 		{E47B2C8A-91D3-4F65-B208-15C8FA60D139}.Release|x86.ActiveCfg = Release|Any CPU
 		{E47B2C8A-91D3-4F65-B208-15C8FA60D139}.Release|x86.Build.0 = Release|Any CPU
+		{9DB6CD9F-B22B-482E-B660-76D58184D406}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9DB6CD9F-B22B-482E-B660-76D58184D406}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9DB6CD9F-B22B-482E-B660-76D58184D406}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{9DB6CD9F-B22B-482E-B660-76D58184D406}.Debug|x64.Build.0 = Debug|Any CPU
+		{9DB6CD9F-B22B-482E-B660-76D58184D406}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9DB6CD9F-B22B-482E-B660-76D58184D406}.Debug|x86.Build.0 = Debug|Any CPU
+		{9DB6CD9F-B22B-482E-B660-76D58184D406}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9DB6CD9F-B22B-482E-B660-76D58184D406}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9DB6CD9F-B22B-482E-B660-76D58184D406}.Release|x64.ActiveCfg = Release|Any CPU
+		{9DB6CD9F-B22B-482E-B660-76D58184D406}.Release|x64.Build.0 = Release|Any CPU
+		{9DB6CD9F-B22B-482E-B660-76D58184D406}.Release|x86.ActiveCfg = Release|Any CPU
+		{9DB6CD9F-B22B-482E-B660-76D58184D406}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -287,5 +301,6 @@ Global
 		{7EBDDD5C-2768-45CF-BDF4-E89010A6F75A} = {A26C0EB7-E4A7-4335-8423-E8AEE9EF1738}
 		{D3FA5B6C-9E04-4A12-9E73-CB10D4F235E3} = {A26C0EB7-E4A7-4335-8423-E8AEE9EF1738}
 		{E47B2C8A-91D3-4F65-B208-15C8FA60D139} = {A26C0EB7-E4A7-4335-8423-E8AEE9EF1738}
+		{9DB6CD9F-B22B-482E-B660-76D58184D406} = {A26C0EB7-E4A7-4335-8423-E8AEE9EF1738}
 	EndGlobalSection
 EndGlobal

--- a/README.md
+++ b/README.md
@@ -214,6 +214,8 @@ var result = validator.Validate(userDto);
 
 ### DDD Primitives (NEW in v6.1)
 
+> **Deprecated in v6.4.0.** The `[StronglyTypedId]` source generator is superseded by the standalone [OrionKey](https://github.com/tunahanaliozturk/OrionKey) package (`[OrionId]`). It still works through the v6.x line and is removed in v7.0.0. See [the migration guide](docs/migrations/stronglytypedid-to-orionkey.md). The manual `StronglyTypedId<TValue>` record is not affected.
+
 ```csharp
 // Hybrid ValueObject — abstract class or record-based marker
 public sealed class Money : ValueObject

--- a/README.md
+++ b/README.md
@@ -422,6 +422,75 @@ var msg = ValidationMessages.Get("NotNull", "Email");
 
 ---
 
+## Benchmarks
+
+Measured with BenchmarkDotNet v0.14.0 on an Intel Core i7-7820HQ CPU 2.90GHz (Kaby Lake), Windows 11, .NET 10.0.5 (X64 RyuJIT AVX2). Run with the `ShortRun` job (3 warmup + 3 iterations); numbers are indicative. Run `dotnet run -c Release --project benchmarks/Moongazing.OrionGuard.Benchmarks` to reproduce.
+
+### Null checks
+
+| Method                               | Mean       | Error      | StdDev    | Median     | Ratio  | RatioSD | Gen0   | Allocated | Alloc Ratio |
+|------------------------------------- |-----------:|-----------:|----------:|-----------:|-------:|--------:|-------:|----------:|------------:|
+| RawIfThrow_NotNull                   |  0.9427 ns |  9.0955 ns | 0.4986 ns |  0.7322 ns |  1.175 |    0.72 |      - |         - |          NA |
+| Guard_AgainstNull                    |  0.1294 ns |  0.8487 ns | 0.0465 ns |  0.1418 ns |  0.161 |    0.08 |      - |         - |          NA |
+| Ensure_That_NotNull                  | 15.1543 ns | 34.4373 ns | 1.8876 ns | 14.1039 ns | 18.890 |    7.35 | 0.0191 |      80 B |          NA |
+| FastGuard_NotNull                    |  1.2557 ns |  1.3515 ns | 0.0741 ns |  1.2389 ns |  1.565 |    0.59 |      - |         - |          NA |
+| Guard_AgainstNullOrEmpty_ValidString |  1.1358 ns |  3.1390 ns | 0.1721 ns |  1.0534 ns |  1.416 |    0.56 |      - |         - |          NA |
+| FastGuard_NotNullOrEmpty_ValidString |  0.0796 ns |  1.7406 ns | 0.0954 ns |  0.0534 ns |  0.099 |    0.12 |      - |         - |          NA |
+| Ensure_NotNullOrEmpty_ValidString    |  0.0000 ns |  0.0000 ns | 0.0000 ns |  0.0000 ns |  0.000 |    0.00 |      - |         - |          NA |
+
+### Email validation
+
+| Method                    | Mean     | Error    | StdDev   | Ratio | RatioSD | Gen0   | Allocated | Alloc Ratio |
+|-------------------------- |---------:|---------:|---------:|------:|--------:|-------:|----------:|------------:|
+| RawCompiledRegex_Email    | 78.23 ns | 23.68 ns | 1.298 ns |  1.00 |    0.02 |      - |         - |          NA |
+| GeneratedRegex_Email      | 79.45 ns | 34.13 ns | 1.871 ns |  1.02 |    0.03 |      - |         - |          NA |
+| Guard_AgainstInvalidEmail | 74.11 ns | 28.21 ns | 1.546 ns |  0.95 |    0.02 |      - |         - |          NA |
+| FastGuard_Email_SpanBased | 11.66 ns | 19.49 ns | 1.068 ns |  0.15 |    0.01 |      - |         - |          NA |
+| Ensure_That_Email         | 84.45 ns | 33.18 ns | 1.819 ns |  1.08 |    0.03 | 0.0191 |      80 B |          NA |
+
+### Regex patterns
+
+| Method                      | Mean      | Error     | StdDev   | Gen0   | Allocated |
+|---------------------------- |----------:|----------:|---------:|-------:|----------:|
+| RegexCache_Email            | 155.53 ns | 51.732 ns | 2.836 ns | 0.0191 |      80 B |
+| GeneratedRegex_Email        |  75.65 ns | 30.528 ns | 1.673 ns |      - |         - |
+| RegexCache_PhoneNumber      | 120.45 ns | 10.215 ns | 0.560 ns | 0.0153 |      64 B |
+| GeneratedRegex_PhoneNumber  |  50.09 ns | 56.275 ns | 3.085 ns |      - |         - |
+| RegexCache_AlphaNumeric     | 104.81 ns | 87.034 ns | 4.771 ns | 0.0134 |      56 B |
+| GeneratedRegex_AlphaNumeric |  35.11 ns |  6.788 ns | 0.372 ns |      - |         - |
+
+### Object validation
+
+| Method                            | Mean         | Error        | StdDev     | Ratio  | RatioSD | Gen0   | Allocated | Alloc Ratio |
+|---------------------------------- |-------------:|-------------:|-----------:|-------:|--------:|-------:|----------:|------------:|
+| ManualValidation                  |     4.786 ns |     1.316 ns |  0.0721 ns |   1.00 |    0.02 |      - |         - |          NA |
+| Validate_For_AllProperties        | 2,546.446 ns |   542.276 ns | 29.7240 ns | 532.11 |    8.78 | 0.8850 |    3704 B |          NA |
+| Validate_For_WithPropertyChaining | 2,777.566 ns | 1,464.866 ns | 80.2942 ns | 580.41 |   16.38 | 0.8545 |    3576 B |          NA |
+| Validate_ForStrict_AllProperties  | 2,642.425 ns | 1,409.270 ns | 77.2468 ns | 552.17 |   15.72 | 0.8698 |    3640 B |          NA |
+
+### Security guards
+
+| Method                     | Mean         | Error        | StdDev     | Allocated |
+|--------------------------- |-------------:|-------------:|-----------:|----------:|
+| AgainstSqlInjection_Short  |     41.98 ns |     6.435 ns |   0.353 ns |         - |
+| AgainstSqlInjection_Medium |  1,266.87 ns |   607.982 ns |  33.326 ns |         - |
+| AgainstSqlInjection_Long   | 25,233.83 ns | 2,297.883 ns | 125.955 ns |         - |
+| AgainstXss_Short           |     34.03 ns |    31.848 ns |   1.746 ns |         - |
+| AgainstXss_Medium          |    297.09 ns |   217.671 ns |  11.931 ns |         - |
+| AgainstXss_Long            |  3,230.04 ns | 1,115.045 ns |  61.119 ns |         - |
+| AgainstInjection_Short     |    129.59 ns |    29.715 ns |   1.629 ns |         - |
+| AgainstInjection_Medium    |  1,735.31 ns |   451.942 ns |  24.772 ns |         - |
+
+### Domain primitives
+
+| Method                     | Mean       | Error      | StdDev    | Ratio | RatioSD | Gen0   | Allocated | Alloc Ratio |
+|--------------------------- |-----------:|-----------:|----------:|------:|--------:|-------:|----------:|------------:|
+| ValueObject_ClassEquality  | 104.908 ns | 66.1232 ns | 3.6244 ns |  1.00 |    0.04 | 0.0343 |     144 B |        1.00 |
+| ValueObject_RecordEquality |   6.187 ns |  0.9568 ns | 0.0524 ns |  0.06 |    0.00 |      - |         - |        0.00 |
+| AggregateRoot_RaiseAndPull | 160.362 ns | 25.2494 ns | 1.3840 ns |  1.53 |    0.05 | 0.0172 |      72 B |        0.50 |
+
+---
+
 ## FluentValidation Migration
 
 OrionGuard provides a compatibility layer for easy migration:

--- a/demo/Moongazing.OrionGuard.Demo/Domain/Ids.cs
+++ b/demo/Moongazing.OrionGuard.Demo/Domain/Ids.cs
@@ -13,6 +13,10 @@ namespace Moongazing.OrionGuard.Demo.Domain;
 // wiring.
 // ============================================================================
 
+// OrionGuard's [StronglyTypedId] is obsolete (superseded by OrionKey). The demo
+// keeps exercising it because OrionGuard still ships and supports the generator
+// through v6.x. Suppression is intentional and scoped to these declarations.
+#pragma warning disable CS0618
 [StronglyTypedId<Guid>]
 public readonly partial struct ProductId;
 
@@ -21,6 +25,7 @@ public readonly partial struct SkuId;
 
 [StronglyTypedId<string>]
 public readonly partial struct CountryCode;
+#pragma warning restore CS0618
 
 // ============================================================================
 // Style 2: MANUAL RECORD — inherits StronglyTypedId<TValue> abstract record.

--- a/docs/migrations/stronglytypedid-to-orionkey.md
+++ b/docs/migrations/stronglytypedid-to-orionkey.md
@@ -1,0 +1,48 @@
+# Migrating from OrionGuard `[StronglyTypedId]` to OrionKey
+
+OrionGuard's `[StronglyTypedId<TValue>]` source generator is soft-deprecated as of
+v6.4.0. The feature now lives in the standalone **OrionKey** package and will be
+removed from OrionGuard in v7.0.0. The generator still works in the v6.x line —
+this migration is not urgent, but new code should use OrionKey.
+
+This applies only to the **source generator** (`[StronglyTypedId]` on a `readonly
+partial struct`). The manual `StronglyTypedId<TValue>` abstract record,
+`IStronglyTypedId<TValue>`, and the `AgainstDefaultStronglyTypedId` guard are not
+deprecated and have no OrionKey equivalent — keep using them as-is.
+
+## Steps
+
+1. Install OrionKey:
+
+   ```bash
+   dotnet add package OrionKey
+   ```
+
+2. Swap the attribute and the `using`:
+
+   | OrionGuard | OrionKey |
+   |---|---|
+   | `using Moongazing.OrionGuard.Domain.Primitives;` | `using Moongazing.OrionKey;` |
+   | `[StronglyTypedId<Guid>]` | `[OrionId<Guid>]` |
+   | `[StronglyTypedId<int>]` | `[OrionId<int>]` (externally assigned) |
+   | `[StronglyTypedId<long>]` | `[OrionId<long>]` (externally assigned) or `[OrionId<long, Snowflake>]` (generated) |
+   | `[StronglyTypedId<string>]` | `[OrionId<string, Ulid>]` or `[OrionId<string, NanoId>]` |
+
+3. The struct stays a `readonly partial struct` — no other change to your type.
+
+## What you get
+
+The emitted surface is equivalent: `Value`, a constructor, `Empty`, `New()` where
+applicable, `IEquatable`, equality operators, an EF Core `ValueConverter` (emitted
+when the project references EF Core), a `System.Text.Json` converter, a
+`TypeConverter`, and `IParsable`/`ISpanParsable`.
+
+OrionKey additionally provides:
+
+- `IComparable` and ordering operators for sortable strategies (`Snowflake`,
+  `Ulid`, `GuidV7`).
+- Explicit ID strategies: `Snowflake` (64-bit, sortable), `Ulid`, `NanoId`,
+  `GuidV7`.
+- `OrionKey.Testing` — deterministic ID generators for tests.
+
+See the OrionKey README at https://github.com/tunahanaliozturk/OrionKey.

--- a/docs/migrations/v6.4.0-outbox-locks.md
+++ b/docs/migrations/v6.4.0-outbox-locks.md
@@ -1,0 +1,81 @@
+# v6.4.0 Migration — OrionGuard_OutboxLocks
+
+This document provides EF Core migration snippets for the new `OrionGuard_OutboxLocks` table used by
+`SkipLockedDistributedLock`. Required only if you opt in to multi-instance outbox safety. Single-instance
+consumers who want v6.3 behaviour without applying this migration should call
+`opts.UseOutbox(...).UseDistributedLock<NullDistributedLock>()`.
+
+## Apply the EF Core configuration
+
+Inside your `DbContext.OnModelCreating`:
+
+```csharp
+modelBuilder.ApplyConfiguration(
+    new Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Locking.OutboxLockEntityTypeConfiguration());
+```
+
+## Generate the migration
+
+```bash
+dotnet ef migrations add Add_OrionGuard_OutboxLocks --context YourDbContext
+dotnet ef database update --context YourDbContext
+```
+
+## Reference DDL per provider
+
+Use these only if you bypass EF Core migrations (e.g., DBA-managed schemas).
+
+### PostgreSQL
+```sql
+CREATE TABLE "OrionGuard_OutboxLocks" (
+    "LockKey"        VARCHAR(200) PRIMARY KEY,
+    "HolderId"       UUID NULL,
+    "AcquiredOnUtc"  TIMESTAMP NOT NULL,
+    "ExpiresOnUtc"   TIMESTAMP NOT NULL
+);
+```
+
+### SQL Server
+```sql
+CREATE TABLE [OrionGuard_OutboxLocks] (
+    [LockKey]        NVARCHAR(200) NOT NULL PRIMARY KEY,
+    [HolderId]       UNIQUEIDENTIFIER NULL,
+    [AcquiredOnUtc]  DATETIME2 NOT NULL,
+    [ExpiresOnUtc]   DATETIME2 NOT NULL
+);
+```
+
+### MySQL / MariaDB
+```sql
+CREATE TABLE OrionGuard_OutboxLocks (
+    LockKey       VARCHAR(200) NOT NULL,
+    HolderId      CHAR(36) NULL,
+    AcquiredOnUtc DATETIME NOT NULL,
+    ExpiresOnUtc  DATETIME NOT NULL,
+    PRIMARY KEY (LockKey)
+);
+```
+
+### SQLite (test environments only)
+```sql
+CREATE TABLE OrionGuard_OutboxLocks (
+    LockKey       TEXT NOT NULL PRIMARY KEY,
+    HolderId      TEXT NULL,
+    AcquiredOnUtc TEXT NOT NULL,
+    ExpiresOnUtc  TEXT NOT NULL
+);
+```
+
+## Verification
+
+After applying, a successful boot logs:
+
+```
+OrionGuard outbox dispatcher started with distributed locking key 'orion_guard_outbox_dispatcher' (lease 00:00:30).
+```
+
+If the table is missing, the dispatcher logs a one-time warning and skips processing on every poll:
+
+```
+OrionGuard_OutboxLocks table not found. Distributed locking is disabled until the v6.4.0 migration is applied.
+```

--- a/docs/superpowers/plans/2026-05-19-orionguard-v6.4.0-implementation.md
+++ b/docs/superpowers/plans/2026-05-19-orionguard-v6.4.0-implementation.md
@@ -1,0 +1,3340 @@
+# OrionGuard v6.4.0 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship five source-compatible v6.4.0 features: `BusinessRule` base classes, `Guard.AgainstBrokenRule`, ProblemDetails mapping for `BusinessRuleValidationException`, pluggable `IDistributedLock` for outbox dispatchers, `OutboxTypeMapRegistry`, and an `OutboxArchivalHostedService`.
+
+**Architecture:** Single umbrella PR on `feature/v6.4.0`. New code lives in existing packages (`Moongazing.OrionGuard`, `Moongazing.OrionGuard.AspNetCore`, `Moongazing.OrionGuard.EntityFrameworkCore`). All new options thread through the existing `OrionGuardEfCoreOptions` fluent surface — no new builder type, no new NuGet packages. Backward compatibility is preserved by `TryAddSingleton` defaults, opt-in archival, and AQN fallback in the type map.
+
+**Tech Stack:** .NET 8/9/10 multi-target, xUnit, EF Core (Pomelo/PG/MSSQL/SQLite providers), ASP.NET Core 8/9/10.
+
+**Spec:** `docs/superpowers/specs/2026-05-19-orionguard-v6.4.0-design.md`
+
+**Branch:** `feature/v6.4.0` (already created off `master`).
+
+---
+
+## File Structure
+
+### `Moongazing.OrionGuard` (core)
+
+| Path | Status | Purpose |
+|---|---|---|
+| `Domain/Rules/BusinessRule.cs` | Create | Abstract base for `IBusinessRule` |
+| `Domain/Rules/AsyncBusinessRule.cs` | Create | Abstract base for `IAsyncBusinessRule` |
+| `Core/Guard.cs` | Modify | Add `AgainstBrokenRule` + `AgainstBrokenRuleAsync` |
+| `Domain/Primitives/Entity.cs` | Modify | `CheckRule`/`CheckRuleAsync` delegate to Guard helpers |
+
+### `Moongazing.OrionGuard.AspNetCore`
+
+| Path | Status | Purpose |
+|---|---|---|
+| `ProblemDetails/OrionGuardProblemDetailsFactory.cs` | Modify | Add `Create(BusinessRuleValidationException)` overload |
+| `Options/OrionGuardAspNetCoreOptions.cs` | Modify | Add `BusinessRuleStatusCode` property |
+| `ExceptionHandling/OrionGuardExceptionHandler.cs` | Modify | Add `BusinessRuleValidationException` branch |
+
+### `Moongazing.OrionGuard.EntityFrameworkCore`
+
+| Path | Status | Purpose |
+|---|---|---|
+| `Outbox/Locking/IDistributedLock.cs` | Create | Abstraction |
+| `Outbox/Locking/IDistributedLockHandle.cs` | Create | Lease handle (`IAsyncDisposable`) |
+| `Outbox/Locking/NullDistributedLock.cs` | Create | No-op opt-out impl |
+| `Outbox/Locking/SkipLockedDistributedLock.cs` | Create | Default DB impl |
+| `Outbox/Locking/OutboxLock.cs` | Create | EF entity for `OrionGuard_OutboxLocks` |
+| `Outbox/Locking/OutboxLockEntityTypeConfiguration.cs` | Create | EF mapping |
+| `Outbox/TypeMap/OutboxTypeMapRegistry.cs` | Create | Logical-name ↔ Type registry |
+| `Outbox/TypeMap/OutboxTypeMapOptions.cs` | Create | AQN fallback toggle |
+| `Outbox/Archival/OutboxArchivalHostedService.cs` | Create | Retention-based deletion |
+| `Outbox/Archival/OutboxArchivalOptions.cs` | Create | Archival configuration |
+| `Outbox/OutboxOptions.cs` | Modify | Add `LockKey`, `LockLeaseDuration` |
+| `Outbox/OutboxDispatcherHostedService.cs` | Modify | Inject lock + registry; use both |
+| `DomainEventSaveChangesInterceptor.cs` | Modify | Writer prefers registry's logical name |
+| `OrionGuardEfCoreOptions.cs` | Modify | `ServiceCustomizations`, `UseDistributedLock<T>`, `UseOutboxTypeMap`, `UseOutboxArchival` |
+| `ServiceCollectionExtensions.cs` | Modify | TryAdd defaults; apply customizations |
+
+### Documentation
+
+| Path | Status | Purpose |
+|---|---|---|
+| `docs/migrations/v6.4.0-outbox-locks.md` | Create | EF migration template (4 providers) |
+| `CHANGELOG.md` | Modify | Add `[6.4.0]` section |
+| All `<Version>` properties in `src/**/*.csproj` | Modify | Bump 6.3.0 → 6.4.0 |
+
+---
+
+## Conventions
+
+- **Test framework:** xUnit, `[Fact]` / `[Theory]`+`[InlineData]`. Naming: `MethodUnderTest_ShouldDoX_WhenY`. Plain `Assert.X`. Source files start with `using` blocks.
+- **Coverage bar:** Each new public method has at least one happy-path test and one negative-path test.
+- **Commit cadence:** Commit after each task. Use the commit messages listed at each task's final step. **No `Co-Authored-By` trailer.**
+- **Branch:** Already on `feature/v6.4.0`. All commits go here.
+- **Verification command (any task):** `dotnet build` from repo root must succeed before commit; `dotnet test` for the affected test project must pass.
+
+---
+
+## Task 1: `BusinessRule` and `AsyncBusinessRule` abstract bases
+
+**Files:**
+- Create: `src/Moongazing.OrionGuard/Domain/Rules/BusinessRule.cs`
+- Create: `src/Moongazing.OrionGuard/Domain/Rules/AsyncBusinessRule.cs`
+- Test: `tests/Moongazing.OrionGuard.Tests/Domain/Rules/BusinessRuleTests.cs`
+- Test: `tests/Moongazing.OrionGuard.Tests/Domain/Rules/AsyncBusinessRuleTests.cs`
+
+- [ ] **Step 1: Write the failing sync tests**
+
+Create `tests/Moongazing.OrionGuard.Tests/Domain/Rules/BusinessRuleTests.cs`:
+
+```csharp
+using Moongazing.OrionGuard.Domain.Rules;
+
+namespace Moongazing.OrionGuard.Tests.Domain.Rules;
+
+public class BusinessRuleTests
+{
+    private sealed class OrderMustHaveItems(bool isBroken) : BusinessRule
+    {
+        public override bool IsBroken() => isBroken;
+        public override string DefaultMessage => "An order must have at least one item.";
+    }
+
+    private sealed class CustomKeyRule : BusinessRule
+    {
+        public override bool IsBroken() => true;
+        public override string DefaultMessage => "x";
+        public override string MessageKey => "custom_key";
+    }
+
+    private sealed class WithArgsRule(int min) : BusinessRule
+    {
+        public override bool IsBroken() => true;
+        public override string DefaultMessage => "must be >= {0}";
+        public override object[] MessageArgs => new object[] { min };
+    }
+
+    [Fact]
+    public void IsBroken_ShouldReturnSubclassImplementation()
+    {
+        Assert.True(new OrderMustHaveItems(true).IsBroken());
+        Assert.False(new OrderMustHaveItems(false).IsBroken());
+    }
+
+    [Fact]
+    public void MessageKey_ShouldDefaultToTypeName()
+    {
+        var rule = new OrderMustHaveItems(true);
+        Assert.Equal(nameof(OrderMustHaveItems), rule.MessageKey);
+    }
+
+    [Fact]
+    public void MessageKey_ShouldRespectOverride()
+    {
+        Assert.Equal("custom_key", new CustomKeyRule().MessageKey);
+    }
+
+    [Fact]
+    public void MessageArgs_ShouldDefaultToNull()
+    {
+        Assert.Null(new OrderMustHaveItems(true).MessageArgs);
+    }
+
+    [Fact]
+    public void MessageArgs_ShouldRespectOverride()
+    {
+        Assert.Equal(new object[] { 5 }, new WithArgsRule(5).MessageArgs);
+    }
+}
+```
+
+- [ ] **Step 2: Write the failing async tests**
+
+Create `tests/Moongazing.OrionGuard.Tests/Domain/Rules/AsyncBusinessRuleTests.cs`:
+
+```csharp
+using Moongazing.OrionGuard.Domain.Rules;
+
+namespace Moongazing.OrionGuard.Tests.Domain.Rules;
+
+public class AsyncBusinessRuleTests
+{
+    private sealed class UniqueEmailRule(bool isBroken) : AsyncBusinessRule
+    {
+        public override Task<bool> IsBrokenAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(isBroken);
+        public override string DefaultMessage => "Email must be unique.";
+    }
+
+    [Fact]
+    public async Task IsBrokenAsync_ShouldReturnSubclassImplementation()
+    {
+        Assert.True(await new UniqueEmailRule(true).IsBrokenAsync());
+        Assert.False(await new UniqueEmailRule(false).IsBrokenAsync());
+    }
+
+    [Fact]
+    public void MessageKey_ShouldDefaultToTypeName()
+    {
+        var rule = new UniqueEmailRule(true);
+        Assert.Equal(nameof(UniqueEmailRule), rule.MessageKey);
+    }
+
+    [Fact]
+    public async Task IsBrokenAsync_ShouldRespectCancellation()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        var rule = new ThrowingRule();
+        await Assert.ThrowsAsync<OperationCanceledException>(() => rule.IsBrokenAsync(cts.Token));
+    }
+
+    private sealed class ThrowingRule : AsyncBusinessRule
+    {
+        public override Task<bool> IsBrokenAsync(CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(false);
+        }
+        public override string DefaultMessage => "x";
+    }
+}
+```
+
+- [ ] **Step 3: Run both tests to verify they fail**
+
+```
+dotnet test tests/Moongazing.OrionGuard.Tests --filter "FullyQualifiedName~BusinessRuleTests|FullyQualifiedName~AsyncBusinessRuleTests"
+```
+
+Expected: build error — `BusinessRule` / `AsyncBusinessRule` types do not exist.
+
+- [ ] **Step 4: Create `BusinessRule.cs`**
+
+Create `src/Moongazing.OrionGuard/Domain/Rules/BusinessRule.cs`:
+
+```csharp
+namespace Moongazing.OrionGuard.Domain.Rules;
+
+/// <summary>
+/// Abstract base for synchronous business rules. Subclasses implement <see cref="IsBroken"/> and
+/// <see cref="DefaultMessage"/>; <see cref="MessageKey"/> defaults to the CLR type name.
+/// </summary>
+public abstract class BusinessRule : IBusinessRule
+{
+    /// <inheritdoc />
+    public abstract bool IsBroken();
+
+    /// <inheritdoc />
+    public abstract string DefaultMessage { get; }
+
+    /// <inheritdoc />
+    public virtual string MessageKey => GetType().Name;
+
+    /// <inheritdoc />
+    public virtual object[]? MessageArgs => null;
+}
+```
+
+- [ ] **Step 5: Create `AsyncBusinessRule.cs`**
+
+Create `src/Moongazing.OrionGuard/Domain/Rules/AsyncBusinessRule.cs`:
+
+```csharp
+namespace Moongazing.OrionGuard.Domain.Rules;
+
+/// <summary>
+/// Abstract base for asynchronous business rules. Subclasses implement <see cref="IsBrokenAsync"/>
+/// and <see cref="DefaultMessage"/>; <see cref="MessageKey"/> defaults to the CLR type name.
+/// </summary>
+public abstract class AsyncBusinessRule : IAsyncBusinessRule
+{
+    /// <inheritdoc />
+    public abstract Task<bool> IsBrokenAsync(CancellationToken cancellationToken = default);
+
+    /// <inheritdoc />
+    public abstract string DefaultMessage { get; }
+
+    /// <inheritdoc />
+    public virtual string MessageKey => GetType().Name;
+
+    /// <inheritdoc />
+    public virtual object[]? MessageArgs => null;
+}
+```
+
+- [ ] **Step 6: Run tests, expect PASS**
+
+```
+dotnet test tests/Moongazing.OrionGuard.Tests --filter "FullyQualifiedName~BusinessRuleTests|FullyQualifiedName~AsyncBusinessRuleTests"
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 7: Commit**
+
+```
+git add src/Moongazing.OrionGuard/Domain/Rules/BusinessRule.cs src/Moongazing.OrionGuard/Domain/Rules/AsyncBusinessRule.cs tests/Moongazing.OrionGuard.Tests/Domain/Rules/BusinessRuleTests.cs tests/Moongazing.OrionGuard.Tests/Domain/Rules/AsyncBusinessRuleTests.cs
+git commit -m "feat(core): BusinessRule and AsyncBusinessRule abstract bases
+
+Defaults MessageKey to the CLR type name, leaves IsBroken/IsBrokenAsync
+and DefaultMessage abstract. Existing IBusinessRule consumers unaffected."
+```
+
+---
+
+## Task 2: `Guard.AgainstBrokenRule` and `Guard.AgainstBrokenRuleAsync`
+
+**Files:**
+- Modify: `src/Moongazing.OrionGuard/Core/Guard.cs`
+- Test: `tests/Moongazing.OrionGuard.Tests/Core/Guard_AgainstBrokenRuleTests.cs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/Moongazing.OrionGuard.Tests/Core/Guard_AgainstBrokenRuleTests.cs`:
+
+```csharp
+using Moongazing.OrionGuard.Core;
+using Moongazing.OrionGuard.Domain.Exceptions;
+using Moongazing.OrionGuard.Domain.Rules;
+
+namespace Moongazing.OrionGuard.Tests.Core;
+
+public class Guard_AgainstBrokenRuleTests
+{
+    private sealed class StubRule(bool isBroken) : BusinessRule
+    {
+        public override bool IsBroken() => isBroken;
+        public override string DefaultMessage => "stub broken";
+    }
+
+    private sealed class StubAsyncRule(bool isBroken) : AsyncBusinessRule
+    {
+        public override Task<bool> IsBrokenAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(isBroken);
+        public override string DefaultMessage => "stub broken async";
+    }
+
+    [Fact]
+    public void AgainstBrokenRule_ShouldNotThrow_WhenRuleIsNotBroken()
+    {
+        Guard.AgainstBrokenRule(new StubRule(false));
+    }
+
+    [Fact]
+    public void AgainstBrokenRule_ShouldThrowBusinessRuleValidationException_WhenRuleIsBroken()
+    {
+        var ex = Assert.Throws<BusinessRuleValidationException>(
+            () => Guard.AgainstBrokenRule(new StubRule(true)));
+        Assert.Equal(nameof(StubRule), ex.RuleName);
+        Assert.Equal(nameof(StubRule), ex.MessageKey);
+        Assert.Equal("stub broken", ex.Message);
+    }
+
+    [Fact]
+    public void AgainstBrokenRule_ShouldThrow_WhenRuleIsNull()
+    {
+        Assert.Throws<ArgumentNullException>(() => Guard.AgainstBrokenRule(null!));
+    }
+
+    [Fact]
+    public async Task AgainstBrokenRuleAsync_ShouldNotThrow_WhenRuleIsNotBroken()
+    {
+        await Guard.AgainstBrokenRuleAsync(new StubAsyncRule(false));
+    }
+
+    [Fact]
+    public async Task AgainstBrokenRuleAsync_ShouldThrowBusinessRuleValidationException_WhenRuleIsBroken()
+    {
+        var ex = await Assert.ThrowsAsync<BusinessRuleValidationException>(
+            () => Guard.AgainstBrokenRuleAsync(new StubAsyncRule(true)));
+        Assert.Equal(nameof(StubAsyncRule), ex.RuleName);
+        Assert.Equal("stub broken async", ex.Message);
+    }
+
+    [Fact]
+    public async Task AgainstBrokenRuleAsync_ShouldThrow_WhenRuleIsNull()
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            () => Guard.AgainstBrokenRuleAsync(null!));
+    }
+
+    [Fact]
+    public async Task AgainstBrokenRuleAsync_ShouldRespectCancellation()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => Guard.AgainstBrokenRuleAsync(new CancelObservingRule(), cts.Token));
+    }
+
+    private sealed class CancelObservingRule : AsyncBusinessRule
+    {
+        public override Task<bool> IsBrokenAsync(CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(false);
+        }
+        public override string DefaultMessage => "x";
+    }
+}
+```
+
+- [ ] **Step 2: Run tests, expect failure**
+
+```
+dotnet test tests/Moongazing.OrionGuard.Tests --filter "FullyQualifiedName~Guard_AgainstBrokenRuleTests"
+```
+
+Expected: build error — `Guard.AgainstBrokenRule` does not exist.
+
+- [ ] **Step 3: Add helpers to `Guard.cs`**
+
+In `src/Moongazing.OrionGuard/Core/Guard.cs`, add `using` directives at the top if missing:
+
+```csharp
+using Moongazing.OrionGuard.Domain.Exceptions;
+using Moongazing.OrionGuard.Domain.Rules;
+```
+
+Append inside `public static class Guard` (before the closing brace of the type — after `AgainstTrue` is a fine spot):
+
+```csharp
+    /// <summary>
+    /// Evaluates a synchronous business rule and throws <see cref="BusinessRuleValidationException"/>
+    /// when the rule reports itself broken.
+    /// </summary>
+    /// <param name="rule">The rule to evaluate. Cannot be null.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="rule"/> is null.</exception>
+    /// <exception cref="BusinessRuleValidationException">Thrown when the rule is broken.</exception>
+    public static void AgainstBrokenRule(IBusinessRule rule)
+    {
+        ArgumentNullException.ThrowIfNull(rule);
+        if (rule.IsBroken())
+        {
+            throw new BusinessRuleValidationException(rule);
+        }
+    }
+
+    /// <summary>
+    /// Evaluates an asynchronous business rule and throws <see cref="BusinessRuleValidationException"/>
+    /// when the rule reports itself broken.
+    /// </summary>
+    /// <param name="rule">The rule to evaluate. Cannot be null.</param>
+    /// <param name="cancellationToken">A token to observe while waiting for the task to complete.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="rule"/> is null.</exception>
+    /// <exception cref="BusinessRuleValidationException">Thrown when the rule is broken.</exception>
+    public static async Task AgainstBrokenRuleAsync(
+        IAsyncBusinessRule rule,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(rule);
+        if (await rule.IsBrokenAsync(cancellationToken).ConfigureAwait(false))
+        {
+            throw new BusinessRuleValidationException(rule);
+        }
+    }
+```
+
+- [ ] **Step 4: Run tests, expect PASS**
+
+```
+dotnet test tests/Moongazing.OrionGuard.Tests --filter "FullyQualifiedName~Guard_AgainstBrokenRuleTests"
+```
+
+Expected: 7 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/Moongazing.OrionGuard/Core/Guard.cs tests/Moongazing.OrionGuard.Tests/Core/Guard_AgainstBrokenRuleTests.cs
+git commit -m "feat(core): Guard.AgainstBrokenRule and AgainstBrokenRuleAsync
+
+Static helpers that evaluate IBusinessRule / IAsyncBusinessRule and throw
+BusinessRuleValidationException when broken. Naming follows the existing
+Guard.AgainstX surface."
+```
+
+---
+
+## Task 3: `Entity.CheckRule` delegates to `Guard.AgainstBrokenRule`
+
+**Goal:** DRY — `Entity.CheckRule` and `Entity.CheckRuleAsync` currently duplicate the null-guard + IsBroken + throw logic; rewrite as one-line delegations.
+
+**Files:**
+- Modify: `src/Moongazing.OrionGuard/Domain/Primitives/Entity.cs` (lines 86–110)
+- Test: `tests/Moongazing.OrionGuard.Tests/Domain/Primitives/EntityCheckRuleDelegationTests.cs`
+
+- [ ] **Step 1: Write the delegation behaviour-equivalence test**
+
+Create `tests/Moongazing.OrionGuard.Tests/Domain/Primitives/EntityCheckRuleDelegationTests.cs`:
+
+```csharp
+using Moongazing.OrionGuard.Domain.Exceptions;
+using Moongazing.OrionGuard.Domain.Primitives;
+using Moongazing.OrionGuard.Domain.Rules;
+
+namespace Moongazing.OrionGuard.Tests.Domain.Primitives;
+
+public class EntityCheckRuleDelegationTests
+{
+    private sealed class TestEntity : Entity<int>
+    {
+        public TestEntity(int id) : base(id) { }
+
+        public void EnforceSync(IBusinessRule rule) => CheckRule(rule);
+        public Task EnforceAsync(IAsyncBusinessRule rule, CancellationToken ct = default)
+            => CheckRuleAsync(rule, ct);
+    }
+
+    private sealed class StubRule(bool isBroken) : BusinessRule
+    {
+        public override bool IsBroken() => isBroken;
+        public override string DefaultMessage => "broken";
+    }
+
+    private sealed class StubAsyncRule(bool isBroken) : AsyncBusinessRule
+    {
+        public override Task<bool> IsBrokenAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(isBroken);
+        public override string DefaultMessage => "broken async";
+    }
+
+    [Fact]
+    public void CheckRule_ShouldNotThrow_WhenRuleIsNotBroken()
+    {
+        new TestEntity(1).EnforceSync(new StubRule(false));
+    }
+
+    [Fact]
+    public void CheckRule_ShouldThrowBusinessRuleValidationException_WhenRuleIsBroken()
+    {
+        var ex = Assert.Throws<BusinessRuleValidationException>(
+            () => new TestEntity(1).EnforceSync(new StubRule(true)));
+        Assert.Equal(nameof(StubRule), ex.RuleName);
+        Assert.Equal("broken", ex.Message);
+    }
+
+    [Fact]
+    public void CheckRule_ShouldThrow_WhenRuleIsNull()
+    {
+        Assert.Throws<ArgumentNullException>(() => new TestEntity(1).EnforceSync(null!));
+    }
+
+    [Fact]
+    public async Task CheckRuleAsync_ShouldThrowBusinessRuleValidationException_WhenRuleIsBroken()
+    {
+        var ex = await Assert.ThrowsAsync<BusinessRuleValidationException>(
+            () => new TestEntity(1).EnforceAsync(new StubAsyncRule(true)));
+        Assert.Equal(nameof(StubAsyncRule), ex.RuleName);
+    }
+
+    [Fact]
+    public async Task CheckRuleAsync_ShouldThrow_WhenRuleIsNull()
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            () => new TestEntity(1).EnforceAsync(null!));
+    }
+}
+```
+
+- [ ] **Step 2: Run tests; behaviour-equivalence tests should already pass against the v6.3 implementation**
+
+```
+dotnet test tests/Moongazing.OrionGuard.Tests --filter "FullyQualifiedName~EntityCheckRuleDelegationTests"
+```
+
+Expected: 5 tests pass (existing v6.3 `Entity.CheckRule` already produces these results).
+
+- [ ] **Step 3: Rewrite `Entity.CheckRule` and `Entity.CheckRuleAsync` as delegations**
+
+In `src/Moongazing.OrionGuard/Domain/Primitives/Entity.cs`, ensure the `using` block includes:
+
+```csharp
+using Moongazing.OrionGuard.Core;
+```
+
+Replace the body of `CheckRule` (line 86 area) so the whole method becomes:
+
+```csharp
+    /// <summary>
+    /// Enforces a synchronous business rule. Throws <see cref="BusinessRuleValidationException"/>
+    /// if the rule reports itself as broken. Delegates to <see cref="Guard.AgainstBrokenRule"/>.
+    /// </summary>
+    /// <param name="rule">The business rule to validate. Cannot be null.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="rule"/> is null.</exception>
+    /// <exception cref="BusinessRuleValidationException">Thrown when the rule is broken.</exception>
+    protected static void CheckRule(IBusinessRule rule) => Guard.AgainstBrokenRule(rule);
+```
+
+And `CheckRuleAsync`:
+
+```csharp
+    /// <summary>
+    /// Enforces an asynchronous business rule. Throws <see cref="BusinessRuleValidationException"/>
+    /// if the rule reports itself as broken. Delegates to <see cref="Guard.AgainstBrokenRuleAsync"/>.
+    /// </summary>
+    /// <param name="rule">The asynchronous business rule to validate. Cannot be null.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="rule"/> is null.</exception>
+    /// <exception cref="BusinessRuleValidationException">Thrown when the rule is broken.</exception>
+    protected static Task CheckRuleAsync(IAsyncBusinessRule rule, CancellationToken cancellationToken = default)
+        => Guard.AgainstBrokenRuleAsync(rule, cancellationToken);
+```
+
+- [ ] **Step 4: Run all core tests; old `EntityTests` plus new tests must pass**
+
+```
+dotnet test tests/Moongazing.OrionGuard.Tests --filter "FullyQualifiedName~Entity"
+```
+
+Expected: all existing `EntityTests` + new `EntityCheckRuleDelegationTests` pass.
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/Moongazing.OrionGuard/Domain/Primitives/Entity.cs tests/Moongazing.OrionGuard.Tests/Domain/Primitives/EntityCheckRuleDelegationTests.cs
+git commit -m "refactor(core): Entity.CheckRule delegates to Guard.AgainstBrokenRule
+
+Removes duplicated null-guard + IsBroken + throw logic so the Guard helper
+is the single source of truth. Public behaviour unchanged."
+```
+
+---
+
+## Task 4: `OrionGuardProblemDetailsFactory.Create(BusinessRuleValidationException)`
+
+**Files:**
+- Modify: `src/Moongazing.OrionGuard.AspNetCore/ProblemDetails/OrionGuardProblemDetailsFactory.cs`
+- Test: `tests/Moongazing.OrionGuard.AspNetCore.Tests/ProblemDetails/OrionGuardProblemDetailsFactory_BusinessRuleTests.cs`
+
+> **Note:** If `tests/Moongazing.OrionGuard.AspNetCore.Tests/` does not yet exist, **stop** and check the repo. If it is missing, add the project. The PR for v6.3 should already have set it up — verify with `ls tests/`. If it truly is missing, run:
+>
+> ```
+> dotnet new xunit -o tests/Moongazing.OrionGuard.AspNetCore.Tests -f net10.0
+> dotnet sln Moongazing.OrionGuard.sln add tests/Moongazing.OrionGuard.AspNetCore.Tests
+> dotnet add tests/Moongazing.OrionGuard.AspNetCore.Tests reference src/Moongazing.OrionGuard.AspNetCore
+> ```
+>
+> and commit that scaffold separately before proceeding.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/Moongazing.OrionGuard.AspNetCore.Tests/ProblemDetails/OrionGuardProblemDetailsFactory_BusinessRuleTests.cs`:
+
+```csharp
+using Microsoft.AspNetCore.Http;
+using Moongazing.OrionGuard.AspNetCore.ProblemDetails;
+using Moongazing.OrionGuard.Domain.Exceptions;
+using Moongazing.OrionGuard.Domain.Rules;
+
+namespace Moongazing.OrionGuard.AspNetCore.Tests.ProblemDetails;
+
+public class OrionGuardProblemDetailsFactory_BusinessRuleTests
+{
+    private sealed class BrokenRule : BusinessRule
+    {
+        public override bool IsBroken() => true;
+        public override string DefaultMessage => "Order must have at least one item.";
+    }
+
+    [Fact]
+    public void Create_ShouldUse422_AsDefaultStatus()
+    {
+        var pd = OrionGuardProblemDetailsFactory.Create(new BusinessRuleValidationException(new BrokenRule()));
+        Assert.Equal(StatusCodes.Status422UnprocessableEntity, pd.Status);
+    }
+
+    [Fact]
+    public void Create_ShouldUseRuleSpecificType()
+    {
+        var pd = OrionGuardProblemDetailsFactory.Create(new BusinessRuleValidationException(new BrokenRule()));
+        Assert.Equal("https://moongazing.dev/orionguard/problems/business-rule-violation", pd.Type);
+    }
+
+    [Fact]
+    public void Create_ShouldKeyErrorsByRuleName()
+    {
+        var pd = OrionGuardProblemDetailsFactory.Create(new BusinessRuleValidationException(new BrokenRule()));
+        Assert.True(pd.Errors.ContainsKey(nameof(BrokenRule)));
+        Assert.Equal(new[] { "Order must have at least one item." }, pd.Errors[nameof(BrokenRule)]);
+    }
+
+    [Fact]
+    public void Create_ShouldUseBusinessRuleViolationTitle()
+    {
+        var pd = OrionGuardProblemDetailsFactory.Create(new BusinessRuleValidationException(new BrokenRule()));
+        Assert.Equal("Business Rule Violation", pd.Title);
+    }
+}
+```
+
+- [ ] **Step 2: Run test, expect failure**
+
+```
+dotnet test tests/Moongazing.OrionGuard.AspNetCore.Tests --filter "FullyQualifiedName~OrionGuardProblemDetailsFactory_BusinessRuleTests"
+```
+
+Expected: build error — no `Create(BusinessRuleValidationException)` overload.
+
+- [ ] **Step 3: Add the factory overload**
+
+In `src/Moongazing.OrionGuard.AspNetCore/ProblemDetails/OrionGuardProblemDetailsFactory.cs`:
+
+Add to the existing `using` block (top of file) if missing:
+
+```csharp
+using Microsoft.AspNetCore.Http;
+using Moongazing.OrionGuard.Domain.Exceptions;
+```
+
+Add inside `public static class OrionGuardProblemDetailsFactory`, before the closing brace:
+
+```csharp
+    private const string BusinessRuleProblemType =
+        "https://moongazing.dev/orionguard/problems/business-rule-violation";
+    private const string BusinessRuleTitle = "Business Rule Violation";
+
+    /// <summary>
+    /// Creates a <see cref="ValidationProblemDetails"/> from a <see cref="BusinessRuleValidationException"/>.
+    /// Errors are keyed by the rule's CLR type name; status defaults to 422.
+    /// </summary>
+    /// <param name="exception">The business rule exception.</param>
+    /// <returns>A <see cref="ValidationProblemDetails"/> ready for serialization.</returns>
+    public static ValidationProblemDetails Create(BusinessRuleValidationException exception)
+    {
+        var errors = new Dictionary<string, string[]>
+        {
+            [exception.RuleName] = new[] { exception.Message },
+        };
+
+        return new ValidationProblemDetails(errors)
+        {
+            Type = BusinessRuleProblemType,
+            Title = BusinessRuleTitle,
+            Status = StatusCodes.Status422UnprocessableEntity,
+        };
+    }
+```
+
+- [ ] **Step 4: Run tests, expect PASS**
+
+```
+dotnet test tests/Moongazing.OrionGuard.AspNetCore.Tests --filter "FullyQualifiedName~OrionGuardProblemDetailsFactory_BusinessRuleTests"
+```
+
+Expected: 4 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/Moongazing.OrionGuard.AspNetCore/ProblemDetails/OrionGuardProblemDetailsFactory.cs tests/Moongazing.OrionGuard.AspNetCore.Tests/ProblemDetails/OrionGuardProblemDetailsFactory_BusinessRuleTests.cs
+git commit -m "feat(aspnetcore): ProblemDetails factory for BusinessRuleValidationException
+
+Adds Create(BusinessRuleValidationException) overload — 422, RuleName-keyed
+errors, OrionGuard-specific Type URL."
+```
+
+---
+
+## Task 5: `OrionGuardAspNetCoreOptions.BusinessRuleStatusCode`
+
+**Files:**
+- Modify: `src/Moongazing.OrionGuard.AspNetCore/Options/OrionGuardAspNetCoreOptions.cs`
+
+- [ ] **Step 1: Open the options file and add the property**
+
+In `src/Moongazing.OrionGuard.AspNetCore/Options/OrionGuardAspNetCoreOptions.cs`, ensure `using Microsoft.AspNetCore.Http;` is present, then add this property inside the class:
+
+```csharp
+    /// <summary>
+    /// HTTP status code returned for <see cref="Domain.Exceptions.BusinessRuleValidationException"/>.
+    /// Defaults to <see cref="StatusCodes.Status422UnprocessableEntity"/> (RFC 9457 — request is
+    /// syntactically valid but semantically rejected). Override (e.g., to 400) for legacy clients.
+    /// </summary>
+    public int BusinessRuleStatusCode { get; set; } = StatusCodes.Status422UnprocessableEntity;
+```
+
+If the existing class declares using `Moongazing.OrionGuard.Domain.Exceptions` already, use the short type name in the cref.
+
+- [ ] **Step 2: Build to verify no compile errors**
+
+```
+dotnet build src/Moongazing.OrionGuard.AspNetCore
+```
+
+Expected: success.
+
+- [ ] **Step 3: Commit**
+
+```
+git add src/Moongazing.OrionGuard.AspNetCore/Options/OrionGuardAspNetCoreOptions.cs
+git commit -m "feat(aspnetcore): BusinessRuleStatusCode option (default 422)
+
+Exposes the status code returned by OrionGuardExceptionHandler for
+BusinessRuleValidationException. Consumers override to 400 for legacy clients."
+```
+
+---
+
+## Task 6: `OrionGuardExceptionHandler` — `BusinessRuleValidationException` branch
+
+**Files:**
+- Modify: `src/Moongazing.OrionGuard.AspNetCore/ExceptionHandling/OrionGuardExceptionHandler.cs`
+- Test: `tests/Moongazing.OrionGuard.AspNetCore.Tests/ExceptionHandling/OrionGuardExceptionHandler_BusinessRuleTests.cs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/Moongazing.OrionGuard.AspNetCore.Tests/ExceptionHandling/OrionGuardExceptionHandler_BusinessRuleTests.cs`:
+
+```csharp
+using System.Text;
+using System.Text.Json;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moongazing.OrionGuard.AspNetCore.ExceptionHandling;
+using Moongazing.OrionGuard.AspNetCore.Options;
+using Moongazing.OrionGuard.Domain.Exceptions;
+using Moongazing.OrionGuard.Domain.Rules;
+
+namespace Moongazing.OrionGuard.AspNetCore.Tests.ExceptionHandling;
+
+public class OrionGuardExceptionHandler_BusinessRuleTests
+{
+    private sealed class BrokenRule : BusinessRule
+    {
+        public override bool IsBroken() => true;
+        public override string DefaultMessage => "Order must have at least one item.";
+    }
+
+    private static (HttpContext ctx, MemoryStream body) NewContext()
+    {
+        var ctx = new DefaultHttpContext();
+        var body = new MemoryStream();
+        ctx.Response.Body = body;
+        return (ctx, body);
+    }
+
+    [Fact]
+    public async Task TryHandleAsync_ShouldReturn422_WhenUseProblemDetailsTrueAndDefaults()
+    {
+        var (ctx, body) = NewContext();
+        var options = new OrionGuardAspNetCoreOptions { UseProblemDetails = true };
+        var handler = new OrionGuardExceptionHandler(NullLogger<OrionGuardExceptionHandler>.Instance, options);
+
+        var handled = await handler.TryHandleAsync(ctx, new BusinessRuleValidationException(new BrokenRule()), CancellationToken.None);
+
+        Assert.True(handled);
+        Assert.Equal(StatusCodes.Status422UnprocessableEntity, ctx.Response.StatusCode);
+
+        body.Position = 0;
+        var pd = JsonSerializer.Deserialize<ValidationProblemDetails>(body, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        Assert.NotNull(pd);
+        Assert.True(pd!.Errors.ContainsKey(nameof(BrokenRule)));
+    }
+
+    [Fact]
+    public async Task TryHandleAsync_ShouldRespectCustomStatusCode()
+    {
+        var (ctx, body) = NewContext();
+        var options = new OrionGuardAspNetCoreOptions { UseProblemDetails = true, BusinessRuleStatusCode = StatusCodes.Status400BadRequest };
+        var handler = new OrionGuardExceptionHandler(NullLogger<OrionGuardExceptionHandler>.Instance, options);
+
+        await handler.TryHandleAsync(ctx, new BusinessRuleValidationException(new BrokenRule()), CancellationToken.None);
+
+        Assert.Equal(StatusCodes.Status400BadRequest, ctx.Response.StatusCode);
+    }
+
+    [Fact]
+    public async Task TryHandleAsync_ShouldFallBackToSimpleJson_WhenUseProblemDetailsFalse()
+    {
+        var (ctx, body) = NewContext();
+        var options = new OrionGuardAspNetCoreOptions { UseProblemDetails = false };
+        var handler = new OrionGuardExceptionHandler(NullLogger<OrionGuardExceptionHandler>.Instance, options);
+
+        var handled = await handler.TryHandleAsync(ctx, new BusinessRuleValidationException(new BrokenRule()), CancellationToken.None);
+
+        Assert.True(handled);
+        Assert.Equal(StatusCodes.Status422UnprocessableEntity, ctx.Response.StatusCode);
+
+        body.Position = 0;
+        var json = Encoding.UTF8.GetString(body.ToArray());
+        Assert.Contains(nameof(BrokenRule), json);
+        Assert.Contains("Order must have at least one item.", json);
+    }
+}
+```
+
+- [ ] **Step 2: Run tests; expect failure (no BusinessRule branch yet → returns false → handled == false)**
+
+```
+dotnet test tests/Moongazing.OrionGuard.AspNetCore.Tests --filter "FullyQualifiedName~OrionGuardExceptionHandler_BusinessRuleTests"
+```
+
+Expected: 3 tests fail — handler does not match `BusinessRuleValidationException`.
+
+- [ ] **Step 3: Add the BusinessRule branch to `TryHandleAsync`**
+
+In `src/Moongazing.OrionGuard.AspNetCore/ExceptionHandling/OrionGuardExceptionHandler.cs`, add this `using` directive if missing:
+
+```csharp
+using Moongazing.OrionGuard.Domain.Exceptions;
+```
+
+Insert the new branch **between** the `AggregateValidationException` block (ends at the `return true;` near line 80) and the `GuardException` block (`if (exception is GuardException guardException)` line 82). Final structure of `TryHandleAsync`:
+
+```csharp
+    public async ValueTask<bool> TryHandleAsync(
+        HttpContext httpContext,
+        Exception exception,
+        CancellationToken cancellationToken)
+    {
+        if (exception is AggregateValidationException aggregateException)
+        {
+            // ...existing code unchanged...
+            return true;
+        }
+
+        if (exception is BusinessRuleValidationException ruleException)
+        {
+            _logger.LogWarning(
+                ruleException,
+                "Business rule '{RuleName}' violated: {Message}",
+                ruleException.RuleName,
+                ruleException.Message);
+
+            var statusCode = _options.BusinessRuleStatusCode;
+
+            if (_options.UseProblemDetails)
+            {
+                var problemDetails = OrionGuardProblemDetailsFactory.Create(ruleException);
+                problemDetails.Status = statusCode;
+
+                httpContext.Response.StatusCode = statusCode;
+                httpContext.Response.ContentType = MediaTypeNames.Application.Json;
+
+                await httpContext.Response.WriteAsJsonAsync(
+                    problemDetails,
+                    SerializerOptions,
+                    cancellationToken).ConfigureAwait(false);
+            }
+            else
+            {
+                httpContext.Response.StatusCode = statusCode;
+                httpContext.Response.ContentType = MediaTypeNames.Application.Json;
+
+                await httpContext.Response.WriteAsJsonAsync(
+                    new { ruleName = ruleException.RuleName, message = ruleException.Message },
+                    SerializerOptions,
+                    cancellationToken).ConfigureAwait(false);
+            }
+
+            return true;
+        }
+
+        if (exception is GuardException guardException)
+        {
+            // ...existing code unchanged...
+        }
+
+        return false;
+    }
+```
+
+- [ ] **Step 4: Run tests, expect PASS**
+
+```
+dotnet test tests/Moongazing.OrionGuard.AspNetCore.Tests --filter "FullyQualifiedName~OrionGuardExceptionHandler_BusinessRuleTests"
+```
+
+Expected: 3 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/Moongazing.OrionGuard.AspNetCore/ExceptionHandling/OrionGuardExceptionHandler.cs tests/Moongazing.OrionGuard.AspNetCore.Tests/ExceptionHandling/OrionGuardExceptionHandler_BusinessRuleTests.cs
+git commit -m "feat(aspnetcore): OrionGuardExceptionHandler handles BusinessRuleValidationException
+
+Adds a third branch between AggregateValidationException and GuardException.
+Returns 422 by default; honours OrionGuardAspNetCoreOptions.BusinessRuleStatusCode."
+```
+
+---
+
+## Task 7: `IDistributedLock` and `IDistributedLockHandle` interfaces
+
+**Files:**
+- Create: `src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Locking/IDistributedLock.cs`
+- Create: `src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Locking/IDistributedLockHandle.cs`
+
+- [ ] **Step 1: Create `IDistributedLock.cs`**
+
+```csharp
+namespace Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Locking;
+
+/// <summary>
+/// Acquires named distributed leases used by outbox dispatcher and archival workers.
+/// Implementations MUST be non-blocking — if the lock is held, return <see langword="null"/>
+/// immediately rather than waiting.
+/// </summary>
+public interface IDistributedLock
+{
+    /// <summary>
+    /// Tries to acquire the lock identified by <paramref name="lockKey"/>. Returns a handle on
+    /// success; <see langword="null"/> when another holder owns the lock.
+    /// </summary>
+    /// <param name="lockKey">Logical lock identifier.</param>
+    /// <param name="leaseDuration">
+    /// Maximum time the caller intends to hold the lock. Lease expiry releases the lock for other
+    /// holders even if the original owner crashes without disposing the handle.
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<IDistributedLockHandle?> TryAcquireAsync(
+        string lockKey,
+        TimeSpan leaseDuration,
+        CancellationToken cancellationToken = default);
+}
+```
+
+- [ ] **Step 2: Create `IDistributedLockHandle.cs`**
+
+```csharp
+namespace Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Locking;
+
+/// <summary>
+/// Lease handle returned by <see cref="IDistributedLock.TryAcquireAsync"/>. Disposing releases
+/// the lock (best-effort — release is a no-op if the lease has already expired and another
+/// holder has taken over).
+/// </summary>
+public interface IDistributedLockHandle : IAsyncDisposable
+{
+    /// <summary>The lock key this handle holds.</summary>
+    string LockKey { get; }
+}
+```
+
+- [ ] **Step 3: Build**
+
+```
+dotnet build src/Moongazing.OrionGuard.EntityFrameworkCore
+```
+
+Expected: success.
+
+- [ ] **Step 4: Commit**
+
+```
+git add src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Locking/IDistributedLock.cs src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Locking/IDistributedLockHandle.cs
+git commit -m "feat(efcore): IDistributedLock and IDistributedLockHandle abstractions
+
+Non-blocking, lease-based lock contract used by outbox dispatcher and
+archival workers."
+```
+
+---
+
+## Task 8: `OutboxLock` entity and EF type configuration
+
+**Files:**
+- Create: `src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Locking/OutboxLock.cs`
+- Create: `src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Locking/OutboxLockEntityTypeConfiguration.cs`
+
+- [ ] **Step 1: Create `OutboxLock.cs`**
+
+```csharp
+namespace Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Locking;
+
+/// <summary>
+/// Persistent row backing <see cref="SkipLockedDistributedLock"/>. Each lock key is one row in
+/// <c>OrionGuard_OutboxLocks</c>. <see cref="HolderId"/> is null when the lock is free; otherwise
+/// the GUID of the current owner. <see cref="ExpiresOnUtc"/> is the lease deadline; if it is in
+/// the past, any caller may take over.
+/// </summary>
+public sealed class OutboxLock
+{
+    public string LockKey { get; set; } = default!;
+    public Guid? HolderId { get; set; }
+    public DateTime AcquiredOnUtc { get; set; }
+    public DateTime ExpiresOnUtc { get; set; }
+}
+```
+
+- [ ] **Step 2: Create `OutboxLockEntityTypeConfiguration.cs`**
+
+```csharp
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Locking;
+
+/// <summary>
+/// EF Core mapping for <see cref="OutboxLock"/>. Apply inside your <c>OnModelCreating</c>:
+/// <c>modelBuilder.ApplyConfiguration(new OutboxLockEntityTypeConfiguration());</c>.
+/// </summary>
+public sealed class OutboxLockEntityTypeConfiguration : IEntityTypeConfiguration<OutboxLock>
+{
+    public void Configure(EntityTypeBuilder<OutboxLock> builder)
+    {
+        builder.ToTable("OrionGuard_OutboxLocks");
+        builder.HasKey(x => x.LockKey);
+        builder.Property(x => x.LockKey).HasMaxLength(200).IsRequired();
+        builder.Property(x => x.HolderId);
+        builder.Property(x => x.AcquiredOnUtc);
+        builder.Property(x => x.ExpiresOnUtc);
+    }
+}
+```
+
+- [ ] **Step 3: Build**
+
+```
+dotnet build src/Moongazing.OrionGuard.EntityFrameworkCore
+```
+
+Expected: success.
+
+- [ ] **Step 4: Commit**
+
+```
+git add src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Locking/OutboxLock.cs src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Locking/OutboxLockEntityTypeConfiguration.cs
+git commit -m "feat(efcore): OutboxLock entity and EntityTypeConfiguration
+
+Table OrionGuard_OutboxLocks (PK = LockKey, max 200 chars). Consumers
+apply the configuration in OnModelCreating before applying the v6.4.0 migration."
+```
+
+---
+
+## Task 9: `NullDistributedLock` no-op implementation
+
+**Files:**
+- Create: `src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Locking/NullDistributedLock.cs`
+- Test: `tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/Locking/NullDistributedLockTests.cs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/Locking/NullDistributedLockTests.cs`:
+
+```csharp
+using Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Locking;
+
+namespace Moongazing.OrionGuard.EntityFrameworkCore.Tests.Outbox.Locking;
+
+public class NullDistributedLockTests
+{
+    [Fact]
+    public async Task TryAcquireAsync_ShouldAlwaysReturnHandle()
+    {
+        var @lock = new NullDistributedLock();
+        var handle = await @lock.TryAcquireAsync("k", TimeSpan.FromMinutes(1));
+        Assert.NotNull(handle);
+        Assert.Equal("k", handle!.LockKey);
+    }
+
+    [Fact]
+    public async Task TryAcquireAsync_ShouldReturnHandleEvenOnRepeatedCalls()
+    {
+        var @lock = new NullDistributedLock();
+        var first = await @lock.TryAcquireAsync("k", TimeSpan.FromMinutes(1));
+        var second = await @lock.TryAcquireAsync("k", TimeSpan.FromMinutes(1));
+        Assert.NotNull(first);
+        Assert.NotNull(second);
+    }
+
+    [Fact]
+    public async Task DisposeAsync_ShouldNotThrow()
+    {
+        var @lock = new NullDistributedLock();
+        var handle = await @lock.TryAcquireAsync("k", TimeSpan.FromSeconds(1));
+        await handle!.DisposeAsync();
+    }
+}
+```
+
+- [ ] **Step 2: Run tests, expect failure**
+
+```
+dotnet test tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests --filter "FullyQualifiedName~NullDistributedLockTests"
+```
+
+Expected: build error — `NullDistributedLock` does not exist.
+
+- [ ] **Step 3: Create the impl**
+
+Create `src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Locking/NullDistributedLock.cs`:
+
+```csharp
+namespace Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Locking;
+
+/// <summary>
+/// No-op implementation that always acquires the lock and never blocks. Useful for single-instance
+/// consumers who do not want to apply the v6.4.0 <c>OrionGuard_OutboxLocks</c> migration. Wire via
+/// <c>opts.UseOutbox(...).UseDistributedLock&lt;NullDistributedLock&gt;()</c>.
+/// </summary>
+public sealed class NullDistributedLock : IDistributedLock
+{
+    public Task<IDistributedLockHandle?> TryAcquireAsync(
+        string lockKey,
+        TimeSpan leaseDuration,
+        CancellationToken cancellationToken = default)
+        => Task.FromResult<IDistributedLockHandle?>(new Handle(lockKey));
+
+    private sealed class Handle(string lockKey) : IDistributedLockHandle
+    {
+        public string LockKey => lockKey;
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+}
+```
+
+- [ ] **Step 4: Run tests, expect PASS**
+
+```
+dotnet test tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests --filter "FullyQualifiedName~NullDistributedLockTests"
+```
+
+Expected: 3 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Locking/NullDistributedLock.cs tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/Locking/NullDistributedLockTests.cs
+git commit -m "feat(efcore): NullDistributedLock no-op opt-out
+
+Always acquires the lock — restores v6.3 single-instance behaviour for
+consumers who do not apply the OrionGuard_OutboxLocks migration."
+```
+
+---
+
+## Task 10: `SkipLockedDistributedLock` — acquire/release happy path
+
+**Goal:** Implement the DB-backed lock with acquire/release working against a free slot. Lease-expiry takeover and missing-table tolerance follow in subsequent tasks.
+
+**Files:**
+- Create: `src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Locking/SkipLockedDistributedLock.cs`
+- Test: `tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/Locking/SkipLockedDistributedLockTests.cs`
+- Test helper: `tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/Locking/LockingTestFixture.cs`
+
+- [ ] **Step 1: Inspect existing test infrastructure**
+
+The EF Core test project should already contain an in-memory-SQLite fixture from v6.3.0 outbox tests. Locate it:
+
+```
+ls tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/
+```
+
+If a `TestDbContext.cs` or similar test-DbContext already exists, reuse it. Otherwise scaffold `LockingTestFixture.cs` with this content (one shared in-memory SQLite connection per fixture, `OutboxLock` mapped, schema created on construction):
+
+```csharp
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Locking;
+
+namespace Moongazing.OrionGuard.EntityFrameworkCore.Tests.Outbox.Locking;
+
+public sealed class LockingTestFixture : IAsyncDisposable
+{
+    public SqliteConnection Connection { get; }
+    public IServiceProvider Services { get; }
+
+    public LockingTestFixture()
+    {
+        Connection = new SqliteConnection("Filename=:memory:");
+        Connection.Open();
+
+        var services = new ServiceCollection();
+        services.AddDbContext<LockingTestDbContext>(o => o.UseSqlite(Connection));
+        services.AddScoped<DbContext>(sp => sp.GetRequiredService<LockingTestDbContext>());
+        Services = services.BuildServiceProvider();
+
+        using var scope = Services.CreateScope();
+        var ctx = scope.ServiceProvider.GetRequiredService<LockingTestDbContext>();
+        ctx.Database.EnsureCreated();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await Connection.DisposeAsync();
+        if (Services is IDisposable d) d.Dispose();
+    }
+}
+
+public sealed class LockingTestDbContext(DbContextOptions<LockingTestDbContext> options) : DbContext(options)
+{
+    public DbSet<OutboxLock> Locks => Set<OutboxLock>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+        => modelBuilder.ApplyConfiguration(new OutboxLockEntityTypeConfiguration());
+}
+```
+
+- [ ] **Step 2: Write happy-path tests**
+
+Create `tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/Locking/SkipLockedDistributedLockTests.cs`:
+
+```csharp
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Locking;
+
+namespace Moongazing.OrionGuard.EntityFrameworkCore.Tests.Outbox.Locking;
+
+public class SkipLockedDistributedLockTests : IAsyncLifetime
+{
+    private LockingTestFixture _fx = default!;
+
+    public Task InitializeAsync() { _fx = new LockingTestFixture(); return Task.CompletedTask; }
+    public async Task DisposeAsync() => await _fx.DisposeAsync();
+
+    private SkipLockedDistributedLock NewLock() =>
+        new(_fx.Services.GetRequiredService<IServiceScopeFactory>(), NullLogger<SkipLockedDistributedLock>.Instance);
+
+    [Fact]
+    public async Task TryAcquireAsync_ShouldReturnHandle_WhenSlotIsFree()
+    {
+        var @lock = NewLock();
+        var handle = await @lock.TryAcquireAsync("k", TimeSpan.FromSeconds(30));
+        Assert.NotNull(handle);
+        Assert.Equal("k", handle!.LockKey);
+    }
+
+    [Fact]
+    public async Task TryAcquireAsync_ShouldReturnNull_WhenSlotIsHeld()
+    {
+        var @lock = NewLock();
+        var first = await @lock.TryAcquireAsync("k", TimeSpan.FromSeconds(30));
+        Assert.NotNull(first);
+
+        var second = await @lock.TryAcquireAsync("k", TimeSpan.FromSeconds(30));
+        Assert.Null(second);
+    }
+
+    [Fact]
+    public async Task TryAcquireAsync_ShouldSucceedAgain_AfterFirstHandleIsDisposed()
+    {
+        var @lock = NewLock();
+        var first = await @lock.TryAcquireAsync("k", TimeSpan.FromSeconds(30));
+        Assert.NotNull(first);
+        await first!.DisposeAsync();
+
+        var second = await @lock.TryAcquireAsync("k", TimeSpan.FromSeconds(30));
+        Assert.NotNull(second);
+    }
+}
+```
+
+- [ ] **Step 3: Run tests, expect failure**
+
+```
+dotnet test tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests --filter "FullyQualifiedName~SkipLockedDistributedLockTests"
+```
+
+Expected: build error — `SkipLockedDistributedLock` does not exist.
+
+- [ ] **Step 4: Create the impl**
+
+Create `src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Locking/SkipLockedDistributedLock.cs`:
+
+```csharp
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Locking;
+
+/// <summary>
+/// Default DB-backed <see cref="IDistributedLock"/> implementation. Uses an <see cref="OutboxLock"/>
+/// row per lock key in the consumer's <c>OrionGuard_OutboxLocks</c> table. Provider-agnostic — all
+/// SQL is issued through EF Core. Lease-based; expired holders are taken over by fresh callers.
+/// </summary>
+public sealed class SkipLockedDistributedLock : IDistributedLock
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<SkipLockedDistributedLock>? _logger;
+
+    public SkipLockedDistributedLock(
+        IServiceScopeFactory scopeFactory,
+        ILogger<SkipLockedDistributedLock>? logger = null)
+    {
+        ArgumentNullException.ThrowIfNull(scopeFactory);
+        _scopeFactory = scopeFactory;
+        _logger = logger;
+    }
+
+    public async Task<IDistributedLockHandle?> TryAcquireAsync(
+        string lockKey,
+        TimeSpan leaseDuration,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(lockKey);
+        if (leaseDuration <= TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(leaseDuration), "Lease must be > 0.");
+
+        var holderId = Guid.NewGuid();
+        var now = DateTime.UtcNow;
+        var expires = now + leaseDuration;
+
+        await using var scope = _scopeFactory.CreateAsyncScope();
+        var ctx = scope.ServiceProvider.GetRequiredService<DbContext>();
+
+        await using var tx = await ctx.Database.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+
+        var updated = await ctx.Database.ExecuteSqlInterpolatedAsync(
+            $@"UPDATE OrionGuard_OutboxLocks
+                  SET HolderId = {holderId}, AcquiredOnUtc = {now}, ExpiresOnUtc = {expires}
+                WHERE LockKey = {lockKey}
+                  AND (HolderId IS NULL OR ExpiresOnUtc <= {now})",
+            cancellationToken).ConfigureAwait(false);
+
+        if (updated == 0)
+        {
+            try
+            {
+                await ctx.Database.ExecuteSqlInterpolatedAsync(
+                    $@"INSERT INTO OrionGuard_OutboxLocks (LockKey, HolderId, AcquiredOnUtc, ExpiresOnUtc)
+                       SELECT {lockKey}, {holderId}, {now}, {expires}
+                       WHERE NOT EXISTS (SELECT 1 FROM OrionGuard_OutboxLocks WHERE LockKey = {lockKey})",
+                    cancellationToken).ConfigureAwait(false);
+            }
+            catch (DbUpdateException)
+            {
+                await tx.RollbackAsync(cancellationToken).ConfigureAwait(false);
+                return null;
+            }
+        }
+
+        await tx.CommitAsync(cancellationToken).ConfigureAwait(false);
+
+        var ownerCheck = await ctx.Set<OutboxLock>().AsNoTracking()
+            .Where(x => x.LockKey == lockKey)
+            .Select(x => x.HolderId)
+            .FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);
+
+        if (ownerCheck != holderId)
+        {
+            return null;
+        }
+
+        return new Handle(this, lockKey, holderId);
+    }
+
+    private async Task ReleaseAsync(string lockKey, Guid holderId, CancellationToken cancellationToken = default)
+    {
+        await using var scope = _scopeFactory.CreateAsyncScope();
+        var ctx = scope.ServiceProvider.GetRequiredService<DbContext>();
+        var now = DateTime.UtcNow;
+        await ctx.Database.ExecuteSqlInterpolatedAsync(
+            $@"UPDATE OrionGuard_OutboxLocks
+                  SET HolderId = NULL, ExpiresOnUtc = {now}
+                WHERE LockKey = {lockKey} AND HolderId = {holderId}",
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    private sealed class Handle(SkipLockedDistributedLock owner, string lockKey, Guid holderId) : IDistributedLockHandle
+    {
+        public string LockKey => lockKey;
+
+        public async ValueTask DisposeAsync()
+        {
+            try
+            {
+                await owner.ReleaseAsync(lockKey, holderId).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                owner._logger?.LogWarning(ex,
+                    "Failed to release distributed lock '{LockKey}'. Lease will expire naturally.",
+                    lockKey);
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 5: Run tests, expect PASS**
+
+```
+dotnet test tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests --filter "FullyQualifiedName~SkipLockedDistributedLockTests"
+```
+
+Expected: 3 tests pass.
+
+- [ ] **Step 6: Commit**
+
+```
+git add src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Locking/SkipLockedDistributedLock.cs tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/Locking/LockingTestFixture.cs tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/Locking/SkipLockedDistributedLockTests.cs
+git commit -m "feat(efcore): SkipLockedDistributedLock acquire/release happy path
+
+Provider-agnostic DB-backed lock — EF Core raw SQL against OrionGuard_OutboxLocks,
+named locks, lease-based ownership, holder-id guarded release."
+```
+
+---
+
+## Task 11: `SkipLockedDistributedLock` — lease expiry takeover and holder mismatch on release
+
+**Files:**
+- Modify: `tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/Locking/SkipLockedDistributedLockTests.cs`
+
+- [ ] **Step 1: Add expiry + mismatch tests**
+
+Append inside the existing `SkipLockedDistributedLockTests` class:
+
+```csharp
+    [Fact]
+    public async Task TryAcquireAsync_ShouldTakeOver_WhenLeaseHasExpired()
+    {
+        var @lock = NewLock();
+        var first = await @lock.TryAcquireAsync("k", TimeSpan.FromMilliseconds(50));
+        Assert.NotNull(first);
+
+        await Task.Delay(150);
+
+        var second = await @lock.TryAcquireAsync("k", TimeSpan.FromSeconds(30));
+        Assert.NotNull(second);
+    }
+
+    [Fact]
+    public async Task DisposingExpiredHandle_ShouldBeNoOp_WhenAnotherHolderHasTakenOver()
+    {
+        var @lock = NewLock();
+        var first = await @lock.TryAcquireAsync("k", TimeSpan.FromMilliseconds(50));
+        Assert.NotNull(first);
+        await Task.Delay(150);
+
+        var second = await @lock.TryAcquireAsync("k", TimeSpan.FromSeconds(30));
+        Assert.NotNull(second);
+
+        // Disposing the stale handle must not clobber the new holder.
+        await first!.DisposeAsync();
+
+        var third = await @lock.TryAcquireAsync("k", TimeSpan.FromSeconds(30));
+        Assert.Null(third); // second is still holding it
+    }
+```
+
+- [ ] **Step 2: Run tests**
+
+```
+dotnet test tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests --filter "FullyQualifiedName~SkipLockedDistributedLockTests"
+```
+
+Expected: 5 tests pass — the takeover logic and holder-id mismatch guard are already implemented in Task 10. **If a test fails**, inspect the SQL in `SkipLockedDistributedLock.TryAcquireAsync`'s update WHERE clause (`ExpiresOnUtc <= @now`) and the release UPDATE's `HolderId = @holderId` clause.
+
+- [ ] **Step 3: Commit**
+
+```
+git add tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/Locking/SkipLockedDistributedLockTests.cs
+git commit -m "test(efcore): SkipLockedDistributedLock lease expiry and stale-handle dispose"
+```
+
+---
+
+## Task 12: `SkipLockedDistributedLock` — missing-table fault tolerance
+
+**Files:**
+- Modify: `src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Locking/SkipLockedDistributedLock.cs`
+- Modify: `tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/Locking/SkipLockedDistributedLockTests.cs`
+
+- [ ] **Step 1: Write the failing test (DbContext without `OutboxLock` mapping → table missing)**
+
+Add a new test fixture for this scenario and append the test. In `tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/Locking/SkipLockedDistributedLockTests.cs`, add this private DbContext type and `[Fact]`:
+
+```csharp
+    private sealed class NoLockTableDbContext(DbContextOptions<NoLockTableDbContext> options) : DbContext(options)
+    {
+        // intentionally does NOT apply OutboxLockEntityTypeConfiguration
+    }
+
+    [Fact]
+    public async Task TryAcquireAsync_ShouldReturnNull_WhenLockTableIsMissing()
+    {
+        await using var connection = new Microsoft.Data.Sqlite.SqliteConnection("Filename=:memory:");
+        await connection.OpenAsync();
+
+        var services = new ServiceCollection();
+        services.AddDbContext<NoLockTableDbContext>(o => o.UseSqlite(connection));
+        services.AddScoped<DbContext>(sp => sp.GetRequiredService<NoLockTableDbContext>());
+        await using var sp = services.BuildServiceProvider();
+
+        using (var scope = sp.CreateScope())
+        {
+            var ctx = scope.ServiceProvider.GetRequiredService<NoLockTableDbContext>();
+            await ctx.Database.EnsureCreatedAsync();
+        }
+
+        var @lock = new SkipLockedDistributedLock(
+            sp.GetRequiredService<IServiceScopeFactory>(),
+            NullLogger<SkipLockedDistributedLock>.Instance);
+
+        var handle = await @lock.TryAcquireAsync("k", TimeSpan.FromSeconds(30));
+        Assert.Null(handle);
+
+        // Subsequent calls also return null without throwing.
+        var handle2 = await @lock.TryAcquireAsync("k", TimeSpan.FromSeconds(30));
+        Assert.Null(handle2);
+    }
+```
+
+Make sure these `using` directives appear at the top of the test file:
+
+```csharp
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+```
+
+- [ ] **Step 2: Run test, expect failure**
+
+```
+dotnet test tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests --filter "FullyQualifiedName~TryAcquireAsync_ShouldReturnNull_WhenLockTableIsMissing"
+```
+
+Expected: throws (likely `SqliteException: no such table: OrionGuard_OutboxLocks`).
+
+- [ ] **Step 3: Wrap the SQL calls in a missing-table guard**
+
+In `src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Locking/SkipLockedDistributedLock.cs`:
+
+Add at the class level:
+
+```csharp
+    private int _missingTableWarned;
+
+    private static bool IsMissingTable(Exception ex)
+    {
+        var msg = ex.Message;
+        if (string.IsNullOrEmpty(msg)) return false;
+        return msg.Contains("no such table", StringComparison.OrdinalIgnoreCase)         // SQLite
+            || msg.Contains("Invalid object name", StringComparison.OrdinalIgnoreCase)  // SQL Server
+            || msg.Contains("does not exist", StringComparison.OrdinalIgnoreCase)       // PostgreSQL
+            || msg.Contains("doesn't exist", StringComparison.OrdinalIgnoreCase);       // MySQL/MariaDB
+    }
+
+    private void LogMissingTableOnce()
+    {
+        if (Interlocked.Exchange(ref _missingTableWarned, 1) == 0)
+        {
+            _logger?.LogWarning(
+                "OrionGuard_OutboxLocks table not found. Distributed locking is disabled until the v6.4.0 migration is applied. " +
+                "Single-instance consumers who do not want this migration should call opts.UseDistributedLock<NullDistributedLock>().");
+        }
+    }
+```
+
+Wrap the entire `TryAcquireAsync` body (after argument validation, encompassing all SQL calls) in a `try`/`catch`:
+
+```csharp
+        try
+        {
+            // ... existing body: scope/tx/UPDATE/INSERT/owner check ...
+            return new Handle(this, lockKey, holderId);
+        }
+        catch (Exception ex) when (IsMissingTable(ex))
+        {
+            LogMissingTableOnce();
+            return null;
+        }
+```
+
+Add the corresponding guard in `ReleaseAsync`:
+
+```csharp
+        try
+        {
+            // ... existing release UPDATE ...
+        }
+        catch (Exception ex) when (IsMissingTable(ex))
+        {
+            // table was removed between acquire and release — nothing to clean up.
+        }
+```
+
+- [ ] **Step 4: Run tests, expect PASS**
+
+```
+dotnet test tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests --filter "FullyQualifiedName~SkipLockedDistributedLockTests"
+```
+
+Expected: 6 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Locking/SkipLockedDistributedLock.cs tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/Locking/SkipLockedDistributedLockTests.cs
+git commit -m "feat(efcore): SkipLockedDistributedLock tolerates missing OrionGuard_OutboxLocks
+
+Returns null + warns once per instance instead of throwing when the v6.4.0
+migration has not been applied. Keeps zero-migration upgrades from v6.3.0 alive."
+```
+
+---
+
+## Task 13: `SkipLockedDistributedLock` concurrency integration test
+
+**Files:**
+- Create: `tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/Locking/SkipLockedDistributedLockConcurrencyTests.cs`
+
+- [ ] **Step 1: Write the concurrency test**
+
+```csharp
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Locking;
+
+namespace Moongazing.OrionGuard.EntityFrameworkCore.Tests.Outbox.Locking;
+
+public class SkipLockedDistributedLockConcurrencyTests : IAsyncLifetime
+{
+    private LockingTestFixture _fx = default!;
+
+    public Task InitializeAsync() { _fx = new LockingTestFixture(); return Task.CompletedTask; }
+    public async Task DisposeAsync() => await _fx.DisposeAsync();
+
+    [Fact]
+    public async Task TryAcquireAsync_ShouldHandOutExactlyOneHandle_AcrossFiveParallelCallers()
+    {
+        var @lock = new SkipLockedDistributedLock(
+            _fx.Services.GetRequiredService<IServiceScopeFactory>(),
+            NullLogger<SkipLockedDistributedLock>.Instance);
+
+        var tasks = Enumerable.Range(0, 5)
+            .Select(_ => @lock.TryAcquireAsync("k", TimeSpan.FromSeconds(30)))
+            .ToArray();
+
+        var handles = await Task.WhenAll(tasks);
+
+        Assert.Equal(1, handles.Count(h => h is not null));
+        Assert.Equal(4, handles.Count(h => h is null));
+    }
+}
+```
+
+- [ ] **Step 2: Run the test**
+
+```
+dotnet test tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests --filter "FullyQualifiedName~SkipLockedDistributedLockConcurrencyTests"
+```
+
+Expected: PASS — exactly one handle returned.
+
+> **Note for the engineer:** SQLite in-memory serializes connections; this test still validates the lock semantics because the UPDATE/INSERT+ownership-check pattern correctly funnels everyone through the same row. If a future PR moves the integration test to a real PG/MSSQL fixture, this test transfers without changes.
+
+- [ ] **Step 3: Commit**
+
+```
+git add tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/Locking/SkipLockedDistributedLockConcurrencyTests.cs
+git commit -m "test(efcore): SkipLockedDistributedLock parallel acquire returns exactly one handle"
+```
+
+---
+
+## Task 14: `OutboxOptions` — `LockKey` and `LockLeaseDuration`
+
+**Files:**
+- Modify: `src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/OutboxOptions.cs`
+
+- [ ] **Step 1: Add the two properties**
+
+Inside `public sealed class OutboxOptions`, append (with `_field`-pattern + validation matching the existing properties):
+
+```csharp
+    private string lockKey = "orion_guard_outbox_dispatcher";
+    private TimeSpan lockLeaseDuration = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Lock key used by <see cref="Locking.IDistributedLock"/> to coordinate dispatcher instances.
+    /// Cannot be null or whitespace. Default <c>orion_guard_outbox_dispatcher</c>.
+    /// </summary>
+    /// <exception cref="ArgumentException">Thrown when set to null, empty, or whitespace.</exception>
+    public string LockKey
+    {
+        get => lockKey;
+        set
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                throw new ArgumentException($"{nameof(LockKey)} cannot be null or whitespace.", nameof(value));
+            }
+            lockKey = value;
+        }
+    }
+
+    /// <summary>
+    /// Lease duration for the distributed lock. Must exceed the wall-clock cost of a single
+    /// <see cref="OutboxDispatcherHostedService.ProcessBatchAsync"/> call. Must be &gt; 0. Default 30s.
+    /// </summary>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when set to a non-positive value.</exception>
+    public TimeSpan LockLeaseDuration
+    {
+        get => lockLeaseDuration;
+        set
+        {
+            if (value <= TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(nameof(value), value,
+                    $"{nameof(LockLeaseDuration)} must be greater than zero.");
+            }
+            lockLeaseDuration = value;
+        }
+    }
+```
+
+- [ ] **Step 2: Build**
+
+```
+dotnet build src/Moongazing.OrionGuard.EntityFrameworkCore
+```
+
+Expected: success.
+
+- [ ] **Step 3: Commit**
+
+```
+git add src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/OutboxOptions.cs
+git commit -m "feat(efcore): OutboxOptions.LockKey and LockLeaseDuration
+
+LockKey default 'orion_guard_outbox_dispatcher', LockLeaseDuration default 30s."
+```
+
+---
+
+## Task 15: `OutboxTypeMapRegistry` and `OutboxTypeMapOptions`
+
+**Files:**
+- Create: `src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/TypeMap/OutboxTypeMapRegistry.cs`
+- Create: `src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/TypeMap/OutboxTypeMapOptions.cs`
+- Test: `tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/TypeMap/OutboxTypeMapRegistryTests.cs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/TypeMap/OutboxTypeMapRegistryTests.cs`:
+
+```csharp
+using Moongazing.OrionGuard.Domain.Events;
+using Moongazing.OrionGuard.EntityFrameworkCore.Outbox.TypeMap;
+
+namespace Moongazing.OrionGuard.EntityFrameworkCore.Tests.Outbox.TypeMap;
+
+public class OutboxTypeMapRegistryTests
+{
+    private sealed record UserRegistered : DomainEventBase;
+    private sealed record OrderPlaced : DomainEventBase;
+
+    [Fact]
+    public void Map_ShouldStoreRoundTrip()
+    {
+        var r = new OutboxTypeMapRegistry().Map<UserRegistered>("user.registered");
+
+        Assert.True(r.TryResolve("user.registered", out var t));
+        Assert.Equal(typeof(UserRegistered), t);
+
+        Assert.True(r.TryGetLogicalName(typeof(UserRegistered), out var name));
+        Assert.Equal("user.registered", name);
+    }
+
+    [Fact]
+    public void TryResolve_ShouldReturnFalse_WhenLogicalNameUnknown()
+    {
+        var r = new OutboxTypeMapRegistry();
+        Assert.False(r.TryResolve("nope", out var t));
+        Assert.Null(t);
+    }
+
+    [Fact]
+    public void Map_ShouldThrow_WhenSameNameMapsToDifferentType()
+    {
+        var r = new OutboxTypeMapRegistry().Map<UserRegistered>("evt");
+        Assert.Throws<InvalidOperationException>(() => r.Map<OrderPlaced>("evt"));
+    }
+
+    [Fact]
+    public void Map_ShouldThrow_WhenSameTypeMapsToDifferentName()
+    {
+        var r = new OutboxTypeMapRegistry().Map<UserRegistered>("a");
+        Assert.Throws<InvalidOperationException>(() => r.Map<UserRegistered>("b"));
+    }
+
+    [Fact]
+    public void Map_ShouldBeIdempotent_WhenSameTypeAndSameName()
+    {
+        var r = new OutboxTypeMapRegistry().Map<UserRegistered>("u");
+        r.Map<UserRegistered>("u"); // no throw
+    }
+
+    [Fact]
+    public void OutboxTypeMapOptions_AllowAssemblyQualifiedNameFallback_ShouldDefaultTrue()
+    {
+        Assert.True(new OutboxTypeMapOptions().AllowAssemblyQualifiedNameFallback);
+    }
+}
+```
+
+- [ ] **Step 2: Run, expect failure**
+
+```
+dotnet test tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests --filter "FullyQualifiedName~OutboxTypeMapRegistryTests"
+```
+
+Expected: build error.
+
+- [ ] **Step 3: Create `OutboxTypeMapRegistry.cs`**
+
+```csharp
+using System.Diagnostics.CodeAnalysis;
+using Moongazing.OrionGuard.Domain.Events;
+
+namespace Moongazing.OrionGuard.EntityFrameworkCore.Outbox.TypeMap;
+
+/// <summary>
+/// Maps stable logical names (e.g. <c>"user.registered"</c>) to CLR event types. Used by the outbox
+/// dispatcher to avoid <see cref="Type.GetType(string)"/> reflection and to decouple persisted
+/// payloads from internal type identity. Populated once at startup; no thread-safety on <see cref="Map{TEvent}"/>.
+/// </summary>
+public sealed class OutboxTypeMapRegistry
+{
+    private readonly Dictionary<string, Type> _byName = new(StringComparer.Ordinal);
+    private readonly Dictionary<Type, string> _byType = new();
+
+    /// <summary>Maps an event type to a logical name. Throws on collision (same name → different type, or vice versa).</summary>
+    public OutboxTypeMapRegistry Map<TEvent>(string logicalName) where TEvent : IDomainEvent
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(logicalName);
+
+        var type = typeof(TEvent);
+
+        if (_byName.TryGetValue(logicalName, out var existingType) && existingType != type)
+        {
+            throw new InvalidOperationException(
+                $"Outbox type map collision: '{logicalName}' is already mapped to {existingType.FullName}.");
+        }
+        if (_byType.TryGetValue(type, out var existingName) && existingName != logicalName)
+        {
+            throw new InvalidOperationException(
+                $"Outbox type map collision: {type.FullName} is already mapped to '{existingName}'.");
+        }
+
+        _byName[logicalName] = type;
+        _byType[type] = logicalName;
+        return this;
+    }
+
+    public bool TryResolve(string logicalName, [NotNullWhen(true)] out Type? type)
+        => _byName.TryGetValue(logicalName, out type);
+
+    public bool TryGetLogicalName(Type type, [NotNullWhen(true)] out string? logicalName)
+        => _byType.TryGetValue(type, out logicalName);
+}
+```
+
+- [ ] **Step 4: Create `OutboxTypeMapOptions.cs`**
+
+```csharp
+namespace Moongazing.OrionGuard.EntityFrameworkCore.Outbox.TypeMap;
+
+/// <summary>Controls fallback behaviour when an outbox row's <c>EventType</c> is not in the registry.</summary>
+public sealed class OutboxTypeMapOptions
+{
+    /// <summary>
+    /// When true, the dispatcher falls back to <see cref="Type.GetType(string)"/> for event types not
+    /// registered in the <see cref="OutboxTypeMapRegistry"/>. Default <see langword="true"/> for v6.3 source compatibility.
+    /// Set false for AOT-only deployments.
+    /// </summary>
+    public bool AllowAssemblyQualifiedNameFallback { get; set; } = true;
+}
+```
+
+- [ ] **Step 5: Run, expect PASS**
+
+```
+dotnet test tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests --filter "FullyQualifiedName~OutboxTypeMapRegistryTests"
+```
+
+Expected: 6 tests pass.
+
+- [ ] **Step 6: Commit**
+
+```
+git add src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/TypeMap/OutboxTypeMapRegistry.cs src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/TypeMap/OutboxTypeMapOptions.cs tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/TypeMap/OutboxTypeMapRegistryTests.cs
+git commit -m "feat(efcore): OutboxTypeMapRegistry with AQN fallback options
+
+Maps logical name to CLR type; collisions throw at startup. Default
+OutboxTypeMapOptions keeps AQN fallback enabled for v6.3 source compatibility."
+```
+
+---
+
+## Task 16: Writer side — interceptor prefers registry's logical name
+
+**Files:**
+- Modify: `src/Moongazing.OrionGuard.EntityFrameworkCore/DomainEventSaveChangesInterceptor.cs` (around line 71)
+
+> **Background:** The current interceptor writes `EventType = e.GetType().AssemblyQualifiedName!`. When an `OutboxTypeMapRegistry` is registered and contains the event type, we want to write the logical name instead. When no registry is registered or the event is not in it, we keep writing AQN.
+
+- [ ] **Step 1: Locate the existing class — read for context**
+
+Run:
+
+```
+sed -n '1,80p' src/Moongazing.OrionGuard.EntityFrameworkCore/DomainEventSaveChangesInterceptor.cs
+```
+
+Note the constructor and any field for `OutboxTypeMapRegistry`. There is none today.
+
+- [ ] **Step 2: Add registry injection**
+
+Add `using Moongazing.OrionGuard.EntityFrameworkCore.Outbox.TypeMap;` to the using block.
+
+Change the class field/ctor area:
+
+```csharp
+public sealed class DomainEventSaveChangesInterceptor : SaveChangesInterceptor
+{
+    private readonly OrionGuardEfCoreOptions options;
+    private readonly IDomainEventDispatcher dispatcher;
+    private readonly DomainEventCollector collector;
+    private readonly OutboxTypeMapRegistry? typeMap;
+
+    public DomainEventSaveChangesInterceptor(
+        OrionGuardEfCoreOptions options,
+        IDomainEventDispatcher dispatcher,
+        DomainEventCollector collector,
+        OutboxTypeMapRegistry? typeMap = null)
+    {
+        this.options = options;
+        this.dispatcher = dispatcher;
+        this.collector = collector;
+        this.typeMap = typeMap;
+    }
+```
+
+(Match the existing constructor style — if the existing one uses primary-constructor syntax, adapt accordingly. Keep `typeMap` optional so existing tests/factories don't break.)
+
+- [ ] **Step 3: Use the registry when writing `EventType`**
+
+Replace the line at ~line 71:
+
+```csharp
+                        EventType = e.GetType().AssemblyQualifiedName!,
+```
+
+with:
+
+```csharp
+                        EventType = ResolveEventTypeId(e.GetType()),
+```
+
+And add this private helper inside the class:
+
+```csharp
+    private string ResolveEventTypeId(Type eventType)
+    {
+        if (typeMap is not null && typeMap.TryGetLogicalName(eventType, out var logical))
+        {
+            return logical;
+        }
+        return eventType.AssemblyQualifiedName ?? eventType.FullName!;
+    }
+```
+
+- [ ] **Step 4: Build and run existing EF Core tests; nothing should regress**
+
+```
+dotnet build src/Moongazing.OrionGuard.EntityFrameworkCore
+dotnet test tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests
+```
+
+Expected: all existing tests pass (interceptor ctor now takes an optional `typeMap` defaulted to null — old call sites continue to compile).
+
+- [ ] **Step 5: Add a writer-side test**
+
+Create `tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/TypeMap/OutboxInterceptor_TypeMapWriterTests.cs`:
+
+```csharp
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Moongazing.OrionGuard.Domain.Events;
+using Moongazing.OrionGuard.Domain.Primitives;
+using Moongazing.OrionGuard.EntityFrameworkCore.Outbox;
+using Moongazing.OrionGuard.EntityFrameworkCore.Outbox.TypeMap;
+
+namespace Moongazing.OrionGuard.EntityFrameworkCore.Tests.Outbox.TypeMap;
+
+public class OutboxInterceptor_TypeMapWriterTests
+{
+    private sealed record UserRegistered : DomainEventBase;
+
+    private sealed class TestAggregate : AggregateRoot<int>
+    {
+        public TestAggregate(int id) : base(id) { }
+        public void Trigger() => RaiseEvent(new UserRegistered());
+    }
+
+    // The exact integration shape depends on existing test scaffolding for the interceptor —
+    // mirror the approach used by tests like OutboxInterceptorTests / similar from v6.3.
+    // The key assertion:
+    //   When OutboxTypeMapRegistry registers UserRegistered → "user.registered",
+    //   the persisted OutboxMessage.EventType equals "user.registered".
+    //   When no registry is registered, EventType equals UserRegistered's AssemblyQualifiedName.
+
+    [Fact]
+    public void Placeholder_ReplaceWithIntegrationStyleMatchingExistingInterceptorTests()
+    {
+        // The engineer implementing this task should follow the pattern used in the existing
+        // outbox interceptor tests (a SQLite-backed DbContext that applies OutboxMessageEntityTypeConfiguration,
+        // an AggregateRoot stored, SaveChanges, then assert on the OutboxMessage rows).
+        // This test is a stub to surface the requirement in the plan; the real implementation must
+        // exercise both code paths (registry hit, registry miss / AQN fallback).
+        Assert.True(true);
+    }
+}
+```
+
+> **Important:** Replace the placeholder test with two integration-style tests. The first registers an `OutboxTypeMapRegistry` and asserts `EventType == "user.registered"`. The second omits the registry and asserts `EventType == typeof(UserRegistered).AssemblyQualifiedName`. Pattern after existing outbox interceptor tests in `tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/`.
+
+- [ ] **Step 6: Commit**
+
+```
+git add src/Moongazing.OrionGuard.EntityFrameworkCore/DomainEventSaveChangesInterceptor.cs tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/TypeMap/OutboxInterceptor_TypeMapWriterTests.cs
+git commit -m "feat(efcore): SaveChanges interceptor writes logical name when type map is registered
+
+Falls back to AssemblyQualifiedName when no registry or no mapping is present.
+Existing v6.3 behaviour preserved when no registry is wired."
+```
+
+---
+
+## Task 17: Refactor `OutboxDispatcherHostedService` constructor to inject new deps
+
+**Files:**
+- Modify: `src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/OutboxDispatcherHostedService.cs`
+
+> **Why this is its own task:** dispatcher integration with `IDistributedLock` (Task 18) and type-map (Task 19) both need the constructor change first. Doing it separately keeps each TDD step honest.
+
+- [ ] **Step 1: Add the new dependencies as constructor params**
+
+In `src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/OutboxDispatcherHostedService.cs`, add to using:
+
+```csharp
+using Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Locking;
+using Moongazing.OrionGuard.EntityFrameworkCore.Outbox.TypeMap;
+```
+
+Modify the class fields and constructor (currently 3 params: options, scopeFactory, logger):
+
+```csharp
+    private readonly OutboxOptions options;
+    private readonly IServiceScopeFactory scopeFactory;
+    private readonly IDistributedLock distributedLock;
+    private readonly OutboxTypeMapRegistry typeMap;
+    private readonly OutboxTypeMapOptions typeMapOptions;
+    private readonly ILogger<OutboxDispatcherHostedService>? logger;
+
+    public OutboxDispatcherHostedService(
+        OutboxOptions options,
+        IServiceScopeFactory scopeFactory,
+        IDistributedLock distributedLock,
+        OutboxTypeMapRegistry typeMap,
+        OutboxTypeMapOptions typeMapOptions,
+        ILogger<OutboxDispatcherHostedService>? logger = null)
+    {
+        this.options = options ?? throw new ArgumentNullException(nameof(options));
+        this.scopeFactory = scopeFactory ?? throw new ArgumentNullException(nameof(scopeFactory));
+        this.distributedLock = distributedLock ?? throw new ArgumentNullException(nameof(distributedLock));
+        this.typeMap = typeMap ?? throw new ArgumentNullException(nameof(typeMap));
+        this.typeMapOptions = typeMapOptions ?? throw new ArgumentNullException(nameof(typeMapOptions));
+        this.logger = logger;
+    }
+```
+
+- [ ] **Step 2: Update the factory in `ServiceCollectionExtensions.AddOrionGuardEfCore`**
+
+In `src/Moongazing.OrionGuard.EntityFrameworkCore/ServiceCollectionExtensions.cs`, update the `AddHostedService` factory (around line 50):
+
+```csharp
+            services.AddHostedService(sp => new OutboxDispatcherHostedService(
+                sp.GetRequiredService<OutboxOptions>(),
+                sp.GetRequiredService<IServiceScopeFactory>(),
+                sp.GetRequiredService<IDistributedLock>(),
+                sp.GetRequiredService<OutboxTypeMapRegistry>(),
+                sp.GetRequiredService<OutboxTypeMapOptions>(),
+                sp.GetService<ILogger<OutboxDispatcherHostedService>>()));
+```
+
+Add the `using` directives for `Locking` and `TypeMap` namespaces if missing.
+
+Then immediately above the `AddHostedService` call (still inside the `Outbox` strategy branch), add the default registrations:
+
+```csharp
+            services.TryAddSingleton<IDistributedLock, SkipLockedDistributedLock>();
+            services.TryAddSingleton(new OutboxTypeMapRegistry());
+            services.TryAddSingleton(new OutboxTypeMapOptions());
+```
+
+- [ ] **Step 3: Build**
+
+```
+dotnet build
+```
+
+Expected: success. Old dispatcher tests that manually constructed `OutboxDispatcherHostedService(options, scopeFactory)` or with two-arg/three-arg constructor will FAIL TO COMPILE. Update them to pass `NullDistributedLock`, an empty `OutboxTypeMapRegistry`, and a default `OutboxTypeMapOptions`. Identify them with:
+
+```
+dotnet build 2>&1 | grep "OutboxDispatcherHostedService"
+```
+
+For each test that constructs the dispatcher, update to:
+
+```csharp
+new OutboxDispatcherHostedService(
+    options,
+    scopeFactory,
+    new NullDistributedLock(),
+    new OutboxTypeMapRegistry(),
+    new OutboxTypeMapOptions(),
+    logger);
+```
+
+- [ ] **Step 4: Run all EF Core tests**
+
+```
+dotnet test tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests
+```
+
+Expected: all tests pass (behaviour unchanged so far — new params not yet used).
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/OutboxDispatcherHostedService.cs src/Moongazing.OrionGuard.EntityFrameworkCore/ServiceCollectionExtensions.cs tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/
+git commit -m "refactor(efcore): OutboxDispatcherHostedService injects IDistributedLock and OutboxTypeMapRegistry
+
+Constructor expanded; DI factory updated. Tests reconstructed via NullDistributedLock +
+empty registry — behaviour preserved while wiring is in place for Tasks 18-19."
+```
+
+---
+
+## Task 18: Dispatcher acquires distributed lock per polling iteration
+
+**Files:**
+- Modify: `src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/OutboxDispatcherHostedService.cs` — `ExecuteAsync`
+- Test: `tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/OutboxDispatcher_LockIntegrationTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/OutboxDispatcher_LockIntegrationTests.cs`:
+
+```csharp
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moongazing.OrionGuard.EntityFrameworkCore.Outbox;
+using Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Locking;
+using Moongazing.OrionGuard.EntityFrameworkCore.Outbox.TypeMap;
+
+namespace Moongazing.OrionGuard.EntityFrameworkCore.Tests.Outbox;
+
+public class OutboxDispatcher_LockIntegrationTests
+{
+    [Fact]
+    public async Task ProcessBatchAsync_ShouldStillRun_WhenInvokedDirectly()
+    {
+        // Direct ProcessBatchAsync calls bypass the ExecuteAsync lock loop. This test exists to lock
+        // down that ProcessBatchAsync remains test-callable without requiring lock acquisition,
+        // which keeps existing v6.3 outbox tests passing.
+        // (Concrete assertion: build a small fixture with the existing outbox setup, seed a row,
+        //  call ProcessBatchAsync, assert the row was processed.)
+        // Pattern after existing OutboxDispatcherHostedServiceTests; the only delta is the new
+        // constructor args.
+        Assert.True(true); // placeholder — fill in matching existing test scaffolding
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ShouldSkipBatch_WhenLockUnavailable()
+    {
+        // Tracks how many times ProcessBatchAsync runs when lock returns null vs. handle.
+        // Implementation: replace IDistributedLock with a stub that returns null the first call
+        // and a handle the second. Track batch invocations by inspecting OutboxMessage state
+        // after a short run. Expected: row is NOT processed in iteration 1, IS processed in iteration 2.
+        Assert.True(true); // placeholder — engineer fills in matching existing scaffolding
+    }
+}
+```
+
+> **Engineer note:** Replace both placeholders with integration tests using the existing outbox test fixture (SQLite, `OutboxMessageEntityTypeConfiguration`, the v6.3 dispatcher tests' patterns). The lock test uses a stub `IDistributedLock` (inline class implementing the interface). Cancel the dispatcher quickly via `CancellationToken` after a single polling cycle.
+
+- [ ] **Step 2: Run, observe — placeholders pass, real tests would fail because `ExecuteAsync` does not yet consult the lock**
+
+```
+dotnet test tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests --filter "FullyQualifiedName~OutboxDispatcher_LockIntegrationTests"
+```
+
+- [ ] **Step 3: Wire `IDistributedLock` into `ExecuteAsync`**
+
+In `src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/OutboxDispatcherHostedService.cs`, replace the body of `ExecuteAsync` with:
+
+```csharp
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        logger?.LogInformation(
+            "OrionGuard outbox dispatcher started with distributed locking key '{LockKey}' (lease {Lease}).",
+            options.LockKey, options.LockLeaseDuration);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await using var handle = await distributedLock.TryAcquireAsync(
+                    options.LockKey,
+                    options.LockLeaseDuration,
+                    stoppingToken).ConfigureAwait(false);
+
+                if (handle is null)
+                {
+                    // Why: another worker holds the lock; back off until the next poll.
+                    await Task.Delay(options.PollingInterval, stoppingToken).ConfigureAwait(false);
+                    continue;
+                }
+
+                await ProcessBatchAsync(stoppingToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+            catch
+            {
+                // Why: swallow per-batch faults so the worker survives transient infrastructure
+                // errors. Per-row dispatch faults are recorded on the OutboxMessage row itself.
+            }
+
+            try
+            {
+                await Task.Delay(options.PollingInterval, stoppingToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+        }
+    }
+```
+
+- [ ] **Step 4: Run all EF Core tests, expect no regressions**
+
+```
+dotnet test tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/OutboxDispatcherHostedService.cs tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/OutboxDispatcher_LockIntegrationTests.cs
+git commit -m "feat(efcore): outbox dispatcher consults IDistributedLock per polling iteration
+
+Skips ProcessBatchAsync when the lock is held by another instance.
+Default SkipLockedDistributedLock means multi-instance deployments no longer
+double-dispatch as long as the OrionGuard_OutboxLocks migration is applied."
+```
+
+---
+
+## Task 19: Dispatcher uses `OutboxTypeMapRegistry` for type resolution
+
+**Files:**
+- Modify: `src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/OutboxDispatcherHostedService.cs` — `ProcessBatchAsync`
+- Test: `tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/OutboxDispatcher_TypeMapTests.cs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/OutboxDispatcher_TypeMapTests.cs`:
+
+```csharp
+using Moongazing.OrionGuard.Domain.Events;
+using Moongazing.OrionGuard.EntityFrameworkCore.Outbox;
+using Moongazing.OrionGuard.EntityFrameworkCore.Outbox.TypeMap;
+
+namespace Moongazing.OrionGuard.EntityFrameworkCore.Tests.Outbox;
+
+public class OutboxDispatcher_TypeMapTests
+{
+    private sealed record UserRegistered : DomainEventBase;
+
+    // Each test below builds on the existing outbox test scaffolding (SQLite DbContext +
+    // outbox table). Seed an OutboxMessage row, run ProcessBatchAsync, assert outcome:
+    //
+    // (A) Registry hit:
+    //     - registry = empty.Map<UserRegistered>("user.registered")
+    //     - row.EventType = "user.registered"
+    //     - expect: dispatched (ProcessedOnUtc set, Error null)
+    //
+    // (B) AQN fallback path:
+    //     - registry = empty
+    //     - row.EventType = typeof(UserRegistered).AssemblyQualifiedName
+    //     - opts.AllowAssemblyQualifiedNameFallback = true (default)
+    //     - expect: dispatched
+    //
+    // (C) AQN fallback disabled + unregistered:
+    //     - registry = empty
+    //     - row.EventType = typeof(UserRegistered).AssemblyQualifiedName
+    //     - opts.AllowAssemblyQualifiedNameFallback = false
+    //     - expect: dead-lettered with Error starting "TYPE_NOT_FOUND"
+
+    [Fact] public void Placeholder_RegistryHit_DispatchesRow() => Assert.True(true);
+    [Fact] public void Placeholder_AqnFallback_DispatchesRow() => Assert.True(true);
+    [Fact] public void Placeholder_NoFallback_DeadLetters() => Assert.True(true);
+}
+```
+
+> **Engineer note:** Replace the three placeholders with real integration tests. Pattern after the v6.3 `OutboxDispatcherHostedServiceTests` (which already cover dispatch-vs-deadletter). The new variants only change what is put in `EventType` and what is in the registry / options.
+
+- [ ] **Step 2: Update `ProcessBatchAsync` to consult the registry first**
+
+In `src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/OutboxDispatcherHostedService.cs`, locate the type resolution block in `ProcessBatchAsync` (around lines 123–142 — the `var type = Type.GetType(msg.EventType);` block). Replace **only** the resolution part:
+
+```csharp
+                Type? type;
+                if (typeMap.TryResolve(msg.EventType, out var resolved))
+                {
+                    type = resolved;
+                }
+                else if (typeMapOptions.AllowAssemblyQualifiedNameFallback)
+                {
+                    type = Type.GetType(msg.EventType);
+                }
+                else
+                {
+                    type = null;
+                }
+
+                if (type is null)
+                {
+                    msg.Error = $"TYPE_NOT_FOUND: cannot resolve event type '{msg.EventType}'. " +
+                                $"Registry has no mapping and AQN fallback is " +
+                                $"{(typeMapOptions.AllowAssemblyQualifiedNameFallback ? "enabled but resolution failed" : "disabled")}.";
+                    msg.ProcessedOnUtc = DateTime.UtcNow;
+                    logger?.LogWarning(
+                        "Outbox row {RowId} dead-lettered: type '{EventType}' could not be resolved.",
+                        msg.Id, msg.EventType);
+                }
+                else if (!typeof(IDomainEvent).IsAssignableFrom(type))
+                {
+                    // existing branch — unchanged
+                }
+                else
+                {
+                    // existing branch — unchanged (deserialize, dispatch, mark processed)
+                }
+```
+
+Keep the surrounding `try/catch` and `SaveChangesAsync` calls intact.
+
+- [ ] **Step 3: Run all EF Core tests; replace placeholder tests with real assertions before declaring done**
+
+```
+dotnet test tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests
+```
+
+Expected: all tests pass, including three new TypeMap dispatcher tests.
+
+- [ ] **Step 4: Commit**
+
+```
+git add src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/OutboxDispatcherHostedService.cs tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/OutboxDispatcher_TypeMapTests.cs
+git commit -m "feat(efcore): outbox dispatcher resolves event types via OutboxTypeMapRegistry
+
+Logical-name path first, then AQN fallback when allowed. Dead-letter message
+makes the fallback state explicit."
+```
+
+---
+
+## Task 20: `OutboxArchivalOptions` and `OutboxArchivalHostedService.ArchiveBatchAsync`
+
+**Files:**
+- Create: `src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Archival/OutboxArchivalOptions.cs`
+- Create: `src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Archival/OutboxArchivalHostedService.cs` (partial — only `ArchiveBatchAsync` for now)
+- Test: `tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/Archival/OutboxArchivalHostedServiceTests.cs`
+
+- [ ] **Step 1: Create `OutboxArchivalOptions.cs`**
+
+```csharp
+namespace Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Archival;
+
+/// <summary>Configures the opt-in <see cref="OutboxArchivalHostedService"/>.</summary>
+public sealed class OutboxArchivalOptions
+{
+    /// <summary>How long to keep processed rows before deletion. Default 30 days.</summary>
+    public TimeSpan RetentionPeriod { get; set; } = TimeSpan.FromDays(30);
+
+    /// <summary>How often the archival worker polls. Default 1 hour.</summary>
+    public TimeSpan PollingInterval { get; set; } = TimeSpan.FromHours(1);
+
+    /// <summary>Max rows deleted per batch. Default 1000.</summary>
+    public int BatchSize { get; set; } = 1000;
+
+    /// <summary>
+    /// When true, rows with <c>Error</c> set (dead-letter) are never deleted regardless of
+    /// retention. Default true.
+    /// </summary>
+    public bool PreserveDeadLetters { get; set; } = true;
+
+    /// <summary>Lock key used to coordinate archival across instances. Default <c>orion_guard_outbox_archival</c>.</summary>
+    public string LockKey { get; set; } = "orion_guard_outbox_archival";
+}
+```
+
+- [ ] **Step 2: Create `OutboxArchivalHostedService.cs` with only `ArchiveBatchAsync` (testable, no loop yet)**
+
+```csharp
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Locking;
+
+namespace Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Archival;
+
+/// <summary>
+/// Periodically deletes processed outbox rows older than <see cref="OutboxArchivalOptions.RetentionPeriod"/>.
+/// Opt-in: register via <c>opts.UseOutboxArchival(...)</c>. Coordinates with the dispatcher through a
+/// separate <see cref="IDistributedLock"/> key.
+/// </summary>
+public sealed class OutboxArchivalHostedService : BackgroundService
+{
+    private readonly OutboxArchivalOptions options;
+    private readonly IServiceScopeFactory scopeFactory;
+    private readonly IDistributedLock distributedLock;
+    private readonly ILogger<OutboxArchivalHostedService>? logger;
+
+    public OutboxArchivalHostedService(
+        OutboxArchivalOptions options,
+        IServiceScopeFactory scopeFactory,
+        IDistributedLock distributedLock,
+        ILogger<OutboxArchivalHostedService>? logger = null)
+    {
+        this.options = options ?? throw new ArgumentNullException(nameof(options));
+        this.scopeFactory = scopeFactory ?? throw new ArgumentNullException(nameof(scopeFactory));
+        this.distributedLock = distributedLock ?? throw new ArgumentNullException(nameof(distributedLock));
+        this.logger = logger;
+    }
+
+    /// <summary>Deletes one batch of processed rows older than the retention cutoff. Public for tests.</summary>
+    public async Task<int> ArchiveBatchAsync(CancellationToken cancellationToken)
+    {
+        var cutoff = DateTime.UtcNow - options.RetentionPeriod;
+        await using var scope = scopeFactory.CreateAsyncScope();
+        var ctx = scope.ServiceProvider.GetRequiredService<DbContext>();
+
+        var query = ctx.Set<OutboxMessage>()
+            .Where(m => m.ProcessedOnUtc != null && m.ProcessedOnUtc < cutoff);
+
+        if (options.PreserveDeadLetters)
+            query = query.Where(m => m.Error == null);
+
+        var deleted = await query
+            .OrderBy(m => m.ProcessedOnUtc)
+            .Take(options.BatchSize)
+            .ExecuteDeleteAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        if (deleted > 0)
+            logger?.LogInformation("Outbox archival deleted {Count} rows older than {Cutoff:O}.", deleted, cutoff);
+
+        return deleted;
+    }
+
+    /// <inheritdoc />
+    protected override Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        // Filled in by Task 21.
+        return Task.CompletedTask;
+    }
+}
+```
+
+- [ ] **Step 3: Write the failing tests**
+
+Create `tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/Archival/OutboxArchivalHostedServiceTests.cs`:
+
+```csharp
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moongazing.OrionGuard.EntityFrameworkCore.Outbox;
+using Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Archival;
+using Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Locking;
+
+namespace Moongazing.OrionGuard.EntityFrameworkCore.Tests.Outbox.Archival;
+
+public class OutboxArchivalHostedServiceTests
+{
+    // Pattern: build a fixture similar to LockingTestFixture but with the OutboxMessage table mapped.
+    // Seed processed rows with varying ProcessedOnUtc dates and Error states, call ArchiveBatchAsync,
+    // assert which rows remain.
+
+    [Fact]
+    public async Task ArchiveBatchAsync_ShouldDeleteRowsOlderThanRetention()
+    {
+        // Seed:
+        //   row A: ProcessedOnUtc = now - 45d, Error = null  -> deleted
+        //   row B: ProcessedOnUtc = now - 5d,  Error = null  -> kept (within retention)
+        //   row C: ProcessedOnUtc = null,                    -> kept (not processed)
+        // Options: RetentionPeriod=30d, PreserveDeadLetters=true, BatchSize=10
+        // Expected: ArchiveBatchAsync returns 1; only row A removed.
+        Assert.True(true); // engineer replaces with real assertion
+    }
+
+    [Fact]
+    public async Task ArchiveBatchAsync_ShouldPreserveDeadLetters_WhenPreserveDeadLettersIsTrue()
+    {
+        // Seed:
+        //   row A: ProcessedOnUtc = now - 45d, Error = null  -> deleted
+        //   row B: ProcessedOnUtc = now - 45d, Error = "boom" -> kept
+        // Options: PreserveDeadLetters=true
+        Assert.True(true);
+    }
+
+    [Fact]
+    public async Task ArchiveBatchAsync_ShouldDeleteDeadLetters_WhenPreserveDeadLettersIsFalse()
+    {
+        // Same seed as above, options.PreserveDeadLetters=false -> both deleted.
+        Assert.True(true);
+    }
+
+    [Fact]
+    public async Task ArchiveBatchAsync_ShouldRespectBatchSize()
+    {
+        // Seed N=20 rows all eligible. BatchSize=5. Expect 5 deleted, 15 remain.
+        Assert.True(true);
+    }
+}
+```
+
+> **Engineer:** replace the four placeholder tests with concrete implementations using the test fixture for `OutboxMessage` (a `DbContext` that applies `OutboxMessageEntityTypeConfiguration`). Seed rows manually, call `ArchiveBatchAsync`, assert.
+
+- [ ] **Step 4: Run, expect placeholders pass; replace with real tests and verify they pass too**
+
+```
+dotnet test tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests --filter "FullyQualifiedName~OutboxArchivalHostedServiceTests"
+```
+
+Expected: 4 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Archival/OutboxArchivalOptions.cs src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Archival/OutboxArchivalHostedService.cs tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/Archival/OutboxArchivalHostedServiceTests.cs
+git commit -m "feat(efcore): OutboxArchivalHostedService.ArchiveBatchAsync
+
+Retention-based ExecuteDeleteAsync against OrionGuard_Outbox. Default
+30-day retention, 1000-row batches, dead-letter preservation. Loop in next task."
+```
+
+---
+
+## Task 21: `OutboxArchivalHostedService.ExecuteAsync` loop with locking
+
+**Files:**
+- Modify: `src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Archival/OutboxArchivalHostedService.cs`
+
+- [ ] **Step 1: Implement the loop**
+
+Replace the empty `ExecuteAsync` body in `OutboxArchivalHostedService` with:
+
+```csharp
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        logger?.LogInformation(
+            "OrionGuard outbox archival started. Retention {Retention}, batch {BatchSize}, polling {Polling}.",
+            options.RetentionPeriod, options.BatchSize, options.PollingInterval);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await using var handle = await distributedLock.TryAcquireAsync(
+                    options.LockKey,
+                    TimeSpan.FromMinutes(5),
+                    stoppingToken).ConfigureAwait(false);
+
+                if (handle is null)
+                {
+                    await Task.Delay(options.PollingInterval, stoppingToken).ConfigureAwait(false);
+                    continue;
+                }
+
+                await ArchiveBatchAsync(stoppingToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) { break; }
+            catch (Exception ex)
+            {
+                logger?.LogError(ex, "Outbox archival batch failed.");
+            }
+
+            try
+            {
+                await Task.Delay(options.PollingInterval, stoppingToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) { break; }
+        }
+    }
+```
+
+- [ ] **Step 2: Build and run all EF Core tests**
+
+```
+dotnet build src/Moongazing.OrionGuard.EntityFrameworkCore
+dotnet test tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests
+```
+
+Expected: all tests pass — loop is not directly exercised by tests (we test `ArchiveBatchAsync` directly), so this should be a no-op behaviour change.
+
+- [ ] **Step 3: Commit**
+
+```
+git add src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Archival/OutboxArchivalHostedService.cs
+git commit -m "feat(efcore): OutboxArchivalHostedService.ExecuteAsync polling loop with lock
+
+Acquires orion_guard_outbox_archival lock per iteration; sleeps when held."
+```
+
+---
+
+## Task 22: `OrionGuardEfCoreOptions.ServiceCustomizations` + `UseDistributedLock<T>`
+
+**Files:**
+- Modify: `src/Moongazing.OrionGuard.EntityFrameworkCore/OrionGuardEfCoreOptions.cs`
+
+- [ ] **Step 1: Add the customization mechanism and helper**
+
+In `src/Moongazing.OrionGuard.EntityFrameworkCore/OrionGuardEfCoreOptions.cs`, add at the top:
+
+```csharp
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Locking;
+```
+
+Add inside `public sealed class OrionGuardEfCoreOptions`:
+
+```csharp
+    internal List<Action<IServiceCollection>> ServiceCustomizations { get; } = new();
+
+    /// <summary>
+    /// Replaces the registered <see cref="IDistributedLock"/> implementation. Default is
+    /// <see cref="SkipLockedDistributedLock"/>; alternatives include <see cref="NullDistributedLock"/>
+    /// or a custom (e.g. Redis) implementation.
+    /// </summary>
+    public OrionGuardEfCoreOptions UseDistributedLock<TLock>() where TLock : class, IDistributedLock
+    {
+        ServiceCustomizations.Add(services =>
+            services.Replace(ServiceDescriptor.Singleton<IDistributedLock, TLock>()));
+        return this;
+    }
+```
+
+- [ ] **Step 2: Build**
+
+```
+dotnet build src/Moongazing.OrionGuard.EntityFrameworkCore
+```
+
+Expected: success.
+
+- [ ] **Step 3: Commit**
+
+```
+git add src/Moongazing.OrionGuard.EntityFrameworkCore/OrionGuardEfCoreOptions.cs
+git commit -m "feat(efcore): OrionGuardEfCoreOptions.UseDistributedLock<T>
+
+Adds a deferred service-customization list and the lock-override helper."
+```
+
+---
+
+## Task 23: `OrionGuardEfCoreOptions.UseOutboxTypeMap` and `UseOutboxArchival`
+
+**Files:**
+- Modify: `src/Moongazing.OrionGuard.EntityFrameworkCore/OrionGuardEfCoreOptions.cs`
+
+- [ ] **Step 1: Add the two helpers**
+
+Add the following using:
+
+```csharp
+using Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Archival;
+using Moongazing.OrionGuard.EntityFrameworkCore.Outbox.TypeMap;
+```
+
+Add inside the class (after `UseDistributedLock`):
+
+```csharp
+    /// <summary>
+    /// Configures the outbox <see cref="OutboxTypeMapRegistry"/> so events can be persisted under
+    /// stable logical names instead of their assembly-qualified CLR names. Optional — without this
+    /// call the registry stays empty and the dispatcher falls back to AQN resolution.
+    /// </summary>
+    public OrionGuardEfCoreOptions UseOutboxTypeMap(
+        Action<OutboxTypeMapRegistry> configure,
+        Action<OutboxTypeMapOptions>? configureOptions = null)
+    {
+        ArgumentNullException.ThrowIfNull(configure);
+
+        var registry = new OutboxTypeMapRegistry();
+        configure(registry);
+
+        var options = new OutboxTypeMapOptions();
+        configureOptions?.Invoke(options);
+
+        ServiceCustomizations.Add(services =>
+        {
+            services.Replace(ServiceDescriptor.Singleton(registry));
+            services.Replace(ServiceDescriptor.Singleton(options));
+        });
+        return this;
+    }
+
+    /// <summary>
+    /// Enables the opt-in <see cref="OutboxArchivalHostedService"/>. Without this call no archival
+    /// hosted service is registered and processed outbox rows accumulate indefinitely.
+    /// </summary>
+    public OrionGuardEfCoreOptions UseOutboxArchival(Action<OutboxArchivalOptions>? configure = null)
+    {
+        var options = new OutboxArchivalOptions();
+        configure?.Invoke(options);
+
+        ServiceCustomizations.Add(services =>
+        {
+            services.Replace(ServiceDescriptor.Singleton(options));
+            services.AddHostedService<OutboxArchivalHostedService>();
+        });
+        return this;
+    }
+```
+
+- [ ] **Step 2: Build**
+
+```
+dotnet build src/Moongazing.OrionGuard.EntityFrameworkCore
+```
+
+Expected: success.
+
+- [ ] **Step 3: Commit**
+
+```
+git add src/Moongazing.OrionGuard.EntityFrameworkCore/OrionGuardEfCoreOptions.cs
+git commit -m "feat(efcore): OrionGuardEfCoreOptions.UseOutboxTypeMap and UseOutboxArchival
+
+Fluent opt-ins thread registry/options/hosted-service registration through
+the existing customization list."
+```
+
+---
+
+## Task 24: `AddOrionGuardEfCore` wires defaults and applies customizations
+
+**Files:**
+- Modify: `src/Moongazing.OrionGuard.EntityFrameworkCore/ServiceCollectionExtensions.cs`
+- Test: `tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/ServiceCollectionExtensions_v6_4_Tests.cs`
+
+- [ ] **Step 1: Write tests for DI wiring**
+
+Create `tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/ServiceCollectionExtensions_v6_4_Tests.cs`:
+
+```csharp
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Archival;
+using Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Locking;
+using Moongazing.OrionGuard.EntityFrameworkCore.Outbox.TypeMap;
+
+namespace Moongazing.OrionGuard.EntityFrameworkCore.Tests;
+
+public class ServiceCollectionExtensions_v6_4_Tests
+{
+    private sealed class TestDbContext(DbContextOptions<TestDbContext> options) : DbContext(options) { }
+
+    private static IServiceCollection Bootstrap(Action<OrionGuardEfCoreOptions>? configure = null)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddDbContext<TestDbContext>(o => o.UseSqlite("Filename=:memory:"));
+        services.AddOrionGuardEfCore<TestDbContext>(o =>
+        {
+            o.UseOutbox();
+            configure?.Invoke(o);
+        });
+        return services;
+    }
+
+    [Fact]
+    public void AddOrionGuardEfCore_ShouldRegister_SkipLockedDistributedLock_ByDefault_InOutboxMode()
+    {
+        using var sp = Bootstrap().BuildServiceProvider();
+        var @lock = sp.GetRequiredService<IDistributedLock>();
+        Assert.IsType<SkipLockedDistributedLock>(@lock);
+    }
+
+    [Fact]
+    public void AddOrionGuardEfCore_ShouldHonor_UseDistributedLock_Override()
+    {
+        using var sp = Bootstrap(o => o.UseDistributedLock<NullDistributedLock>()).BuildServiceProvider();
+        var @lock = sp.GetRequiredService<IDistributedLock>();
+        Assert.IsType<NullDistributedLock>(@lock);
+    }
+
+    [Fact]
+    public void AddOrionGuardEfCore_ShouldRegister_EmptyTypeMapRegistry_ByDefault_InOutboxMode()
+    {
+        using var sp = Bootstrap().BuildServiceProvider();
+        var registry = sp.GetRequiredService<OutboxTypeMapRegistry>();
+        Assert.NotNull(registry);
+        Assert.False(registry.TryResolve("anything", out _));
+    }
+
+    [Fact]
+    public void AddOrionGuardEfCore_ShouldRegister_DefaultTypeMapOptions_InOutboxMode()
+    {
+        using var sp = Bootstrap().BuildServiceProvider();
+        var options = sp.GetRequiredService<OutboxTypeMapOptions>();
+        Assert.True(options.AllowAssemblyQualifiedNameFallback);
+    }
+
+    [Fact]
+    public void AddOrionGuardEfCore_ShouldNotRegister_OutboxArchivalHostedService_Without_OptIn()
+    {
+        using var sp = Bootstrap().BuildServiceProvider();
+        var hosted = sp.GetServices<IHostedService>();
+        Assert.DoesNotContain(hosted, h => h is OutboxArchivalHostedService);
+    }
+
+    [Fact]
+    public void AddOrionGuardEfCore_ShouldRegister_OutboxArchivalHostedService_When_OptedIn()
+    {
+        using var sp = Bootstrap(o => o.UseOutboxArchival(a => a.RetentionPeriod = TimeSpan.FromDays(7))).BuildServiceProvider();
+        var hosted = sp.GetServices<IHostedService>();
+        Assert.Contains(hosted, h => h is OutboxArchivalHostedService);
+
+        var options = sp.GetRequiredService<OutboxArchivalOptions>();
+        Assert.Equal(TimeSpan.FromDays(7), options.RetentionPeriod);
+    }
+}
+```
+
+- [ ] **Step 2: Run, expect failures**
+
+```
+dotnet test tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests --filter "FullyQualifiedName~ServiceCollectionExtensions_v6_4_Tests"
+```
+
+Expected: most or all fail because `AddOrionGuardEfCore` does not yet apply customizations.
+
+- [ ] **Step 3: Apply customizations in `AddOrionGuardEfCore`**
+
+In `src/Moongazing.OrionGuard.EntityFrameworkCore/ServiceCollectionExtensions.cs`, ensure the using block includes:
+
+```csharp
+using Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Archival;
+using Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Locking;
+using Moongazing.OrionGuard.EntityFrameworkCore.Outbox.TypeMap;
+```
+
+Rewrite the body of `AddOrionGuardEfCore<TDbContext>` so the final shape is:
+
+```csharp
+    public static IServiceCollection AddOrionGuardEfCore<TDbContext>(
+        this IServiceCollection services,
+        Action<OrionGuardEfCoreOptions>? configure = null)
+        where TDbContext : DbContext
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        var options = new OrionGuardEfCoreOptions();
+        configure?.Invoke(options);
+        services.TryAddSingleton(options);
+        services.TryAddSingleton(options.Outbox);
+        services.TryAddScoped<DomainEventCollector>();
+        services.TryAddScoped<DbContext>(sp => sp.GetRequiredService<TDbContext>());
+
+        if (options.Strategy == DomainEventDispatchStrategy.Outbox)
+        {
+            services.TryAddSingleton<IDistributedLock, SkipLockedDistributedLock>();
+            services.TryAddSingleton(new OutboxTypeMapRegistry());
+            services.TryAddSingleton(new OutboxTypeMapOptions());
+
+            services.AddHostedService(sp => new OutboxDispatcherHostedService(
+                sp.GetRequiredService<OutboxOptions>(),
+                sp.GetRequiredService<IServiceScopeFactory>(),
+                sp.GetRequiredService<IDistributedLock>(),
+                sp.GetRequiredService<OutboxTypeMapRegistry>(),
+                sp.GetRequiredService<OutboxTypeMapOptions>(),
+                sp.GetService<ILogger<OutboxDispatcherHostedService>>()));
+        }
+
+        foreach (var customize in options.ServiceCustomizations)
+        {
+            customize(services);
+        }
+
+        return services;
+    }
+```
+
+- [ ] **Step 4: Run tests; expect 6 pass**
+
+```
+dotnet test tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests --filter "FullyQualifiedName~ServiceCollectionExtensions_v6_4_Tests"
+```
+
+Expected: 6 tests pass.
+
+- [ ] **Step 5: Run the full EF Core test project**
+
+```
+dotnet test tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests
+```
+
+Expected: full pass.
+
+- [ ] **Step 6: Commit**
+
+```
+git add src/Moongazing.OrionGuard.EntityFrameworkCore/ServiceCollectionExtensions.cs tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/ServiceCollectionExtensions_v6_4_Tests.cs
+git commit -m "feat(efcore): AddOrionGuardEfCore wires v6.4 defaults and applies customizations
+
+Outbox mode TryAdds IDistributedLock, OutboxTypeMapRegistry, OutboxTypeMapOptions.
+Customizations from UseDistributedLock / UseOutboxTypeMap / UseOutboxArchival apply last."
+```
+
+---
+
+## Task 25: Migration template `docs/migrations/v6.4.0-outbox-locks.md`
+
+**Files:**
+- Create: `docs/migrations/v6.4.0-outbox-locks.md`
+
+- [ ] **Step 1: Write the migration template**
+
+Create `docs/migrations/v6.4.0-outbox-locks.md`:
+
+````markdown
+# v6.4.0 Migration — OrionGuard_OutboxLocks
+
+This document provides EF Core migration snippets for the new `OrionGuard_OutboxLocks` table used by
+`SkipLockedDistributedLock`. Required only if you opt in to multi-instance outbox safety. Single-instance
+consumers who want v6.3 behaviour without applying this migration should call
+`opts.UseOutbox(...).UseDistributedLock<NullDistributedLock>()`.
+
+## Apply the EF Core configuration
+
+Inside your `DbContext.OnModelCreating`:
+
+```csharp
+modelBuilder.ApplyConfiguration(
+    new Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Locking.OutboxLockEntityTypeConfiguration());
+```
+
+## Generate the migration
+
+```bash
+dotnet ef migrations add Add_OrionGuard_OutboxLocks --context YourDbContext
+dotnet ef database update --context YourDbContext
+```
+
+## Reference DDL per provider
+
+Use these only if you bypass EF Core migrations (e.g., DBA-managed schemas).
+
+### PostgreSQL
+```sql
+CREATE TABLE "OrionGuard_OutboxLocks" (
+    "LockKey"        VARCHAR(200) PRIMARY KEY,
+    "HolderId"       UUID NULL,
+    "AcquiredOnUtc"  TIMESTAMP NOT NULL,
+    "ExpiresOnUtc"   TIMESTAMP NOT NULL
+);
+```
+
+### SQL Server
+```sql
+CREATE TABLE [OrionGuard_OutboxLocks] (
+    [LockKey]        NVARCHAR(200) NOT NULL PRIMARY KEY,
+    [HolderId]       UNIQUEIDENTIFIER NULL,
+    [AcquiredOnUtc]  DATETIME2 NOT NULL,
+    [ExpiresOnUtc]   DATETIME2 NOT NULL
+);
+```
+
+### MySQL / MariaDB
+```sql
+CREATE TABLE OrionGuard_OutboxLocks (
+    LockKey       VARCHAR(200) NOT NULL,
+    HolderId      CHAR(36) NULL,
+    AcquiredOnUtc DATETIME NOT NULL,
+    ExpiresOnUtc  DATETIME NOT NULL,
+    PRIMARY KEY (LockKey)
+);
+```
+
+### SQLite (test environments only)
+```sql
+CREATE TABLE OrionGuard_OutboxLocks (
+    LockKey       TEXT NOT NULL PRIMARY KEY,
+    HolderId      TEXT NULL,
+    AcquiredOnUtc TEXT NOT NULL,
+    ExpiresOnUtc  TEXT NOT NULL
+);
+```
+
+## Verification
+
+After applying, a successful boot logs:
+
+```
+OrionGuard outbox dispatcher started with distributed locking key 'orion_guard_outbox_dispatcher' (lease 00:00:30).
+```
+
+If the table is missing, the dispatcher logs a one-time warning and skips processing on every poll:
+
+```
+OrionGuard_OutboxLocks table not found. Distributed locking is disabled until the v6.4.0 migration is applied.
+```
+````
+
+- [ ] **Step 2: Commit**
+
+```
+git add docs/migrations/v6.4.0-outbox-locks.md
+git commit -m "docs(v6.4.0): migration template for OrionGuard_OutboxLocks (4 providers)"
+```
+
+---
+
+## Task 26: `CHANGELOG.md` — `[6.4.0]` section
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Insert the new section above `[6.3.0]`**
+
+Open `CHANGELOG.md`. Insert this block immediately under the existing intro paragraph (after the line about Keep a Changelog / Semantic Versioning and before the first existing `## [6.2.0]` or `## [6.3.0]` header — whichever is highest):
+
+```markdown
+## [6.4.0] - YYYY-MM-DD
+
+### Added
+
+#### Business Rule ergonomics (`Moongazing.OrionGuard`)
+- `BusinessRule` and `AsyncBusinessRule` abstract base classes implementing `IBusinessRule` / `IAsyncBusinessRule`. `MessageKey` defaults to the CLR type name.
+- `Guard.AgainstBrokenRule(IBusinessRule)` and `Guard.AgainstBrokenRuleAsync(IAsyncBusinessRule, CancellationToken)` static helpers. `Entity.CheckRule` / `CheckRuleAsync` now delegate to these helpers (behaviour unchanged).
+
+#### ASP.NET Core ProblemDetails (`Moongazing.OrionGuard.AspNetCore`)
+- `OrionGuardExceptionHandler` now produces a 422 `ValidationProblemDetails` for `BusinessRuleValidationException` (previously fell through to the framework default 500).
+- New `OrionGuardAspNetCoreOptions.BusinessRuleStatusCode` (default 422) for clients that require 400.
+- New `OrionGuardProblemDetailsFactory.Create(BusinessRuleValidationException)` overload — `errors` keyed by `RuleName`, `Type` = `https://moongazing.dev/orionguard/problems/business-rule-violation`.
+
+#### Outbox production-hardening (`Moongazing.OrionGuard.EntityFrameworkCore`)
+- `IDistributedLock` / `IDistributedLockHandle` abstractions. Default `SkipLockedDistributedLock` uses an `OutboxLock` row per key in `OrionGuard_OutboxLocks` (provider-agnostic via EF Core raw SQL). Multi-instance outbox workers no longer double-dispatch.
+- `NullDistributedLock` no-op implementation for single-instance consumers who do not want to apply the new migration. Wire with `opts.UseOutbox().UseDistributedLock<NullDistributedLock>()`.
+- `OutboxTypeMapRegistry` — opt-in logical-name → CLR type mapping. The `SaveChanges` interceptor prefers logical names when registered; the dispatcher resolves them on read. Falls back to AQN when no mapping exists (toggle via `OutboxTypeMapOptions.AllowAssemblyQualifiedNameFallback`).
+- `OutboxArchivalHostedService` — opt-in periodic deletion of processed outbox rows. Default 30-day retention, 1-hour polling, dead-letter rows preserved.
+- `OutboxOptions.LockKey` (default `"orion_guard_outbox_dispatcher"`) and `OutboxOptions.LockLeaseDuration` (default 30s).
+- `OrionGuardEfCoreOptions.UseDistributedLock<T>()`, `UseOutboxTypeMap(...)`, `UseOutboxArchival(...)`.
+
+### Changed
+- `Entity.CheckRule` / `Entity.CheckRuleAsync` internally delegate to `Guard.AgainstBrokenRule` / `Guard.AgainstBrokenRuleAsync`. Public behaviour unchanged.
+- `OutboxDispatcherHostedService` constructor expanded with `IDistributedLock`, `OutboxTypeMapRegistry`, and `OutboxTypeMapOptions` parameters. The DI factory in `AddOrionGuardEfCore` updates accordingly; consumers using only DI are unaffected.
+
+### Migration from v6.3.0
+
+- **No breaking source changes.**
+- **Distributed locking (recommended for multi-instance deployments):**
+  Add an EF Core migration that creates `OrionGuard_OutboxLocks` — see `docs/migrations/v6.4.0-outbox-locks.md`.
+  No code change needed when using `AddOrionGuardEfCore` — `SkipLockedDistributedLock` is wired automatically.
+- **Single-instance consumers who do NOT want to apply the migration:**
+  `opts.UseOutbox(...).UseDistributedLock<NullDistributedLock>()`.
+- **Type-safe outbox payloads (optional):**
+  `opts.UseOutbox(...).UseOutboxTypeMap(r => r.Map<UserRegistered>("user.registered"));`
+- **Outbox archival (optional):**
+  `opts.UseOutbox(...).UseOutboxArchival(a => a.RetentionPeriod = TimeSpan.FromDays(60));`
+- **`BusinessRule` base class (optional):** existing `IBusinessRule` implementations work unchanged.
+- **`Guard.AgainstBrokenRule` (additive):** `Guard.AgainstBrokenRule(new OrderMustHaveItems(order));`
+- **`BusinessRuleValidationException` → 422 ProblemDetails (automatic):** customize via `OrionGuardAspNetCoreOptions.BusinessRuleStatusCode`.
+
+### Roadmap
+
+- v6.5+: Redis / Consul `IDistributedLock` implementations as extension packages. Push-based outbox dispatch (`LISTEN/NOTIFY`, `SqlDependency`). Audit-trail copy-before-delete for archival.
+
+```
+
+Replace `YYYY-MM-DD` with the date at tag time.
+
+- [ ] **Step 2: Commit**
+
+```
+git add CHANGELOG.md
+git commit -m "docs(v6.4.0): CHANGELOG entry"
+```
+
+---
+
+## Task 27: Version bump to 6.4.0 across all `csproj` files
+
+**Files:**
+- Modify: every `src/*/Moongazing.OrionGuard*.csproj` containing `<Version>6.3.0</Version>`
+
+- [ ] **Step 1: Identify all files to update**
+
+```
+grep -l "<Version>6.3.0</Version>" src/**/*.csproj
+```
+
+Expected: 11 files (one per project under `src/`).
+
+- [ ] **Step 2: Bump each one**
+
+For each file in the list, change:
+
+```xml
+<Version>6.3.0</Version>
+```
+
+to:
+
+```xml
+<Version>6.4.0</Version>
+```
+
+Also update any `<VersionPrefix>6.3.0</VersionPrefix>` or `<AssemblyVersion>6.3.0</AssemblyVersion>` you may find with the same grep.
+
+- [ ] **Step 3: Build the whole solution**
+
+```
+dotnet build
+```
+
+Expected: success.
+
+- [ ] **Step 4: Run the full test suite**
+
+```
+dotnet test
+```
+
+Expected: 100% pass — every test project across the solution.
+
+- [ ] **Step 5: Update `OutboxActivitySource` version string in `OutboxDispatcherHostedService`**
+
+In `src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/OutboxDispatcherHostedService.cs`:
+
+```csharp
+    private static readonly ActivitySource OutboxActivitySource = new("Moongazing.OrionGuard.DomainEvents", "6.4.0");
+```
+
+(Was `"6.3.0"`.) Then build again to confirm no regression.
+
+```
+dotnet build
+```
+
+- [ ] **Step 6: Commit**
+
+```
+git add src/**/*.csproj src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/OutboxDispatcherHostedService.cs
+git commit -m "chore(release): bump all package versions to 6.4.0"
+```
+
+---
+
+## Final verification
+
+- [ ] **Run the full solution build and test**
+
+```
+dotnet build
+dotnet test
+```
+
+Both must succeed end-to-end.
+
+- [ ] **Inspect the diff against `master`**
+
+```
+git log --oneline master..HEAD
+git diff --stat master..HEAD
+```
+
+Expected commit topology (one commit per Task 1–27 above, in order). If any task was split or merged, that is fine as long as the file changes accumulate.
+
+- [ ] **Push the branch**
+
+```
+git push -u origin feature/v6.4.0
+```
+
+- [ ] **Open the umbrella PR**
+
+```
+gh pr create --base master --head feature/v6.4.0 --title "feat(v6.4.0): business rule helpers, outbox locking, type map, archival" --body "$(cat <<'EOF'
+## Summary
+
+Implements the v6.4.0 roadmap (see spec at \`docs/superpowers/specs/2026-05-19-orionguard-v6.4.0-design.md\`):
+
+- BusinessRule / AsyncBusinessRule abstract base classes
+- Guard.AgainstBrokenRule + Entity.CheckRule delegation
+- ProblemDetails mapping for BusinessRuleValidationException (422)
+- IDistributedLock abstraction + SkipLockedDistributedLock + NullDistributedLock
+- OutboxTypeMapRegistry with AQN fallback
+- OutboxArchivalHostedService (opt-in, retention-based)
+
+Source-compatible with v6.3.0. New optional migration: \`OrionGuard_OutboxLocks\`.
+
+## Test plan
+
+- [ ] dotnet build succeeds across net8/net9/net10
+- [ ] dotnet test green on all test projects
+- [ ] Two-instance manual smoke: confirm only one worker dispatches per polling cycle
+- [ ] Migration template applies cleanly on PG/MSSQL/MySQL/SQLite
+EOF
+)"
+```
+
+- [ ] **Tag and announce after merge**
+
+After merge to `master`:
+
+```
+git checkout master
+git pull
+git tag -a v6.4.0 -m "v6.4.0"
+git push origin v6.4.0
+```
+
+Update `CHANGELOG.md`'s `[6.4.0] - YYYY-MM-DD` with the actual tag date in a follow-up commit on `master`.
+
+---
+
+## Self-Review Summary
+
+| Spec section | Implemented by task |
+|---|---|
+| §3 BusinessRule base classes | Task 1 |
+| §4 Guard.AgainstBrokenRule + Entity delegation | Tasks 2, 3 |
+| §5 ProblemDetails for BusinessRuleValidationException | Tasks 4, 5, 6 |
+| §6 IDistributedLock abstraction | Tasks 7, 8, 9, 10, 11, 12, 13 |
+| §6.5 OutboxOptions additions | Task 14 |
+| §7 OutboxTypeMapRegistry | Tasks 15, 16, 19 |
+| §6.4 / §6.7 Dispatcher integration | Tasks 17, 18, 19 |
+| §8 OutboxArchivalHostedService | Tasks 20, 21 |
+| §6.7 / §7.6 / §8.4 DI fluent extensions | Tasks 22, 23, 24 |
+| §9.2 Migration template | Task 25 |
+| §9.2 / §13 CHANGELOG | Task 26 |
+| §10 Version bump + tag | Task 27 |
+
+All spec sections map to one or more tasks. No placeholders remain in any executable step (writer-side and integration-style test stubs in Tasks 16, 18, 19, 20 are explicitly flagged with "engineer note" instructions that point to existing patterns to mirror — they document a known scaffolding-dependent gap rather than a forgotten requirement).

--- a/docs/superpowers/plans/2026-05-21-stronglytypedid-deprecation.md
+++ b/docs/superpowers/plans/2026-05-21-stronglytypedid-deprecation.md
@@ -1,0 +1,420 @@
+# `[StronglyTypedId]` Soft-Deprecation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Soft-deprecate OrionGuard's `[StronglyTypedId<TValue>]` source generator in favour of the standalone OrionKey package — the injected attribute gets `[Obsolete]` (warning, not error), the generator keeps working, and consumers are pointed to OrionKey.
+
+**Architecture:** A focused, additive change on the `feature/v6.4.0` branch. The only behavioural change is adding `[System.Obsolete]` to the attribute text the generator injects via `RegisterPostInitializationOutput`. OrionGuard's own usages of the attribute (the demo) are wrapped in a scoped `#pragma warning disable CS0618`. No OrionKey dependency is added. No generator logic changes.
+
+**Tech Stack:** .NET 8/9/10, C#, Roslyn incremental source generator, xUnit.
+
+**Spec:** `docs/superpowers/specs/2026-05-21-stronglytypedid-deprecation-design.md`
+
+**Branch:** `feature/v6.4.0` (already checked out; the deprecation folds into the unshipped v6.4.0 release).
+
+---
+
+## Conventions
+
+- **No `Co-Authored-By` trailer in commit messages. No emojis.**
+- Commit after each task with the message in the task's final step.
+- OrionGuard builds with `TreatWarningsAsErrors=true` — every task must end with a warning-clean `dotnet build`.
+- Verification: `dotnet build Moongazing.OrionGuard.sln -c Release` and `dotnet test Moongazing.OrionGuard.sln -c Release` before each commit.
+
+## File Structure
+
+| Path | Change | Responsibility |
+|---|---|---|
+| `src/Moongazing.OrionGuard.Generators/StronglyTypedIds/StronglyTypedIdAttribute.cs` | Modify | Add `[Obsolete]` + revised XML summary to the injected attribute source text |
+| `demo/Moongazing.OrionGuard.Demo/Domain/Ids.cs` | Modify | Wrap the three `[StronglyTypedId]` struct declarations in `#pragma warning disable CS0618` |
+| `tests/Moongazing.OrionGuard.Generators.Tests/StronglyTypedIdDeprecationTests.cs` | Create | One test asserting a `[StronglyTypedId]` usage compiles to a CS0618 obsolete warning |
+| `CHANGELOG.md` | Modify | Add a `### Deprecated` subsection to the `[6.4.0]` entry |
+| `docs/migrations/stronglytypedid-to-orionkey.md` | Create | Migration guide from `[StronglyTypedId]` to OrionKey `[OrionId]` |
+| `README.md` | Modify | Annotate `[StronglyTypedId]` mentions with a deprecation note |
+
+## Background for the implementer
+
+- The generator project `Moongazing.OrionGuard.Generators` injects the `[StronglyTypedId]` attribute into every consuming compilation. The text lives in `StronglyTypedIdAttribute.cs` as a verbatim string `StronglyTypedIdAttributeSource.Source`. The injected type is `Moongazing.OrionGuard.Domain.Primitives.StronglyTypedIdAttribute<TValue>`, `internal sealed`.
+- The generator matches it via `ForAttributeWithMetadataName(StronglyTypedIdAttributeSource.FullName, ...)`. Adding `[Obsolete]` does not change the metadata name, so the generator keeps matching — no generator logic change is needed.
+- `[Obsolete("msg")]` without an `error: true` argument produces a CS0618 **warning** at every usage site. That is the soft-deprecation signal.
+- The generator unit tests (`StronglyTypedIdGenerator*.cs`) inspect `GeneratorDriverRunResult.Diagnostics` — the diagnostics the *generator* reports. CS0618 is a *compiler* diagnostic and never appears there, so those tests are unaffected and need no change.
+- The demo project compiles with the generator active; its `[StronglyTypedId]` usages WILL raise CS0618 and, under `TreatWarningsAsErrors`, break the build unless suppressed.
+
+---
+
+## Task 1: Add `[Obsolete]` to the injected attribute
+
+**Files:**
+- Modify: `src/Moongazing.OrionGuard.Generators/StronglyTypedIds/StronglyTypedIdAttribute.cs`
+
+- [ ] **Step 1: Read the current file**
+
+Run: `sed -n '1,40p' src/Moongazing.OrionGuard.Generators/StronglyTypedIds/StronglyTypedIdAttribute.cs`
+
+The file declares `StronglyTypedIdAttributeSource` with a `FullName` const and a `Source` verbatim-string const. The `Source` string contains, near its end:
+
+```csharp
+    /// <summary>
+    /// Marks a readonly partial struct as a strongly-typed id backed by the specified primitive type.
+    /// The OrionGuard source generator emits equality, comparison, conversion members, as well as
+    /// EF Core ValueConverter, System.Text.Json converter, and TypeConverter companion types.
+    /// </summary>
+    /// <typeparam name=""TValue"">Underlying primitive type. Supported: System.Guid, int, long,
+    /// string, System.Ulid (net9.0+).</typeparam>
+    [System.AttributeUsage(System.AttributeTargets.Struct, Inherited = false, AllowMultiple = false)]
+    internal sealed class StronglyTypedIdAttribute<TValue> : System.Attribute { }
+```
+
+(The exact wording of the summary may differ slightly — match what is actually there.)
+
+- [ ] **Step 2: Replace the attribute declaration block inside the `Source` string**
+
+Replace the `<summary>` / `<typeparam>` / `[AttributeUsage]` / class-declaration block shown above with this block. Note this text sits inside a C# verbatim string (`@"..."`), so any literal double-quote must be doubled (`""`). The `[Obsolete]` message below contains **no** double-quotes, so it needs no escaping; apostrophes are literal.
+
+```csharp
+    /// <summary>
+    /// Marks a readonly partial struct as a strongly-typed id backed by the specified primitive type.
+    /// </summary>
+    /// <remarks>
+    /// DEPRECATED. This generator is superseded by the standalone OrionKey package. Install
+    /// the OrionKey NuGet package and use [OrionId&lt;TValue&gt;] or [OrionId&lt;TValue, TStrategy&gt;]
+    /// instead. The OrionGuard generator still works but will be removed in v7.0.0.
+    /// See https://www.nuget.org/packages/OrionKey.
+    /// </remarks>
+    /// <typeparam name=""TValue"">Underlying primitive type. Supported: System.Guid, int, long,
+    /// string, System.Ulid (net9.0+).</typeparam>
+    [System.Obsolete(""OrionGuard's [StronglyTypedId] is superseded by the standalone OrionKey package. Install OrionKey and use [OrionId<TValue>] or [OrionId<TValue, TStrategy>] instead - see https://www.nuget.org/packages/OrionKey. OrionGuard's generator will be removed in v7.0.0."")]
+    [System.AttributeUsage(System.AttributeTargets.Struct, Inherited = false, AllowMultiple = false)]
+    internal sealed class StronglyTypedIdAttribute<TValue> : System.Attribute { }
+```
+
+Key points:
+- The `[System.Obsolete(...)]` line uses doubled double-quotes `""` because the whole thing is inside a verbatim string. The message itself contains no double-quotes.
+- `[Obsolete]` has no `error: true` second argument — it is a warning, not an error.
+- The `<remarks>` uses `&lt;` / `&gt;` for the angle brackets because they would otherwise be invalid XML inside the doc comment.
+
+- [ ] **Step 3: Build the generator project**
+
+Run: `dotnet build src/Moongazing.OrionGuard.Generators -c Release`
+Expected: success, 0 warnings. (The generator project itself has no `[StronglyTypedId]` usage, so it stays clean.)
+
+- [ ] **Step 4: Verify the generator still emits — build the core test project's dependency chain**
+
+Run: `dotnet build src/Moongazing.OrionGuard.Generators -c Release` then confirm the `Source` const compiles by building a project that consumes the generator. Defer the full-solution build to Task 2 (the demo will fail until Task 2 suppresses CS0618 — that is expected and is Task 2's job).
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/Moongazing.OrionGuard.Generators/StronglyTypedIds/StronglyTypedIdAttribute.cs
+git commit -m "feat(generators): mark [StronglyTypedId] attribute obsolete in favour of OrionKey
+
+The injected StronglyTypedIdAttribute<TValue> now carries [Obsolete] (a
+warning, not an error). Consumer usages raise CS0618 with migration guidance
+pointing to the standalone OrionKey package. The generator is unchanged and
+still emits every companion; it will be removed in v7.0.0."
+```
+
+---
+
+## Task 2: Suppress CS0618 at OrionGuard's own `[StronglyTypedId]` usages
+
+**Files:**
+- Modify: `demo/Moongazing.OrionGuard.Demo/Domain/Ids.cs`
+- Modify: any other file the full-solution build flags with CS0618 (see Step 2)
+
+- [ ] **Step 1: Wrap the demo's generator-style declarations**
+
+In `demo/Moongazing.OrionGuard.Demo/Domain/Ids.cs`, the "Style 1" section declares three structs with the now-obsolete attribute: `ProductId` (`[StronglyTypedId<Guid>]`), `SkuId` (`[StronglyTypedId<int>]`), `CountryCode` (`[StronglyTypedId<string>]`). The "Style 2" section uses the manual `StronglyTypedId<TValue>` record and is **not** affected.
+
+Wrap only the Style-1 block. Place `#pragma warning disable CS0618` immediately before the first `[StronglyTypedId]` declaration and `#pragma warning restore CS0618` immediately after the last one, with an explanatory comment:
+
+```csharp
+// OrionGuard's [StronglyTypedId] is obsolete (superseded by OrionKey). The demo
+// keeps exercising it because OrionGuard still ships and supports the generator
+// through v6.x. Suppression is intentional and scoped to these declarations.
+#pragma warning disable CS0618
+[StronglyTypedId<Guid>]
+public readonly partial struct ProductId;
+
+[StronglyTypedId<int>]
+public readonly partial struct SkuId;
+
+[StronglyTypedId<string>]
+public readonly partial struct CountryCode;
+#pragma warning restore CS0618
+```
+
+Leave the Style-2 manual records (`OrderId`, `CustomerId`, `InvoiceId`) and all comments untouched.
+
+- [ ] **Step 2: Build the whole solution and collect every remaining CS0618**
+
+Run: `dotnet build Moongazing.OrionGuard.sln -c Release 2>&1 | grep -i "CS0618"`
+
+Expected: ideally empty after Step 1. If any other file reports CS0618 (a core project, another test project, or a sample), it means OrionGuard has another in-repo `[StronglyTypedId]` usage. For each such file, wrap the offending declaration(s) in the same scoped `#pragma warning disable CS0618` / `restore CS0618` pair with a one-line comment explaining the suppression is deliberate. Do **not** disable the warning globally or in a csproj — keep each suppression local and commented.
+
+The generator unit-test source files (`tests/Moongazing.OrionGuard.Generators.Tests/StronglyTypedIdGenerator*.cs`) contain `[StronglyTypedId]` only inside string literals fed to the generator harness — those are not attribute applications in the test assembly and produce no CS0618. If the build proves otherwise, treat them like any other site.
+
+- [ ] **Step 3: Full solution build — must be warning-clean**
+
+Run: `dotnet build Moongazing.OrionGuard.sln -c Release`
+Expected: Build succeeded, 0 warnings, 0 errors.
+
+- [ ] **Step 4: Full solution test**
+
+Run: `dotnet test Moongazing.OrionGuard.sln -c Release`
+Expected: all tests green — the generator behaviour is unchanged.
+
+- [ ] **Step 5: Run the demo**
+
+Run: `dotnet run --project demo/Moongazing.OrionGuard.Demo -c Release`
+Expected: the demo runs and prints its strongly-typed-id section without error.
+
+- [ ] **Step 6: Commit**
+
+```
+git add demo/Moongazing.OrionGuard.Demo/Domain/Ids.cs
+git commit -m "chore(demo): scope-suppress CS0618 for the demo's [StronglyTypedId] usages
+
+The demo still exercises the obsolete generator because OrionGuard supports it
+through v6.x. Suppression is local to the three Style-1 declarations."
+```
+
+(If Step 2 found additional files, `git add` them in this commit too and mention them in the commit body.)
+
+---
+
+## Task 3: Add a deprecation test
+
+**Files:**
+- Create: `tests/Moongazing.OrionGuard.Generators.Tests/StronglyTypedIdDeprecationTests.cs`
+
+This test locks in the deprecation: it compiles a `[StronglyTypedId]` usage and asserts the compiler reports CS0618. If a future edit removes `[Obsolete]`, this test fails.
+
+- [ ] **Step 1: Inspect the existing generator-test harness**
+
+Run: `sed -n '1,55p' tests/Moongazing.OrionGuard.Generators.Tests/StronglyTypedIdGeneratorTests.cs`
+
+Note how it builds a `CSharpCompilation` (the `RunGenerator` helper assembles `MetadataReference`s from loaded assemblies, parses the source, creates the compilation, and runs the generator driver). The new test reuses the same compilation-building approach but additionally inspects the **post-generation compilation's** diagnostics for CS0618.
+
+- [ ] **Step 2: Write the test**
+
+Create `tests/Moongazing.OrionGuard.Generators.Tests/StronglyTypedIdDeprecationTests.cs`:
+
+```csharp
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Moongazing.OrionGuard.Generators;
+using Xunit;
+
+namespace Moongazing.OrionGuard.Generators.Tests;
+
+public class StronglyTypedIdDeprecationTests
+{
+    [Fact]
+    public void StronglyTypedIdAttribute_ShouldRaiseCS0618_WhenApplied()
+    {
+        const string source = """
+            using Moongazing.OrionGuard.Domain.Primitives;
+
+            namespace App
+            {
+                [StronglyTypedId<System.Guid>]
+                public readonly partial struct OrderId { }
+            }
+            """;
+
+        var syntaxTree = CSharpSyntaxTree.ParseText(source);
+
+        var references = System.AppDomain.CurrentDomain.GetAssemblies()
+            .Where(a => !a.IsDynamic && !string.IsNullOrEmpty(a.Location))
+            .Select(a => (MetadataReference)MetadataReference.CreateFromFile(a.Location))
+            .ToList();
+
+        var compilation = CSharpCompilation.Create(
+            "DeprecationTestAssembly",
+            new[] { syntaxTree },
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        var driver = CSharpGeneratorDriver
+            .Create(new StronglyTypedIdGenerator())
+            .RunGeneratorsAndUpdateCompilation(compilation, out var updatedCompilation, out _);
+
+        var cs0618 = updatedCompilation.GetDiagnostics()
+            .Where(d => d.Id == "CS0618")
+            .ToArray();
+
+        Assert.NotEmpty(cs0618);
+        Assert.Contains(cs0618, d => d.GetMessage().Contains("OrionKey"));
+    }
+}
+```
+
+Notes:
+- `RunGeneratorsAndUpdateCompilation` produces `updatedCompilation` — the compilation *with* the generator's injected attribute and emitted companions. `GetDiagnostics()` on it includes the compiler's CS0618 for the obsolete-attribute usage.
+- The test asserts both that CS0618 fires and that its message mentions OrionKey, so it cannot pass against a generic unrelated obsolete warning.
+- If the existing tests reference `StronglyTypedIdGenerator` under a different namespace or the harness uses a different generator type name, match it — adjust the `using` and `new StronglyTypedIdGenerator()` accordingly. Verify against Step 1's reading of the existing test file.
+
+- [ ] **Step 3: Run the test**
+
+Run: `dotnet test tests/Moongazing.OrionGuard.Generators.Tests --filter StronglyTypedIdDeprecationTests`
+Expected: 1 test passes.
+
+- [ ] **Step 4: Full generator-test project run**
+
+Run: `dotnet test tests/Moongazing.OrionGuard.Generators.Tests`
+Expected: all generator tests pass (the existing ones plus the new one).
+
+- [ ] **Step 5: Commit**
+
+```
+git add tests/Moongazing.OrionGuard.Generators.Tests/StronglyTypedIdDeprecationTests.cs
+git commit -m "test(generators): assert [StronglyTypedId] usage raises CS0618
+
+Locks in the OrionKey deprecation — fails if [Obsolete] is ever removed
+from the injected attribute."
+```
+
+---
+
+## Task 4: CHANGELOG and migration guide
+
+**Files:**
+- Modify: `CHANGELOG.md`
+- Create: `docs/migrations/stronglytypedid-to-orionkey.md`
+
+- [ ] **Step 1: Add a `### Deprecated` subsection to the `[6.4.0]` CHANGELOG entry**
+
+Open `CHANGELOG.md`. Find the `## [6.4.0]` section. It already has `### Added` / `### Changed` / `### Migration from v6.3.0` subsections. Add a `### Deprecated` subsection immediately after `### Changed` (Keep-a-Changelog orders sections Added / Changed / Deprecated / Removed / Fixed / Security):
+
+```markdown
+### Deprecated
+
+- The `[StronglyTypedId<TValue>]` source generator is soft-deprecated in favour of the standalone **OrionKey** package (`[OrionId<TValue>]` / `[OrionId<TValue, TStrategy>]`). Existing usages keep compiling and the generator keeps emitting; each `[StronglyTypedId]` usage now raises a CS0618 warning with migration guidance. The generator will be removed in v7.0.0. The manual `StronglyTypedId<TValue>` record, `IStronglyTypedId<TValue>`, and the related guards are unaffected. See `docs/migrations/stronglytypedid-to-orionkey.md`.
+```
+
+- [ ] **Step 2: Create the migration guide**
+
+Create `docs/migrations/stronglytypedid-to-orionkey.md`:
+
+```markdown
+# Migrating from OrionGuard `[StronglyTypedId]` to OrionKey
+
+OrionGuard's `[StronglyTypedId<TValue>]` source generator is soft-deprecated as of
+v6.4.0. The feature now lives in the standalone **OrionKey** package and will be
+removed from OrionGuard in v7.0.0. The generator still works in the v6.x line —
+this migration is not urgent, but new code should use OrionKey.
+
+This applies only to the **source generator** (`[StronglyTypedId]` on a `readonly
+partial struct`). The manual `StronglyTypedId<TValue>` abstract record,
+`IStronglyTypedId<TValue>`, and the `AgainstDefaultStronglyTypedId` guard are not
+deprecated and have no OrionKey equivalent — keep using them as-is.
+
+## Steps
+
+1. Install OrionKey:
+
+   ```bash
+   dotnet add package OrionKey
+   ```
+
+2. Swap the attribute and the `using`:
+
+   | OrionGuard | OrionKey |
+   |---|---|
+   | `using Moongazing.OrionGuard.Domain.Primitives;` | `using Moongazing.OrionKey;` |
+   | `[StronglyTypedId<Guid>]` | `[OrionId<Guid>]` |
+   | `[StronglyTypedId<int>]` | `[OrionId<int>]` (externally assigned) |
+   | `[StronglyTypedId<long>]` | `[OrionId<long>]` (externally assigned) or `[OrionId<long, Snowflake>]` (generated) |
+   | `[StronglyTypedId<string>]` | `[OrionId<string, Ulid>]` or `[OrionId<string, NanoId>]` |
+
+3. The struct stays a `readonly partial struct` — no other change to your type.
+
+## What you get
+
+The emitted surface is equivalent: `Value`, a constructor, `Empty`, `New()` where
+applicable, `IEquatable`, equality operators, an EF Core `ValueConverter` (emitted
+when the project references EF Core), a `System.Text.Json` converter, a
+`TypeConverter`, and `IParsable`/`ISpanParsable`.
+
+OrionKey additionally provides:
+
+- `IComparable` and ordering operators for sortable strategies (`Snowflake`,
+  `Ulid`, `GuidV7`).
+- Explicit ID strategies: `Snowflake` (64-bit, sortable), `Ulid`, `NanoId`,
+  `GuidV7`.
+- `OrionKey.Testing` — deterministic ID generators for tests.
+
+See the OrionKey README at https://github.com/tunahanaliozturk/OrionKey.
+```
+
+- [ ] **Step 3: Verify the docs build (no build step needed — Markdown only) and commit**
+
+```
+git add CHANGELOG.md docs/migrations/stronglytypedid-to-orionkey.md
+git commit -m "docs(v6.4.0): changelog Deprecated entry and OrionKey migration guide"
+```
+
+---
+
+## Task 5: Annotate `[StronglyTypedId]` mentions in the README
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Find every `[StronglyTypedId]` / strongly-typed-id mention in the README**
+
+Run: `grep -n -i "stronglytypedid\|strongly-typed" README.md`
+
+- [ ] **Step 2: Add a deprecation note**
+
+For each section or table row that documents the `[StronglyTypedId]` **generator** (not the manual record), add a concise inline note. Do not delete the examples — the generator still works. A blockquote near the first mention is enough; individual table rows can get a trailing `(deprecated — see OrionKey)`:
+
+```markdown
+> **Deprecated in v6.4.0.** The `[StronglyTypedId]` source generator is superseded by the standalone [OrionKey](https://github.com/tunahanaliozturk/OrionKey) package (`[OrionId]`). It still works through the v6.x line and is removed in v7.0.0. See [the migration guide](docs/migrations/stronglytypedid-to-orionkey.md). The manual `StronglyTypedId<TValue>` record is not affected.
+```
+
+Place the blockquote at the strongly-typed-id section. If the README only mentions it in a feature table, add the note as a footnote under the table. Keep it factual and short — no emojis.
+
+- [ ] **Step 3: Build and test the solution one final time**
+
+Run: `dotnet build Moongazing.OrionGuard.sln -c Release` then `dotnet test Moongazing.OrionGuard.sln -c Release`
+Expected: build warning-clean, all tests green.
+
+- [ ] **Step 4: Commit**
+
+```
+git add README.md
+git commit -m "docs(readme): note [StronglyTypedId] deprecation and point to OrionKey"
+```
+
+---
+
+## Final verification
+
+- [ ] `dotnet build Moongazing.OrionGuard.sln -c Release` — 0 warnings, 0 errors.
+- [ ] `dotnet test Moongazing.OrionGuard.sln -c Release` — all green, including the new `StronglyTypedIdDeprecationTests`.
+- [ ] `dotnet run --project demo/Moongazing.OrionGuard.Demo -c Release` — runs and prints the strongly-typed-id section.
+- [ ] `git log --oneline` — five task commits on `feature/v6.4.0`.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+| Spec section | Task |
+|---|---|
+| §3.1 `[Obsolete]` on injected attribute + XML doc | Task 1 |
+| §3.2 suppress OrionGuard's own usages | Task 2 |
+| §3.3 CHANGELOG `### Deprecated` | Task 4 |
+| §3.4 README + docs annotation | Task 4 (migration guide), Task 5 (README) |
+| §4 migration guidance | Task 4 (`docs/migrations/stronglytypedid-to-orionkey.md`) |
+| §5 testing — deprecation test + green build/test/demo | Task 3 (test), Tasks 2 & 5 (build/test/demo verification) |
+
+Every spec section maps to a task. §3.2's "investigate generator tests" concern is resolved in the background notes (CS0618 is a compiler diagnostic; `GeneratorDriverRunResult.Diagnostics` only carries generator-reported diagnostics) and Task 2 Step 2 still does the empirical full-build sweep as a safety net.
+
+**Placeholder scan:** No `TBD`/`TODO`. Task 2 Step 2 is an empirical "build and collect" step with a concrete fallback action, not a placeholder. Task 5 Step 1/2 depend on the README's actual content, which the engineer greps for — the action (add the given blockquote) is fully specified.
+
+**Type consistency:** The injected attribute name `StronglyTypedIdAttribute<TValue>`, the generator type `StronglyTypedIdGenerator`, the diagnostic id `CS0618`, and the `[OrionId]` target names are used consistently across all tasks.

--- a/docs/superpowers/specs/2026-05-19-orionguard-v6.4.0-design.md
+++ b/docs/superpowers/specs/2026-05-19-orionguard-v6.4.0-design.md
@@ -1,0 +1,740 @@
+# OrionGuard v6.4.0 — Business Rule helpers, Outbox distributed locking, type map & archival
+
+**Date:** 2026-05-19
+**Status:** Approved (design); pending implementation plan
+**Branch:** `feature/v6.4.0`
+**Predecessor:** v6.3.0 (`IDomainEventDispatcher`, MediatR bridge, transactional outbox single-instance)
+
+## 1. Goal
+
+Ship the five features promised in the v6.3.0 → v6.4.0 roadmap as a single source-compatible minor release:
+
+**Business Rule ergonomics (carried over from the original v6.3.0 plan):**
+1. `BusinessRule` / `AsyncBusinessRule` abstract base classes for `IBusinessRule` / `IAsyncBusinessRule`.
+2. `Guard.AgainstBrokenRule(rule)` / `Guard.AgainstBrokenRuleAsync(rule, ct)` helpers.
+3. ASP.NET Core ProblemDetails mapping for `BusinessRuleValidationException` (currently produces a generic 500 because the exception handler does not match it).
+
+**Outbox production-hardening:**
+4. Pluggable `IDistributedLock` abstraction with a default DB-backed implementation so multi-instance outbox workers stop double-dispatching events.
+5. `OutboxTypeMapRegistry` — opt-in logical-name → CLR-type mapping so outbox payloads survive type renames and AOT consumers can avoid `Type.GetType` reflection. Archival hosted service for retention-based cleanup of processed rows.
+
+**Non-goals (deferred):**
+- Redis/Consul `IDistributedLock` implementations — `Moongazing.OrionGuard.Redis` would be a v6.5+ extension package; no concrete consumer demand today.
+- Push-based outbox dispatch (`LISTEN/NOTIFY`, `SqlDependency`) — v6.5+.
+- Event sourcing primitives — v6.5+.
+- Archival → audit-trail table (copy-before-delete) — v6.5+.
+
+## 2. Package layout
+
+| # | Feature | Package | New files | Modified files |
+|---|---|---|---|---|
+| 1 | `BusinessRule` / `AsyncBusinessRule` | `OrionGuard` (core) | `Domain/Rules/BusinessRule.cs`, `Domain/Rules/AsyncBusinessRule.cs` | — |
+| 2 | `Guard.AgainstBrokenRule` | `OrionGuard` (core) | — | `Core/Guard.cs`, `Domain/Primitives/Entity.cs` (delegation) |
+| 3 | ProblemDetails for `BusinessRuleValidationException` | `OrionGuard.AspNetCore` | — | `ExceptionHandling/OrionGuardExceptionHandler.cs`, `ProblemDetails/OrionGuardProblemDetailsFactory.cs`, `Options/OrionGuardAspNetCoreOptions.cs` |
+| 4 | `IDistributedLock` abstraction + DB impl + null impl | `OrionGuard.EntityFrameworkCore` | `Outbox/Locking/IDistributedLock.cs`, `Outbox/Locking/IDistributedLockHandle.cs`, `Outbox/Locking/SkipLockedDistributedLock.cs`, `Outbox/Locking/NullDistributedLock.cs`, `Outbox/Locking/OutboxLock.cs`, `Outbox/Locking/OutboxLockEntityTypeConfiguration.cs` | `Outbox/OutboxDispatcherHostedService.cs`, `Outbox/OutboxOptions.cs`, `OrionGuardEfCoreOptions.cs`, `ServiceCollectionExtensions.cs` |
+| 5 | `OutboxTypeMapRegistry` | `OrionGuard.EntityFrameworkCore` | `Outbox/TypeMap/OutboxTypeMapRegistry.cs`, `Outbox/TypeMap/OutboxTypeMapOptions.cs` | `Outbox/OutboxDispatcherHostedService.cs`, outbox writer code path |
+| 6 | Archival hosted service | `OrionGuard.EntityFrameworkCore` | `Outbox/Archival/OutboxArchivalHostedService.cs`, `Outbox/Archival/OutboxArchivalOptions.cs` | DI helpers |
+
+**No new NuGet packages.** Pluggable `IDistributedLock` lives next to the default implementation in `OrionGuard.EntityFrameworkCore`. A future `OrionGuard.Redis` extension package can take a dependency on `OrionGuard.EntityFrameworkCore` solely for the interface; the abstraction does not require a separate carrier package today. (YAGNI — extract later when concrete demand arrives.)
+
+## 3. Business Rule base classes (`OrionGuard`)
+
+### 3.1 New types
+
+```csharp
+namespace Moongazing.OrionGuard.Domain.Rules;
+
+public abstract class BusinessRule : IBusinessRule
+{
+    public abstract bool IsBroken();
+    public abstract string DefaultMessage { get; }
+    public virtual string MessageKey => GetType().Name;
+    public virtual object[]? MessageArgs => null;
+}
+
+public abstract class AsyncBusinessRule : IAsyncBusinessRule
+{
+    public abstract Task<bool> IsBrokenAsync(CancellationToken cancellationToken = default);
+    public abstract string DefaultMessage { get; }
+    public virtual string MessageKey => GetType().Name;
+    public virtual object[]? MessageArgs => null;
+}
+```
+
+### 3.2 Why default `MessageKey => GetType().Name`
+
+The existing `BusinessRuleValidationException` resolves messages through `ValidationMessages.Get(key)` and falls back to `DefaultMessage` when no translation is registered. Defaulting `MessageKey` to the CLR type name (e.g., `"OrderMustHaveItems"`) gives consumers a least-surprise binding between rule class and resource key. Consumers who prefer snake_case or domain-prefixed keys override the property.
+
+### 3.3 `IsBroken` and `DefaultMessage` are abstract
+
+`IsBroken` is the entire contract — leaving it abstract is non-negotiable.
+`DefaultMessage` is abstract (not virtual with a generic fallback) so consumers cannot accidentally ship a rule with no human-readable description when no resource translation exists.
+
+### 3.4 Existing `IBusinessRule` consumers are unaffected
+
+`BusinessRule` is additive — it implements `IBusinessRule`. Existing interface implementations continue to satisfy `Entity.CheckRule`, `Guard.AgainstBrokenRule`, and `BusinessRuleValidationException` without changes.
+
+## 4. `Guard.AgainstBrokenRule` helpers (`OrionGuard`)
+
+### 4.1 New surface
+
+```csharp
+public static partial class Guard
+{
+    public static void AgainstBrokenRule(IBusinessRule rule)
+    {
+        ArgumentNullException.ThrowIfNull(rule);
+        if (rule.IsBroken())
+        {
+            throw new BusinessRuleValidationException(rule);
+        }
+    }
+
+    public static async Task AgainstBrokenRuleAsync(
+        IAsyncBusinessRule rule,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(rule);
+        if (await rule.IsBrokenAsync(cancellationToken).ConfigureAwait(false))
+        {
+            throw new BusinessRuleValidationException(rule);
+        }
+    }
+}
+```
+
+### 4.2 Naming follows the existing Guard surface
+
+The current Guard surface uses `Guard.AgainstNull`, `Guard.AgainstNullOrEmpty` (static), and value extensions for primitives (`value.AgainstNegative`). A rule is self-contained — not "applied to a value" — so `Guard.AgainstBrokenRule(rule)` is a static call, matching `AgainstNull`. The roadmap entry "`Guard.Against.BrokenRule`" is interpreted as a naming pattern rather than a literal C# chain. Adopting the Ardalis.GuardClauses-style `Guard.Against.X` chain would require redesigning the entire Guard surface and would be a v7.0.0 break.
+
+### 4.3 `Entity.CheckRule` delegates to `Guard.AgainstBrokenRule`
+
+`Entity.CheckRule` and `Entity.CheckRuleAsync` currently contain the same null check + IsBroken check + throw logic. v6.4.0 rewrites them as one-line delegations to the new Guard helpers. Single source of truth; future telemetry/decorator hooks land in one place. Public behaviour is identical; existing tests continue to pass.
+
+## 5. ProblemDetails for `BusinessRuleValidationException` (`OrionGuard.AspNetCore`)
+
+### 5.1 The current gap
+
+`OrionGuardExceptionHandler.TryHandleAsync` matches `AggregateValidationException` and `GuardException` and returns `true` for both. `BusinessRuleValidationException` does not match either branch, so it falls through to the ASP.NET Core default handler — typically a `500 Internal Server Error` ProblemDetails with no rule context.
+
+### 5.2 Handler change
+
+Add a third branch between the aggregate and the guard branches:
+
+```csharp
+if (exception is BusinessRuleValidationException ruleException)
+{
+    _logger.LogWarning(
+        ruleException,
+        "Business rule '{RuleName}' violated: {Message}",
+        ruleException.RuleName,
+        ruleException.Message);
+
+    var statusCode = _options.BusinessRuleStatusCode;
+
+    if (_options.UseProblemDetails)
+    {
+        var problemDetails = OrionGuardProblemDetailsFactory.Create(ruleException);
+        problemDetails.Status = statusCode;
+        httpContext.Response.StatusCode = statusCode;
+        httpContext.Response.ContentType = MediaTypeNames.Application.Json;
+        await httpContext.Response.WriteAsJsonAsync(
+            problemDetails, SerializerOptions, cancellationToken).ConfigureAwait(false);
+    }
+    else
+    {
+        httpContext.Response.StatusCode = statusCode;
+        httpContext.Response.ContentType = MediaTypeNames.Application.Json;
+        await httpContext.Response.WriteAsJsonAsync(
+            new { ruleName = ruleException.RuleName, message = ruleException.Message },
+            SerializerOptions, cancellationToken).ConfigureAwait(false);
+    }
+
+    return true;
+}
+```
+
+Branch order in the handler:
+1. `AggregateValidationException` (most specific — aggregate of multiple validation errors).
+2. `BusinessRuleValidationException` (**new**).
+3. `GuardException` (broadest single-parameter failure).
+
+The three exception hierarchies are disjoint, so order is not behaviourally significant; this order reads as validation → rule → guard, which mirrors call depth.
+
+### 5.3 Factory addition
+
+```csharp
+public static ValidationProblemDetails Create(BusinessRuleValidationException exception)
+{
+    var errors = new Dictionary<string, string[]>
+    {
+        [exception.RuleName] = [exception.Message],
+    };
+
+    return new ValidationProblemDetails(errors)
+    {
+        Type = "https://moongazing.dev/orionguard/problems/business-rule-violation",
+        Title = "Business Rule Violation",
+        Status = StatusCodes.Status422UnprocessableEntity,
+    };
+}
+```
+
+### 5.4 Options
+
+```csharp
+public sealed class OrionGuardAspNetCoreOptions
+{
+    // ...existing properties
+
+    /// <summary>
+    /// HTTP status code returned for <see cref="BusinessRuleValidationException"/>.
+    /// Default 422 Unprocessable Entity (RFC 9457). Override to 400 for clients that require it.
+    /// </summary>
+    public int BusinessRuleStatusCode { get; set; } = StatusCodes.Status422UnprocessableEntity;
+}
+```
+
+### 5.5 Why 422 by default
+
+Request bodies and bindings are syntactically valid by the time a domain rule fires — the failure is semantic. RFC 9457 / REST consensus map this to `422 Unprocessable Entity`. `400 Bad Request` is reserved for syntactic/parsing failures (which is where `GuardException` already lands, 400).
+
+### 5.6 Why a custom `Type` URL
+
+The default `https://tools.ietf.org/html/rfc9457` URL applies to *any* ProblemDetails. Clients that key off `Type` to switch error-handling strategies can use `https://moongazing.dev/orionguard/problems/business-rule-violation` to distinguish business-rule violations from other validation failures without inspecting the body. The URL does not need to resolve; a follow-up `docs/problems/business-rule-violation.md` page is recommended but out of scope for this release.
+
+## 6. `IDistributedLock` abstraction + DB implementation (`OrionGuard.EntityFrameworkCore`)
+
+### 6.1 The current race
+
+`OutboxDispatcherHostedService.ProcessBatchAsync` issues an unguarded `WHERE ProcessedOnUtc IS NULL ORDER BY OccurredOnUtc LIMIT N`. Two workers on the same database get the same N rows and double-dispatch every event. The class-level XML comment and the startup warning currently acknowledge this with "distributed locking lands in v6.4."
+
+### 6.2 Abstraction
+
+```csharp
+namespace Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Locking;
+
+public interface IDistributedLock
+{
+    Task<IDistributedLockHandle?> TryAcquireAsync(
+        string lockKey,
+        TimeSpan leaseDuration,
+        CancellationToken cancellationToken = default);
+}
+
+public interface IDistributedLockHandle : IAsyncDisposable
+{
+    string LockKey { get; }
+}
+```
+
+**Non-blocking semantics:** `TryAcquireAsync` returns `null` immediately if the lock is held. Callers (dispatcher, archival) skip the iteration and try again on the next polling tick. Blocking-acquire APIs in worker loops hide contention behind timeouts.
+
+**Lease-based:** the owner declares how long they intend to hold the lock. Lease expiry releases the lock even if the owner crashes without disposing the handle.
+
+### 6.3 Default DB implementation — `SkipLockedDistributedLock`
+
+#### 6.3.1 Why a dedicated `OutboxLock` table rather than `SELECT ... FOR UPDATE SKIP LOCKED` on `OutboxMessage`
+
+| | `OutboxLock` table | `FOR UPDATE SKIP LOCKED` on rows |
+|---|---|---|
+| Abstraction shape | Named lock, semantic for any worker | Row-level fetch+lock combined |
+| Provider support | EF Core raw SQL works on PG/MSSQL/MySQL/SQLite | PG/MSSQL/MySQL; SQLite no |
+| Test surface | SQLite in-memory integration tests work | Tests must run against a real PG/MSSQL |
+| Coordination with archival | Same locking primitive, different key | Each job invents its own |
+| New consumer migration | Yes (`OrionGuard_OutboxLocks` table) | Yes (none — but tests need a real DB) |
+
+The named-lock model also keeps `IDistributedLock` semantically coherent — a hypothetical Redis implementation maps `lockKey` directly to a Redis key; a `SKIP LOCKED` interpretation wouldn't.
+
+#### 6.3.2 Schema
+
+```csharp
+public sealed class OutboxLock
+{
+    public string LockKey { get; set; } = default!;      // PK, max length 200
+    public Guid? HolderId { get; set; }                  // null when free
+    public DateTime AcquiredOnUtc { get; set; }
+    public DateTime ExpiresOnUtc { get; set; }
+}
+```
+
+Configuration:
+
+```csharp
+public sealed class OutboxLockEntityTypeConfiguration : IEntityTypeConfiguration<OutboxLock>
+{
+    public void Configure(EntityTypeBuilder<OutboxLock> builder)
+    {
+        builder.ToTable("OrionGuard_OutboxLocks");
+        builder.HasKey(x => x.LockKey);
+        builder.Property(x => x.LockKey).HasMaxLength(200).IsRequired();
+        builder.Property(x => x.HolderId);
+        builder.Property(x => x.AcquiredOnUtc);
+        builder.Property(x => x.ExpiresOnUtc);
+    }
+}
+```
+
+#### 6.3.3 Acquire algorithm
+
+All operations run inside an EF Core-managed transaction with `IsolationLevel.ReadCommitted`:
+
+1. `UPDATE OrionGuard_OutboxLocks SET HolderId = @newHolder, AcquiredOnUtc = @now, ExpiresOnUtc = @now + @lease WHERE LockKey = @key AND (HolderId IS NULL OR ExpiresOnUtc <= @now)` — atomic takeover of free or expired locks.
+2. If `affectedRows == 0` (no row existed): `INSERT INTO OrionGuard_OutboxLocks (...) VALUES (...)` inside a `try/catch` for unique-key violation; on violation the lock was created by a concurrent acquirer between (1) and (2), return `null`.
+3. After commit, `SELECT HolderId FROM OrionGuard_OutboxLocks WHERE LockKey = @key`; if the returned `HolderId == @newHolder`, return a `Handle`; otherwise return `null` (another caller raced us during the gap).
+
+The `@newHolder` is a freshly-allocated `Guid` per acquire call. Per-call ID lets release verify ownership and refuses to release a lock the caller no longer holds (lease expired, another worker took over).
+
+#### 6.3.4 Release
+
+```sql
+UPDATE OrionGuard_OutboxLocks
+   SET HolderId = NULL, ExpiresOnUtc = @now
+ WHERE LockKey = @key AND HolderId = @holderId;
+```
+
+Holder-ID guard prevents a slow worker whose lease has expired from clobbering a fresh holder. If the row no longer matches, the release is a no-op.
+
+#### 6.3.5 EF Core integration
+
+`SkipLockedDistributedLock` accepts an `IServiceScopeFactory` and creates a per-acquire scope to resolve `DbContext`. All SQL is executed via `ctx.Database.ExecuteSqlInterpolatedAsync` so provider differences (parameter binding, identifier quoting) stay inside EF Core's translator. The class is provider-agnostic — no `ISqlGenerationHelper` or provider-specific code paths.
+
+### 6.4 Dispatcher integration
+
+```csharp
+protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+{
+    // existing startup log
+
+    while (!stoppingToken.IsCancellationRequested)
+    {
+        try
+        {
+            await using var handle = await _distributedLock.TryAcquireAsync(
+                _options.LockKey,
+                _options.LockLeaseDuration,
+                stoppingToken).ConfigureAwait(false);
+
+            if (handle is null)
+            {
+                await Task.Delay(_options.PollingInterval, stoppingToken).ConfigureAwait(false);
+                continue;
+            }
+
+            await ProcessBatchAsync(stoppingToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) { break; }
+        catch { /* existing per-batch swallow */ }
+
+        try
+        {
+            await Task.Delay(_options.PollingInterval, stoppingToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) { break; }
+    }
+}
+```
+
+### 6.5 Options additions
+
+```csharp
+public sealed class OutboxOptions
+{
+    // existing properties...
+
+    public string LockKey { get; set; } = "orion_guard_outbox_dispatcher";
+
+    /// <summary>
+    /// Lease duration for the distributed lock. Must exceed the expected wall-clock time of a single
+    /// <c>ProcessBatchAsync</c> call. Default 30 seconds.
+    /// </summary>
+    public TimeSpan LockLeaseDuration { get; set; } = TimeSpan.FromSeconds(30);
+}
+```
+
+### 6.6 At-least-once semantics preserved
+
+Outbox dispatch was already at-least-once (lost SaveChanges after dispatch → row re-picked). Lease expiry while a worker is mid-batch widens this window slightly: a lagging worker holding an expired lease can still dispatch rows that a fresh worker also picks up. Consumer handlers were already expected to be idempotent; this expectation does not change. Default lease of 30s versus the default batch size of 100 and the default polling interval of 5s puts the lease comfortably outside normal batch wall-clock.
+
+### 6.7 DI wiring — extends the existing `OrionGuardEfCoreOptions` fluent API
+
+The current entry point is `services.AddOrionGuardEfCore<TDbContext>(opts => opts.UseOutbox(...))`. v6.4.0 keeps this surface and threads new registrations through an internal customization list on `OrionGuardEfCoreOptions`:
+
+```csharp
+public sealed class OrionGuardEfCoreOptions
+{
+    // ...existing properties + UseInline / UseOutbox methods
+
+    internal List<Action<IServiceCollection>> ServiceCustomizations { get; } = new();
+
+    public OrionGuardEfCoreOptions UseDistributedLock<TLock>() where TLock : class, IDistributedLock
+    {
+        ServiceCustomizations.Add(s => s.Replace(ServiceDescriptor.Singleton<IDistributedLock, TLock>()));
+        return this;
+    }
+}
+```
+
+`AddOrionGuardEfCore` then performs:
+
+```csharp
+if (options.Strategy == DomainEventDispatchStrategy.Outbox)
+{
+    services.TryAddSingleton<IDistributedLock, SkipLockedDistributedLock>();
+    // ...other outbox-strategy registrations (type map, etc.)
+}
+
+foreach (var customize in options.ServiceCustomizations)
+    customize(services);
+```
+
+And the dispatcher factory is updated to resolve the new dependencies from the `IServiceProvider`:
+
+```csharp
+services.AddHostedService(sp => new OutboxDispatcherHostedService(
+    sp.GetRequiredService<OutboxOptions>(),
+    sp.GetRequiredService<IServiceScopeFactory>(),
+    sp.GetRequiredService<IDistributedLock>(),
+    sp.GetRequiredService<OutboxTypeMapRegistry>(),
+    sp.GetRequiredService<OutboxTypeMapOptions>(),
+    sp.GetService<ILogger<OutboxDispatcherHostedService>>()));
+```
+
+`TryAddSingleton` means consumers who do nothing still get `SkipLockedDistributedLock` automatically. Consumers can replace via `opts.UseDistributedLock<TLock>()` or by registering `IDistributedLock` *before* `AddOrionGuardEfCore`. v6.3 consumers who do not want to apply the new migration call `opts.UseDistributedLock<NullDistributedLock>()` — a shipped no-op handle factory that immediately returns a handle on every call, restoring v6.3 single-instance behaviour.
+
+### 6.8 `NullDistributedLock` — opt-out for unmigrated single-instance consumers
+
+```csharp
+public sealed class NullDistributedLock : IDistributedLock
+{
+    public Task<IDistributedLockHandle?> TryAcquireAsync(string lockKey, TimeSpan leaseDuration, CancellationToken cancellationToken = default)
+        => Task.FromResult<IDistributedLockHandle?>(new NullHandle(lockKey));
+
+    private sealed class NullHandle(string lockKey) : IDistributedLockHandle
+    {
+        public string LockKey => lockKey;
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+}
+```
+
+Listed in §2 package layout under `Outbox/Locking/`.
+
+## 7. `OutboxTypeMapRegistry` (`OrionGuard.EntityFrameworkCore`)
+
+### 7.1 The current fragility
+
+The dispatcher resolves event types via `Type.GetType(msg.EventType)`, where `msg.EventType` is an assembly-qualified name written at outbox-insert time. This couples persisted payload schema to internal CLR identity: rename `MyApp.Events.UserRegistered` to `MyApp.Domain.Users.UserCreated` and every queued outbox row becomes a dead letter. The dispatcher already carries `[RequiresUnreferencedCode]` + `[RequiresDynamicCode]` annotations to reflect this AOT hostility.
+
+### 7.2 Registry
+
+```csharp
+namespace Moongazing.OrionGuard.EntityFrameworkCore.Outbox.TypeMap;
+
+public sealed class OutboxTypeMapRegistry
+{
+    private readonly Dictionary<string, Type> _byName = new(StringComparer.Ordinal);
+    private readonly Dictionary<Type, string> _byType = new();
+
+    public OutboxTypeMapRegistry Map<TEvent>(string logicalName) where TEvent : IDomainEvent
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(logicalName);
+        var type = typeof(TEvent);
+        if (_byName.TryGetValue(logicalName, out var existing) && existing != type)
+            throw new InvalidOperationException($"Outbox type map collision: '{logicalName}' is already mapped to {existing.FullName}.");
+        if (_byType.TryGetValue(type, out var existingName) && existingName != logicalName)
+            throw new InvalidOperationException($"Outbox type map collision: {type.FullName} is already mapped to '{existingName}'.");
+        _byName[logicalName] = type;
+        _byType[type] = logicalName;
+        return this;
+    }
+
+    public bool TryResolve(string logicalName, [NotNullWhen(true)] out Type? type)
+        => _byName.TryGetValue(logicalName, out type);
+
+    public bool TryGetLogicalName(Type type, [NotNullWhen(true)] out string? logicalName)
+        => _byType.TryGetValue(type, out logicalName);
+}
+
+public sealed class OutboxTypeMapOptions
+{
+    /// <summary>
+    /// When true, the dispatcher falls back to <see cref="Type.GetType(string)"/> for event types not in the registry.
+    /// Default <see langword="true"/> for backward compatibility with v6.3.x rows.
+    /// Set to <see langword="false"/> for AOT deployments.
+    /// </summary>
+    public bool AllowAssemblyQualifiedNameFallback { get; set; } = true;
+}
+```
+
+Registration enforces a 1:1 mapping (no silent override; collisions throw at startup). The registry is a singleton populated once at boot — no thread-safety on `Map` because writes only happen synchronously during DI build.
+
+### 7.3 Writer side
+
+At outbox-insert time (in the EF Core `SaveChanges` interceptor that today produces `OutboxMessage` rows for `AggregateRoot.PullDomainEvents`):
+
+```csharp
+var eventType = @event.GetType();
+var typeId = registry.TryGetLogicalName(eventType, out var name)
+    ? name
+    : eventType.AssemblyQualifiedName ?? eventType.FullName!;
+var msg = new OutboxMessage { EventType = typeId, /* ... */ };
+```
+
+When a consumer registers the logical name, all *new* rows are written with the logical name. Older rows already in the table continue to carry their AQN — the reader's fallback handles them.
+
+### 7.4 Reader side
+
+```csharp
+Type? type;
+if (registry.TryResolve(msg.EventType, out var registered))
+{
+    type = registered;
+}
+else if (_typeMapOptions.AllowAssemblyQualifiedNameFallback)
+{
+    type = Type.GetType(msg.EventType);
+}
+else
+{
+    type = null;
+}
+
+if (type is null)
+{
+    msg.Error = $"TYPE_NOT_FOUND: '{msg.EventType}' is not registered in OutboxTypeMapRegistry and AQN fallback is " +
+                $"{(_typeMapOptions.AllowAssemblyQualifiedNameFallback ? "enabled but resolution failed" : "disabled")}.";
+    msg.ProcessedOnUtc = DateTime.UtcNow;
+    _logger?.LogWarning("Outbox row {RowId} dead-lettered: type '{EventType}' could not be resolved.", msg.Id, msg.EventType);
+    return; // skip dispatch, persist state
+}
+```
+
+### 7.5 AOT path
+
+When `AllowAssemblyQualifiedNameFallback = false`, the dispatcher never calls `Type.GetType`. The `[RequiresUnreferencedCode]`/`[RequiresDynamicCode]` annotations on `OutboxDispatcherHostedService` remain (because the dispatcher still calls `JsonSerializer.Deserialize(string, Type)` which has its own AOT requirements), but consumers running with full AOT can additionally register a JSON `TypeInfoResolver` and disable AQN fallback to eliminate the `Type.GetType` code path. Local `[UnconditionalSuppressMessage]` on the registry-only branch is acceptable because the consumer has explicitly opted in.
+
+### 7.6 DI helper — extends `OrionGuardEfCoreOptions`
+
+```csharp
+public sealed class OrionGuardEfCoreOptions
+{
+    // ...other Use* methods
+
+    public OrionGuardEfCoreOptions UseOutboxTypeMap(
+        Action<OutboxTypeMapRegistry> configure,
+        Action<OutboxTypeMapOptions>? configureOptions = null)
+    {
+        var registry = new OutboxTypeMapRegistry();
+        configure(registry);
+
+        var options = new OutboxTypeMapOptions();
+        configureOptions?.Invoke(options);
+
+        ServiceCustomizations.Add(s =>
+        {
+            s.Replace(ServiceDescriptor.Singleton(registry));
+            s.Replace(ServiceDescriptor.Singleton(options));
+        });
+        return this;
+    }
+}
+```
+
+When `AddOrionGuardEfCore` registers Outbox-strategy services it also `TryAddSingleton`s an empty `OutboxTypeMapRegistry` and default `OutboxTypeMapOptions`, so the dispatcher's resolution always succeeds. If consumers never call `UseOutboxTypeMap`, the registry stays empty, options stay at defaults (AQN fallback enabled), and behaviour matches v6.3.x.
+
+## 8. Archival hosted service (`OrionGuard.EntityFrameworkCore`)
+
+### 8.1 The problem
+
+Processed outbox rows (`ProcessedOnUtc != null`) accumulate forever. Production deployments report tables with tens of millions of rows; the polling query `WHERE ProcessedOnUtc IS NULL` slows down because the index still has to step through processed entries.
+
+### 8.2 Service
+
+```csharp
+public sealed class OutboxArchivalHostedService : BackgroundService
+{
+    public async Task<int> ArchiveBatchAsync(CancellationToken cancellationToken)
+    {
+        var cutoff = DateTime.UtcNow - _options.RetentionPeriod;
+        await using var scope = _scopeFactory.CreateAsyncScope();
+        var ctx = scope.ServiceProvider.GetRequiredService<DbContext>();
+
+        var query = ctx.Set<OutboxMessage>()
+            .Where(m => m.ProcessedOnUtc != null && m.ProcessedOnUtc < cutoff);
+
+        if (_options.PreserveDeadLetters)
+            query = query.Where(m => m.Error == null);
+
+        return await query
+            .OrderBy(m => m.ProcessedOnUtc)
+            .Take(_options.BatchSize)
+            .ExecuteDeleteAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await using var handle = await _distributedLock.TryAcquireAsync(
+                    _options.LockKey, TimeSpan.FromMinutes(5), stoppingToken).ConfigureAwait(false);
+
+                if (handle is null)
+                {
+                    await Task.Delay(_options.PollingInterval, stoppingToken).ConfigureAwait(false);
+                    continue;
+                }
+
+                await ArchiveBatchAsync(stoppingToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) { break; }
+            catch (Exception ex) { _logger?.LogError(ex, "Outbox archival batch failed."); }
+
+            try { await Task.Delay(_options.PollingInterval, stoppingToken).ConfigureAwait(false); }
+            catch (OperationCanceledException) { break; }
+        }
+    }
+}
+```
+
+### 8.3 Options and defaults
+
+```csharp
+public sealed class OutboxArchivalOptions
+{
+    public TimeSpan RetentionPeriod { get; set; } = TimeSpan.FromDays(30);
+    public TimeSpan PollingInterval { get; set; } = TimeSpan.FromHours(1);
+    public int BatchSize { get; set; } = 1000;
+    public bool PreserveDeadLetters { get; set; } = true;
+    public string LockKey { get; set; } = "orion_guard_outbox_archival";
+}
+```
+
+- **30-day retention, 1-hour polling, 1000-row batches** — conservative defaults that keep latency negligible on healthy systems and prevent surprise data loss. Operators tune.
+- **`PreserveDeadLetters = true`** — dead-lettered rows (`Error != null && ProcessedOnUtc != null`) are *never* deleted by default. Operators want to inspect failures; silent deletion would defeat the dead-letter pattern. Setting `false` allows full retention-based cleanup.
+- **`ExecuteDeleteAsync`** (EF Core 7+) — single SQL DELETE, no entity tracking, batch-safe.
+- **Separate lock key** so dispatcher and archival do not block each other.
+
+### 8.4 Opt-in DI helper — extends `OrionGuardEfCoreOptions`
+
+```csharp
+public sealed class OrionGuardEfCoreOptions
+{
+    // ...other Use* methods
+
+    public OrionGuardEfCoreOptions UseOutboxArchival(Action<OutboxArchivalOptions>? configure = null)
+    {
+        var options = new OutboxArchivalOptions();
+        configure?.Invoke(options);
+
+        ServiceCustomizations.Add(s =>
+        {
+            s.Replace(ServiceDescriptor.Singleton(options));
+            s.AddHostedService<OutboxArchivalHostedService>();
+        });
+        return this;
+    }
+}
+```
+
+Archival is opt-in. Consumers who do not call `UseOutboxArchival` see no behavioural change — no hosted service is registered.
+
+## 9. Source compatibility & migration
+
+### 9.1 v6.3.0 → v6.4.0 contract
+
+- **No breaking API changes.** Existing source compiles unchanged.
+- **No required DB migration unless distributed locking is wanted.** Without `OrionGuard_OutboxLocks`, `SkipLockedDistributedLock.TryAcquireAsync` will throw on first call. The dispatcher catches per-batch exceptions and logs; consumers who never deploy the migration but also never scale past one instance are unaffected only if `IDistributedLock` is *not* registered. To keep zero-migration zero-config v6.3.0 behaviour, the outbox builder's default registration must remain `TryAddSingleton<IDistributedLock, SkipLockedDistributedLock>()`, and the dispatcher must tolerate `IDistributedLock` returning `null` *or throwing* — see 9.3.
+- **No required `OutboxTypeMapRegistry` registration.** `AddOrionGuardEfCore` (when `Strategy == Outbox`) `TryAddSingleton`s an empty registry and default `OutboxTypeMapOptions`. Resolution falls back to AQN. v6.3.0 rows continue to dispatch.
+
+### 9.2 Migration cheat sheet (CHANGELOG.md draft)
+
+```markdown
+### Migration from v6.3.0
+
+- **No breaking source changes.**
+- **Distributed locking (recommended for multi-instance deployments):**
+  Add an EF Core migration that creates `OrionGuard_OutboxLocks` (script template at `docs/migrations/v6.4.0-outbox-locks.md`).
+  No code change needed — when `opts.UseOutbox(...)` is selected, `AddOrionGuardEfCore<TDbContext>(...)` auto-wires `SkipLockedDistributedLock`.
+- **Single-instance consumers who do NOT want to apply the new migration:**
+  `opts.UseOutbox(...).UseDistributedLock<NullDistributedLock>()` — restores v6.3.x behaviour.
+- **Type-safe outbox payloads (optional):**
+  `opts.UseOutbox(...).UseOutboxTypeMap(r => r.Map<UserRegistered>("user.registered"));`
+  New rows write the logical name; old rows continue to dispatch via AQN fallback.
+- **Outbox archival (optional):**
+  `opts.UseOutbox(...).UseOutboxArchival(a => a.RetentionPeriod = TimeSpan.FromDays(60));`
+- **`BusinessRule` base class (optional):**
+  Existing `IBusinessRule` implementations work unchanged. Subclass `BusinessRule` to drop the `MessageKey`/`MessageArgs` boilerplate.
+- **`Guard.AgainstBrokenRule` (additive):**
+  `Guard.AgainstBrokenRule(new OrderMustHaveItems(order));`
+  `Entity.CheckRule` keeps working and now delegates to this internally.
+- **`BusinessRuleValidationException` → 422 ProblemDetails (automatic):**
+  Wherever `OrionGuardExceptionHandler` is registered, `BusinessRuleValidationException` now returns a `422 Unprocessable Entity` ProblemDetails. Customize via `OrionGuardAspNetCoreOptions.BusinessRuleStatusCode`.
+```
+
+### 9.3 Lock-table-missing fault tolerance
+
+`SkipLockedDistributedLock.TryAcquireAsync` wraps its EF Core call in a guard that catches `DbException`/`InvalidOperationException` matching "no such table" / "Invalid object name" and returns `null` on first failure, while logging a one-time warning ("OrionGuard_OutboxLocks table not found; distributed locking is disabled. Apply the v6.4.0 migration to enable."). After the warning, subsequent calls also return `null` until the table is migrated in. This keeps zero-migration upgrades from v6.3.0 from breaking — the dispatcher never enters its batch processing because the lock never acquires — but the operator log makes the situation visible. Single-instance consumers who want v6.3.0 behaviour without migrating call `.UseDistributedLock<NullDistributedLock>()` (a no-op handle factory we ship for this case).
+
+## 10. Branch and PR plan
+
+- **Branch:** `feature/v6.4.0` off `master`.
+- **PRs:** Single umbrella PR `feat(v6.4.0): business rule helpers, outbox distributed locking, type map, archival`.
+- **Commit shape inside the PR (suggested):**
+  1. `feat(core): BusinessRule and AsyncBusinessRule abstract bases`
+  2. `feat(core): Guard.AgainstBrokenRule and Entity.CheckRule delegation`
+  3. `feat(aspnetcore): ProblemDetails mapping for BusinessRuleValidationException`
+  4. `feat(efcore): IDistributedLock abstraction and SkipLockedDistributedLock`
+  5. `feat(efcore): OutboxTypeMapRegistry with AQN fallback`
+  6. `feat(efcore): OutboxArchivalHostedService`
+  7. `chore(release): v6.4.0 version bump and CHANGELOG`
+- **Tag:** `v6.4.0` on merge commit to `master`.
+
+## 11. Testing strategy
+
+### 11.1 Core (`tests/Moongazing.OrionGuard.Tests/`)
+
+- `Domain/Rules/BusinessRuleTests.cs` — default `MessageKey == GetType().Name`, abstract `IsBroken`/`DefaultMessage` enforcement, `MessageArgs` override.
+- `Domain/Rules/AsyncBusinessRuleTests.cs` — async equivalents including cancellation propagation.
+- `Core/Guard_AgainstBrokenRuleTests.cs` — happy path, broken rule throws with rule details, null guard.
+- `Core/Guard_AgainstBrokenRuleAsyncTests.cs` — same plus cancellation.
+- `Domain/Primitives/EntityCheckRuleDelegationTests.cs` — behavioural equivalence between v6.3 implementation and v6.4 delegation (exception type, message, RuleName, MessageKey).
+
+### 11.2 AspNetCore (`tests/Moongazing.OrionGuard.AspNetCore.Tests/`)
+
+- `ExceptionHandling/OrionGuardExceptionHandler_BusinessRuleTests.cs` — 422 default response, custom `BusinessRuleStatusCode = 400` override, `UseProblemDetails = false` simple-JSON path, log level == Warning.
+- `ProblemDetails/OrionGuardProblemDetailsFactory_BusinessRuleTests.cs` — `errors` dictionary keyed by `RuleName`, `Type` URL, `Title`, `Status`.
+
+### 11.3 EntityFrameworkCore (`tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/`)
+
+- `Outbox/Locking/SkipLockedDistributedLockTests.cs` — acquire/release happy path, expired-lease takeover, holder-id mismatch on release becomes no-op, double acquire by the same caller, missing-table fault tolerance (returns null + warning).
+- `Outbox/Locking/SkipLockedDistributedLockConcurrencyTests.cs` — integration test using shared SQLite database: spawn 5 tasks calling `TryAcquireAsync`; exactly one returns a handle, the other four return null. Release; another acquires.
+- `Outbox/TypeMap/OutboxTypeMapRegistryTests.cs` — `Map` collision throws on name reuse and on type reuse, `TryResolve`/`TryGetLogicalName` roundtrip, empty registry returns false.
+- `Outbox/OutboxDispatcher_LockIntegrationTests.cs` — two concurrent `OutboxDispatcherHostedService` instances against the same DbContext share-the-database scenario; total dispatch count equals row count, no duplicates.
+- `Outbox/OutboxDispatcher_TypeMapTests.cs` — logical-name path resolves and dispatches, AQN fallback path resolves and dispatches, AQN-fallback-disabled with unregistered name dead-letters with the new error string.
+- `Outbox/Archival/OutboxArchivalHostedServiceTests.cs` — retention cutoff respected, batch size respected, dead-letter rows preserved by default, dead-letter rows deleted when `PreserveDeadLetters = false`, lock acquisition required before delete.
+
+### 11.4 Coverage bar
+
+Match v6.3.0 — every new public method has at least one happy-path and one negative-path test; every new public type appears in at least one integration test.
+
+## 12. Documentation deliverables
+
+- `CHANGELOG.md` — `## [6.4.0] - YYYY-MM-DD` section (filled at tag time) using the template in §9.2.
+- `docs/migrations/v6.4.0-outbox-locks.md` — EF Core migration template with PG / MSSQL / MySQL / SQLite snippets for `OrionGuard_OutboxLocks`.
+- `docs/FEATURES-v6.4.md` — narrative overview matching the existing `FEATURES-v6.x.md` series.
+- `src/Moongazing.OrionGuard*/docs/README.md` (per-package READMEs touched only where the package surface changed): core, AspNetCore, EntityFrameworkCore.
+- *Optional, post-merge:* publish a docs page at `https://moongazing.dev/orionguard/problems/business-rule-violation` corresponding to the ProblemDetails `Type` URL.
+
+## 13. Out-of-scope confirmations
+
+- No `Moongazing.OrionGuard.Redis` package.
+- No `Moongazing.OrionGuard.Distributed` package.
+- No push-based outbox notifications.
+- No event sourcing primitives.
+- No `Guard.Against.X` chain syntax (would be v7.0.0).
+- No automatic `BusinessRule` source generator (overkill for the size of the savings).
+- No archival → audit table copy-before-delete.

--- a/docs/superpowers/specs/2026-05-21-stronglytypedid-deprecation-design.md
+++ b/docs/superpowers/specs/2026-05-21-stronglytypedid-deprecation-design.md
@@ -1,0 +1,101 @@
+# OrionGuard `[StronglyTypedId]` soft-deprecation in favour of OrionKey
+
+**Date:** 2026-05-21
+**Status:** Approved (design); pending implementation plan
+**Branch:** `feature/v6.4.0` (folds into the in-progress v6.4.0 release)
+**Related:** OrionKey v0.1.0 (the standalone successor package, published to NuGet)
+
+## 1. Goal
+
+OrionKey — a standalone Orion-family package — now ships the source-generated strongly-typed-id feature that previously lived only inside OrionGuard's `[StronglyTypedId<TValue>]` generator. OrionGuard's generator is therefore superseded.
+
+This change **soft-deprecates** OrionGuard's `[StronglyTypedId]` source generator and its injected attribute: existing consumers keep compiling and the generator keeps emitting, but each `[StronglyTypedId]` usage now raises a compiler warning that points to OrionKey. The generator will be removed in OrionGuard v7.0.0.
+
+## 2. Scope
+
+**In scope** — only the source generator and its attribute:
+
+- The injected `StronglyTypedIdAttribute<TValue>` (emitted by `Moongazing.OrionGuard.Generators` via `RegisterPostInitializationOutput`) gets `[Obsolete]`.
+- The generator (`StronglyTypedIdGenerator` and its emitters) is **unchanged functionally** — it still emits every companion. Only the attribute carries the deprecation.
+
+**Explicitly out of scope** — these are not superseded by OrionKey and stay untouched:
+
+- The manual `StronglyTypedId<TValue>` abstract record (`Domain/Primitives/StronglyTypedId.cs`). OrionKey has no manual-base equivalent — it is entirely source-generated — so deprecating the manual record would strand its users.
+- `IStronglyTypedId<TValue>` marker interface.
+- `StronglyTypedIdGuards` (`AgainstDefaultStronglyTypedId`) and `StronglyTypedIdServiceExtensions`.
+
+**Non-goals:**
+
+- OrionGuard takes **no** `PackageReference` or `ProjectReference` on OrionKey. The Orion family rule — no library depends on another Orion library — is preserved. The deprecation is a documentation pointer, not a code dependency.
+- No type-forwarding or re-export of OrionKey types from OrionGuard.
+- No removal of the generator in this release; removal is a v7.0.0 concern.
+- No new analyzer diagnostic — the `[Obsolete]` attribute's own CS0618 warning already carries the migration message.
+
+## 3. The change
+
+### 3.1 `[Obsolete]` on the injected attribute
+
+`src/Moongazing.OrionGuard.Generators/StronglyTypedIds/StronglyTypedIdAttribute.cs` holds `StronglyTypedIdAttributeSource.Source` — the C# text injected into every consuming compilation. The injected `StronglyTypedIdAttribute<TValue>` declaration gains:
+
+```csharp
+[System.Obsolete("OrionGuard's [StronglyTypedId] is superseded by the standalone OrionKey package. Install OrionKey and use [OrionId<TValue>] / [OrionId<TValue, TStrategy>] instead — see https://www.nuget.org/packages/OrionKey. OrionGuard's generator will be removed in v7.0.0.")]
+```
+
+`[Obsolete]` is applied **without** the `error: true` argument, so consumer `[StronglyTypedId<...>]` usages produce a CS0618 *warning*, not an error — this is a soft deprecation. The attribute's XML `<summary>` is updated to state the same migration guidance in prose.
+
+Applying `[Obsolete]` to the generic attribute type definition means every construction (`[StronglyTypedId<Guid>]`, `[StronglyTypedId<long>]`, etc.) reports CS0618 at the application site.
+
+### 3.2 OrionGuard's own `[StronglyTypedId]` usages
+
+OrionGuard builds with `TreatWarningsAsErrors=true`, so its own usages of the now-obsolete attribute would break the build. These must be located and suppressed with a scoped `#pragma warning disable CS0618` plus a short comment explaining the suppression is deliberate (the generator's own demo/tests must exercise the attribute they ship).
+
+Known usage to suppress:
+
+- `demo/Moongazing.OrionGuard.Demo/Domain/Ids.cs` — the demo declares strongly-typed ids with `[StronglyTypedId<...>]`. Wrap the declarations in `#pragma warning disable CS0618` / `restore`.
+
+To investigate during planning:
+
+- `tests/Moongazing.OrionGuard.Generators.Tests/StronglyTypedIdGenerator*.cs` (three files) — these feed C# source *text* containing `[StronglyTypedId<...>]` into an in-memory generator harness. The `[StronglyTypedId]` tokens are string literals, not attribute applications in the test assembly, so the test assembly itself raises no CS0618. However, the harness's in-memory `CSharpCompilation` will now contain an obsolete-attribute usage; any test asserting the generated/compiled output is *diagnostic-free* (or filtering diagnostics) may observe CS0618. The plan must check each generator test and, where a test asserts "no diagnostics", either filter CS0618 out of the assertion or add `#pragma warning disable CS0618` to the test's source-text fixture.
+
+The implementation plan must produce the exhaustive list by building the solution after 3.1 and collecting every CS0618 site.
+
+### 3.3 CHANGELOG
+
+The existing `## [6.4.0]` entry in `CHANGELOG.md` gains a `### Deprecated` subsection:
+
+```markdown
+### Deprecated
+
+- The `[StronglyTypedId<TValue>]` source generator is soft-deprecated in favour of the standalone **OrionKey** package (`[OrionId<TValue>]` / `[OrionId<TValue, TStrategy>]`). Existing usages keep compiling and the generator keeps emitting; each `[StronglyTypedId]` usage now raises a CS0618 warning with migration guidance. The generator will be removed in v7.0.0. The manual `StronglyTypedId<TValue>` record, `IStronglyTypedId<TValue>`, and the related guards are unaffected.
+```
+
+### 3.4 Documentation
+
+- `README.md` — wherever `[StronglyTypedId]` appears in an example or feature table, add a one-line deprecation note pointing to OrionKey. Do not delete the examples (the generator still works); annotate them.
+- `docs/` feature guides that document `[StronglyTypedId]` (e.g. the v6.1/v6.2 feature docs) get a short deprecation banner at the relevant section, pointing to OrionKey. Long-form historical docs need only a banner, not a rewrite.
+
+## 4. Migration guidance (for the CHANGELOG / docs)
+
+A consumer migrating from OrionGuard `[StronglyTypedId]` to OrionKey `[OrionId]`:
+
+1. `dotnet add package OrionKey`.
+2. Replace `[StronglyTypedId<Guid>]` with `[OrionId<Guid>]`; `[StronglyTypedId<long>]` with `[OrionId<long>]` (externally-assigned) or `[OrionId<long, Snowflake>]` (generated); `[StronglyTypedId<string>]` with `[OrionId<string, Ulid>]` or `[OrionId<string, NanoId>]`.
+3. Change the `using` from `Moongazing.OrionGuard.Domain.Primitives` to `Moongazing.OrionKey`.
+4. The emitted surface (`Value`, `New()`, equality, EF Core `ValueConverter`, JSON converter, `TypeConverter`, `IParsable`) is equivalent; OrionKey additionally provides `IComparable` for sortable strategies and the `GuidV7`/`Snowflake`/`NanoId` strategies.
+
+This guidance lives in the CHANGELOG `### Deprecated` note and, in fuller form, in a short `docs/migrations/stronglytypedid-to-orionkey.md` page.
+
+## 5. Testing
+
+- After 3.1, `dotnet build` the whole solution and confirm the *only* new diagnostics are CS0618 at known sites; suppress each per 3.2.
+- `dotnet test` the full solution must stay green. The generator tests must still pass — the generator's behaviour is unchanged, so generated-output assertions hold; only diagnostic-free assertions (if any) may need a CS0618 filter.
+- Add one focused generator test asserting that a `[StronglyTypedId]` usage is reported as obsolete — i.e. the harness compilation contains a CS0618 diagnostic. This locks in the deprecation so a future edit cannot silently un-deprecate the attribute.
+- The demo must still run (`dotnet run --project demo/Moongazing.OrionGuard.Demo`) and print its strongly-typed-id section.
+
+## 6. Out-of-scope confirmations
+
+- No OrionKey dependency added to OrionGuard.
+- No change to the manual `StronglyTypedId<TValue>` record, `IStronglyTypedId`, or the guards.
+- No generator removal (v7.0.0).
+- No new analyzer diagnostic ID.
+- No version bump — this folds into the unshipped v6.4.0.

--- a/src/Moongazing.OrionGuard.AspNetCore/ExceptionHandling/OrionGuardExceptionHandler.cs
+++ b/src/Moongazing.OrionGuard.AspNetCore/ExceptionHandling/OrionGuardExceptionHandler.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Logging;
 using Moongazing.OrionGuard.AspNetCore.ProblemDetails;
 using Moongazing.OrionGuard.AspNetCore.Options;
 using Moongazing.OrionGuard.Core;
+using Moongazing.OrionGuard.Domain.Exceptions;
 using Moongazing.OrionGuard.Exceptions;
 
 namespace Moongazing.OrionGuard.AspNetCore.ExceptionHandling;
@@ -72,6 +73,43 @@ public sealed class OrionGuardExceptionHandler : IExceptionHandler
 
                 await httpContext.Response.WriteAsJsonAsync(
                     new { errors },
+                    SerializerOptions,
+                    cancellationToken).ConfigureAwait(false);
+            }
+
+            return true;
+        }
+
+        if (exception is BusinessRuleValidationException ruleException)
+        {
+            _logger.LogWarning(
+                ruleException,
+                "Business rule '{RuleName}' violated: {Message}",
+                ruleException.RuleName,
+                ruleException.Message);
+
+            var statusCode = _options.BusinessRuleStatusCode;
+
+            if (_options.UseProblemDetails)
+            {
+                var problemDetails = OrionGuardProblemDetailsFactory.Create(ruleException);
+                problemDetails.Status = statusCode;
+
+                httpContext.Response.StatusCode = statusCode;
+                httpContext.Response.ContentType = MediaTypeNames.Application.Json;
+
+                await httpContext.Response.WriteAsJsonAsync(
+                    problemDetails,
+                    SerializerOptions,
+                    cancellationToken).ConfigureAwait(false);
+            }
+            else
+            {
+                httpContext.Response.StatusCode = statusCode;
+                httpContext.Response.ContentType = MediaTypeNames.Application.Json;
+
+                await httpContext.Response.WriteAsJsonAsync(
+                    new { ruleName = ruleException.RuleName, message = ruleException.Message },
                     SerializerOptions,
                     cancellationToken).ConfigureAwait(false);
             }

--- a/src/Moongazing.OrionGuard.AspNetCore/Moongazing.OrionGuard.AspNetCore.csproj
+++ b/src/Moongazing.OrionGuard.AspNetCore/Moongazing.OrionGuard.AspNetCore.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.AspNetCore</PackageId>
-    <Version>6.3.0</Version>
+    <Version>6.4.0</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>ASP.NET Core integration for OrionGuard validation library. Provides middleware, Minimal API endpoint filters, MVC action filters, and RFC 9457 ProblemDetails support.</Description>
     <PackageTags>guard;validation;aspnetcore;middleware;minimal-api;problemdetails</PackageTags>

--- a/src/Moongazing.OrionGuard.AspNetCore/Options/OrionGuardAspNetCoreOptions.cs
+++ b/src/Moongazing.OrionGuard.AspNetCore/Options/OrionGuardAspNetCoreOptions.cs
@@ -1,3 +1,5 @@
+using Microsoft.AspNetCore.Http;
+
 namespace Moongazing.OrionGuard.AspNetCore.Options;
 
 /// <summary>
@@ -23,4 +25,11 @@ public sealed class OrionGuardAspNetCoreOptions
     /// Default is <c>false</c>.
     /// </summary>
     public bool SuppressModelStateInvalidFilter { get; set; } = false;
+
+    /// <summary>
+    /// HTTP status code returned for <see cref="Moongazing.OrionGuard.Domain.Exceptions.BusinessRuleValidationException"/>.
+    /// Defaults to <see cref="StatusCodes.Status422UnprocessableEntity"/> (RFC 9457 — request is
+    /// syntactically valid but semantically rejected). Override (e.g., to 400) for legacy clients.
+    /// </summary>
+    public int BusinessRuleStatusCode { get; set; } = StatusCodes.Status422UnprocessableEntity;
 }

--- a/src/Moongazing.OrionGuard.AspNetCore/ProblemDetails/OrionGuardProblemDetailsFactory.cs
+++ b/src/Moongazing.OrionGuard.AspNetCore/ProblemDetails/OrionGuardProblemDetailsFactory.cs
@@ -1,5 +1,7 @@
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Moongazing.OrionGuard.Core;
+using Moongazing.OrionGuard.Domain.Exceptions;
 
 namespace Moongazing.OrionGuard.AspNetCore.ProblemDetails;
 
@@ -12,6 +14,10 @@ public static class OrionGuardProblemDetailsFactory
     private const string ProblemDetailsType = "https://tools.ietf.org/html/rfc9457";
     private const string DefaultTitle = "Validation Failed";
     private const int DefaultStatusCode = 422;
+
+    private const string BusinessRuleProblemType =
+        "https://moongazing.dev/orionguard/problems/business-rule-violation";
+    private const string BusinessRuleTitle = "Business Rule Violation";
 
     /// <summary>
     /// Creates a <see cref="ValidationProblemDetails"/> from a failed <see cref="GuardResult"/>.
@@ -50,5 +56,26 @@ public static class OrionGuardProblemDetailsFactory
         };
 
         return problemDetails;
+    }
+
+    /// <summary>
+    /// Creates a <see cref="ValidationProblemDetails"/> from a <see cref="BusinessRuleValidationException"/>.
+    /// Errors are keyed by the rule's CLR type name; status defaults to 422.
+    /// </summary>
+    /// <param name="exception">The business rule exception.</param>
+    /// <returns>A <see cref="ValidationProblemDetails"/> ready for serialization.</returns>
+    public static ValidationProblemDetails Create(BusinessRuleValidationException exception)
+    {
+        var errors = new Dictionary<string, string[]>
+        {
+            [exception.RuleName] = new[] { exception.Message },
+        };
+
+        return new ValidationProblemDetails(errors)
+        {
+            Type = BusinessRuleProblemType,
+            Title = BusinessRuleTitle,
+            Status = StatusCodes.Status422UnprocessableEntity,
+        };
     }
 }

--- a/src/Moongazing.OrionGuard.Blazor/Moongazing.OrionGuard.Blazor.csproj
+++ b/src/Moongazing.OrionGuard.Blazor/Moongazing.OrionGuard.Blazor.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Blazor</PackageId>
-    <Version>6.3.0</Version>
+    <Version>6.4.0</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Blazor integration for OrionGuard validation library. Provides EditForm validation, custom validation components, and data annotations interop.</Description>
     <PackageTags>guard;validation;blazor;editform;component;wasm;server</PackageTags>

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/DomainEventSaveChangesInterceptor.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/DomainEventSaveChangesInterceptor.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Moongazing.OrionGuard.Domain.Events;
 using Moongazing.OrionGuard.Domain.Primitives;
 using Moongazing.OrionGuard.EntityFrameworkCore.Outbox;
+using Moongazing.OrionGuard.EntityFrameworkCore.Outbox.TypeMap;
 
 namespace Moongazing.OrionGuard.EntityFrameworkCore;
 
@@ -61,6 +62,7 @@ public sealed class DomainEventSaveChangesInterceptor : SaveChangesInterceptor
         else
         {
             var current = Activity.Current;
+            var typeMap = serviceProvider.GetService<OutboxTypeMapRegistry>();
             foreach (var aggregate in aggregates)
             {
                 var events = aggregate.PullDomainEvents();
@@ -68,7 +70,7 @@ public sealed class DomainEventSaveChangesInterceptor : SaveChangesInterceptor
                 {
                     ctx.Add(new OutboxMessage
                     {
-                        EventType = e.GetType().AssemblyQualifiedName!,
+                        EventType = ResolveEventTypeId(e.GetType(), typeMap),
                         Payload = JsonSerializer.Serialize(e, e.GetType()),
                         OccurredOnUtc = e.OccurredOnUtc,
                         TraceParent = current?.Id,
@@ -78,6 +80,15 @@ public sealed class DomainEventSaveChangesInterceptor : SaveChangesInterceptor
             }
         }
         return await base.SavingChangesAsync(eventData, result, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static string ResolveEventTypeId(Type eventType, OutboxTypeMapRegistry? typeMap)
+    {
+        if (typeMap is not null && typeMap.TryGetLogicalName(eventType, out var logical))
+        {
+            return logical;
+        }
+        return eventType.AssemblyQualifiedName ?? eventType.FullName!;
     }
 
     /// <inheritdoc />

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Moongazing.OrionGuard.EntityFrameworkCore.csproj
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Moongazing.OrionGuard.EntityFrameworkCore.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.EntityFrameworkCore</PackageId>
-    <Version>6.3.0</Version>
+    <Version>6.4.0</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>EF Core integration for OrionGuard. Provides a SaveChanges interceptor that dispatches domain events from AggregateRoot&lt;TId&gt; instances after commit (Inline mode) or via a transactional outbox (Outbox mode) consumed by a hosted background worker. Includes W3C trace context propagation across the outbox boundary.</Description>
     <PackageTags>guard;validation;ddd;domain-events;outbox;entity-framework-core;efcore;aggregate-root</PackageTags>

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/OrionGuardEfCoreOptions.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/OrionGuardEfCoreOptions.cs
@@ -1,7 +1,9 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Moongazing.OrionGuard.EntityFrameworkCore.Outbox;
+using Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Archival;
 using Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Locking;
+using Moongazing.OrionGuard.EntityFrameworkCore.Outbox.TypeMap;
 
 namespace Moongazing.OrionGuard.EntityFrameworkCore;
 
@@ -54,6 +56,48 @@ public sealed class OrionGuardEfCoreOptions
     {
         ServiceCustomizations.Add(services =>
             services.Replace(ServiceDescriptor.Singleton<IDistributedLock, TLock>()));
+        return this;
+    }
+
+    /// <summary>
+    /// Configures the outbox <see cref="OutboxTypeMapRegistry"/> so events can be persisted under
+    /// stable logical names instead of their assembly-qualified CLR names. Optional — without this
+    /// call the registry stays empty and the dispatcher falls back to AQN resolution.
+    /// </summary>
+    public OrionGuardEfCoreOptions UseOutboxTypeMap(
+        Action<OutboxTypeMapRegistry> configure,
+        Action<OutboxTypeMapOptions>? configureOptions = null)
+    {
+        ArgumentNullException.ThrowIfNull(configure);
+
+        var registry = new OutboxTypeMapRegistry();
+        configure(registry);
+
+        var options = new OutboxTypeMapOptions();
+        configureOptions?.Invoke(options);
+
+        ServiceCustomizations.Add(services =>
+        {
+            services.Replace(ServiceDescriptor.Singleton(registry));
+            services.Replace(ServiceDescriptor.Singleton(options));
+        });
+        return this;
+    }
+
+    /// <summary>
+    /// Enables the opt-in <see cref="OutboxArchivalHostedService"/>. Without this call no archival
+    /// hosted service is registered and processed outbox rows accumulate indefinitely.
+    /// </summary>
+    public OrionGuardEfCoreOptions UseOutboxArchival(Action<OutboxArchivalOptions>? configure = null)
+    {
+        var options = new OutboxArchivalOptions();
+        configure?.Invoke(options);
+
+        ServiceCustomizations.Add(services =>
+        {
+            services.Replace(ServiceDescriptor.Singleton(options));
+            services.AddHostedService<OutboxArchivalHostedService>();
+        });
         return this;
     }
 }

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/OrionGuardEfCoreOptions.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/OrionGuardEfCoreOptions.cs
@@ -1,4 +1,7 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Moongazing.OrionGuard.EntityFrameworkCore.Outbox;
+using Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Locking;
 
 namespace Moongazing.OrionGuard.EntityFrameworkCore;
 
@@ -37,6 +40,20 @@ public sealed class OrionGuardEfCoreOptions
             configure(temp);
             Outbox = temp;
         }
+        return this;
+    }
+
+    internal List<Action<IServiceCollection>> ServiceCustomizations { get; } = new();
+
+    /// <summary>
+    /// Replaces the registered <see cref="IDistributedLock"/> implementation. Default is
+    /// <see cref="SkipLockedDistributedLock"/>; alternatives include <see cref="NullDistributedLock"/>
+    /// or a custom (e.g. Redis) implementation.
+    /// </summary>
+    public OrionGuardEfCoreOptions UseDistributedLock<TLock>() where TLock : class, IDistributedLock
+    {
+        ServiceCustomizations.Add(services =>
+            services.Replace(ServiceDescriptor.Singleton<IDistributedLock, TLock>()));
         return this;
     }
 }

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Archival/OutboxArchivalHostedService.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Archival/OutboxArchivalHostedService.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -75,9 +76,49 @@ public sealed class OutboxArchivalHostedService : BackgroundService
     }
 
     /// <inheritdoc />
-    protected override Task ExecuteAsync(CancellationToken stoppingToken)
+    [SuppressMessage("Design", "CA1031:Do not catch general exception types",
+        Justification = "Per-batch faults are intentionally swallowed so the worker survives transient infrastructure errors.")]
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        // Filled in by Task 21.
-        return Task.CompletedTask;
+        logger?.LogInformation(
+            "OrionGuard outbox archival started. Retention {Retention}, batch {BatchSize}, polling {Polling}.",
+            options.RetentionPeriod, options.BatchSize, options.PollingInterval);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await using var handle = await distributedLock.TryAcquireAsync(
+                    options.LockKey,
+                    TimeSpan.FromMinutes(5),
+                    stoppingToken).ConfigureAwait(false);
+
+                if (handle is null)
+                {
+                    // Why: another instance owns the lease. Sleep and retry — do not archive.
+                    await Task.Delay(options.PollingInterval, stoppingToken).ConfigureAwait(false);
+                    continue;
+                }
+
+                await ArchiveBatchAsync(stoppingToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                logger?.LogError(ex, "Outbox archival batch failed.");
+            }
+
+            try
+            {
+                await Task.Delay(options.PollingInterval, stoppingToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+        }
     }
 }

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Archival/OutboxArchivalHostedService.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Archival/OutboxArchivalHostedService.cs
@@ -1,0 +1,83 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Locking;
+
+namespace Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Archival;
+
+/// <summary>
+/// Periodically deletes processed outbox rows older than <see cref="OutboxArchivalOptions.RetentionPeriod"/>.
+/// Opt-in: register via <c>opts.UseOutboxArchival(...)</c>. Coordinates with the dispatcher through a
+/// separate <see cref="IDistributedLock"/> key (default <c>orion_guard_outbox_archival</c>).
+/// </summary>
+public sealed class OutboxArchivalHostedService : BackgroundService
+{
+    private readonly OutboxArchivalOptions options;
+    private readonly IServiceScopeFactory scopeFactory;
+    private readonly IDistributedLock distributedLock;
+    private readonly ILogger<OutboxArchivalHostedService>? logger;
+
+    /// <summary>Initializes a new archival worker.</summary>
+    /// <param name="options">Archival configuration.</param>
+    /// <param name="scopeFactory">Factory used to create per-batch DI scopes for resolving <see cref="DbContext"/>.</param>
+    /// <param name="distributedLock">
+    /// Distributed lock used to coordinate archival across instances. Use
+    /// <see cref="NullDistributedLock"/> for single-instance deployments.
+    /// </param>
+    /// <param name="logger">Optional logger.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="options"/>, <paramref name="scopeFactory"/>, or
+    /// <paramref name="distributedLock"/> is <see langword="null"/>.
+    /// </exception>
+    public OutboxArchivalHostedService(
+        OutboxArchivalOptions options,
+        IServiceScopeFactory scopeFactory,
+        IDistributedLock distributedLock,
+        ILogger<OutboxArchivalHostedService>? logger = null)
+    {
+        this.options = options ?? throw new ArgumentNullException(nameof(options));
+        this.scopeFactory = scopeFactory ?? throw new ArgumentNullException(nameof(scopeFactory));
+        this.distributedLock = distributedLock ?? throw new ArgumentNullException(nameof(distributedLock));
+        this.logger = logger;
+    }
+
+    /// <summary>Deletes one batch of processed rows older than the retention cutoff. Public for tests.</summary>
+    /// <param name="cancellationToken">Token used to observe cancellation requests.</param>
+    /// <returns>The number of rows deleted in this batch.</returns>
+    public async Task<int> ArchiveBatchAsync(CancellationToken cancellationToken)
+    {
+        var cutoff = DateTime.UtcNow - options.RetentionPeriod;
+        await using var scope = scopeFactory.CreateAsyncScope();
+        var ctx = scope.ServiceProvider.GetRequiredService<DbContext>();
+
+        var query = ctx.Set<OutboxMessage>()
+            .Where(m => m.ProcessedOnUtc != null && m.ProcessedOnUtc < cutoff);
+
+        if (options.PreserveDeadLetters)
+        {
+            query = query.Where(m => m.Error == null);
+        }
+
+        var deleted = await query
+            .OrderBy(m => m.ProcessedOnUtc)
+            .Take(options.BatchSize)
+            .ExecuteDeleteAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        if (deleted > 0)
+        {
+            logger?.LogInformation(
+                "Outbox archival deleted {Count} rows older than {Cutoff:O}.", deleted, cutoff);
+        }
+
+        return deleted;
+    }
+
+    /// <inheritdoc />
+    protected override Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        // Filled in by Task 21.
+        return Task.CompletedTask;
+    }
+}

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Archival/OutboxArchivalHostedService.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Archival/OutboxArchivalHostedService.cs
@@ -90,7 +90,7 @@ public sealed class OutboxArchivalHostedService : BackgroundService
             {
                 await using var handle = await distributedLock.TryAcquireAsync(
                     options.LockKey,
-                    TimeSpan.FromMinutes(5),
+                    options.LockLeaseDuration,
                     stoppingToken).ConfigureAwait(false);
 
                 if (handle is null)

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Archival/OutboxArchivalOptions.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Archival/OutboxArchivalOptions.cs
@@ -20,4 +20,10 @@ public sealed class OutboxArchivalOptions
 
     /// <summary>Lock key used to coordinate archival across instances. Default <c>orion_guard_outbox_archival</c>.</summary>
     public string LockKey { get; set; } = "orion_guard_outbox_archival";
+
+    /// <summary>
+    /// Lease duration for the archival distributed lock. Must exceed the wall-clock cost of a
+    /// single <see cref="OutboxArchivalHostedService.ArchiveBatchAsync"/> call. Default 5 minutes.
+    /// </summary>
+    public TimeSpan LockLeaseDuration { get; set; } = TimeSpan.FromMinutes(5);
 }

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Archival/OutboxArchivalOptions.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Archival/OutboxArchivalOptions.cs
@@ -1,0 +1,23 @@
+namespace Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Archival;
+
+/// <summary>Configures the opt-in <see cref="OutboxArchivalHostedService"/>.</summary>
+public sealed class OutboxArchivalOptions
+{
+    /// <summary>How long to keep processed rows before deletion. Default 30 days.</summary>
+    public TimeSpan RetentionPeriod { get; set; } = TimeSpan.FromDays(30);
+
+    /// <summary>How often the archival worker polls. Default 1 hour.</summary>
+    public TimeSpan PollingInterval { get; set; } = TimeSpan.FromHours(1);
+
+    /// <summary>Max rows deleted per batch. Default 1000.</summary>
+    public int BatchSize { get; set; } = 1000;
+
+    /// <summary>
+    /// When <see langword="true"/>, rows with <see cref="OutboxMessage.Error"/> set (dead-letter) are
+    /// never deleted regardless of retention. Default <see langword="true"/>.
+    /// </summary>
+    public bool PreserveDeadLetters { get; set; } = true;
+
+    /// <summary>Lock key used to coordinate archival across instances. Default <c>orion_guard_outbox_archival</c>.</summary>
+    public string LockKey { get; set; } = "orion_guard_outbox_archival";
+}

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Locking/IDistributedLock.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Locking/IDistributedLock.cs
@@ -1,0 +1,24 @@
+namespace Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Locking;
+
+/// <summary>
+/// Acquires named distributed leases used by outbox dispatcher and archival workers.
+/// Implementations MUST be non-blocking — if the lock is held, return <see langword="null"/>
+/// immediately rather than waiting.
+/// </summary>
+public interface IDistributedLock
+{
+    /// <summary>
+    /// Tries to acquire the lock identified by <paramref name="lockKey"/>. Returns a handle on
+    /// success; <see langword="null"/> when another holder owns the lock.
+    /// </summary>
+    /// <param name="lockKey">Logical lock identifier.</param>
+    /// <param name="leaseDuration">
+    /// Maximum time the caller intends to hold the lock. Lease expiry releases the lock for other
+    /// holders even if the original owner crashes without disposing the handle.
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<IDistributedLockHandle?> TryAcquireAsync(
+        string lockKey,
+        TimeSpan leaseDuration,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Locking/IDistributedLockHandle.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Locking/IDistributedLockHandle.cs
@@ -1,0 +1,12 @@
+namespace Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Locking;
+
+/// <summary>
+/// Lease handle returned by <see cref="IDistributedLock.TryAcquireAsync"/>. Disposing releases
+/// the lock (best-effort — release is a no-op if the lease has already expired and another
+/// holder has taken over).
+/// </summary>
+public interface IDistributedLockHandle : IAsyncDisposable
+{
+    /// <summary>The lock key this handle holds.</summary>
+    string LockKey { get; }
+}

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Locking/NullDistributedLock.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Locking/NullDistributedLock.cs
@@ -1,0 +1,21 @@
+namespace Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Locking;
+
+/// <summary>
+/// No-op implementation that always acquires the lock and never blocks. Useful for single-instance
+/// consumers who do not want to apply the v6.4.0 <c>OrionGuard_OutboxLocks</c> migration. Wire via
+/// <c>opts.UseOutbox(...).UseDistributedLock&lt;NullDistributedLock&gt;()</c>.
+/// </summary>
+public sealed class NullDistributedLock : IDistributedLock
+{
+    public Task<IDistributedLockHandle?> TryAcquireAsync(
+        string lockKey,
+        TimeSpan leaseDuration,
+        CancellationToken cancellationToken = default)
+        => Task.FromResult<IDistributedLockHandle?>(new Handle(lockKey));
+
+    private sealed class Handle(string lockKey) : IDistributedLockHandle
+    {
+        public string LockKey => lockKey;
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+}

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Locking/OutboxLock.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Locking/OutboxLock.cs
@@ -1,0 +1,15 @@
+namespace Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Locking;
+
+/// <summary>
+/// Persistent row backing <c>SkipLockedDistributedLock</c>. Each lock key is one row in
+/// <c>OrionGuard_OutboxLocks</c>. <see cref="HolderId"/> is null when the lock is free; otherwise
+/// the GUID of the current owner. <see cref="ExpiresOnUtc"/> is the lease deadline; if it is in
+/// the past, any caller may take over.
+/// </summary>
+public sealed class OutboxLock
+{
+    public string LockKey { get; set; } = default!;
+    public Guid? HolderId { get; set; }
+    public DateTime AcquiredOnUtc { get; set; }
+    public DateTime ExpiresOnUtc { get; set; }
+}

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Locking/OutboxLockEntityTypeConfiguration.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Locking/OutboxLockEntityTypeConfiguration.cs
@@ -1,0 +1,21 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Locking;
+
+/// <summary>
+/// EF Core mapping for <see cref="OutboxLock"/>. Apply inside your <c>OnModelCreating</c>:
+/// <c>modelBuilder.ApplyConfiguration(new OutboxLockEntityTypeConfiguration());</c>.
+/// </summary>
+public sealed class OutboxLockEntityTypeConfiguration : IEntityTypeConfiguration<OutboxLock>
+{
+    public void Configure(EntityTypeBuilder<OutboxLock> builder)
+    {
+        builder.ToTable("OrionGuard_OutboxLocks");
+        builder.HasKey(x => x.LockKey);
+        builder.Property(x => x.LockKey).HasMaxLength(200).IsRequired();
+        builder.Property(x => x.HolderId);
+        builder.Property(x => x.AcquiredOnUtc);
+        builder.Property(x => x.ExpiresOnUtc);
+    }
+}

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Locking/SkipLockedDistributedLock.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Locking/SkipLockedDistributedLock.cs
@@ -13,6 +13,7 @@ public sealed class SkipLockedDistributedLock : IDistributedLock
 {
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly ILogger<SkipLockedDistributedLock>? _logger;
+    private int _missingTableWarned;
 
     public SkipLockedDistributedLock(
         IServiceScopeFactory scopeFactory,
@@ -32,64 +33,99 @@ public sealed class SkipLockedDistributedLock : IDistributedLock
         if (leaseDuration <= TimeSpan.Zero)
             throw new ArgumentOutOfRangeException(nameof(leaseDuration), "Lease must be > 0.");
 
-        var holderId = Guid.NewGuid();
-        var now = DateTime.UtcNow;
-        var expires = now + leaseDuration;
-
-        await using var scope = _scopeFactory.CreateAsyncScope();
-        var ctx = scope.ServiceProvider.GetRequiredService<DbContext>();
-
-        await using var tx = await ctx.Database.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
-
-        var updated = await ctx.Database.ExecuteSqlInterpolatedAsync(
-            $@"UPDATE OrionGuard_OutboxLocks
-                  SET HolderId = {holderId}, AcquiredOnUtc = {now}, ExpiresOnUtc = {expires}
-                WHERE LockKey = {lockKey}
-                  AND (HolderId IS NULL OR ExpiresOnUtc <= {now})",
-            cancellationToken).ConfigureAwait(false);
-
-        if (updated == 0)
+        try
         {
-            try
+            var holderId = Guid.NewGuid();
+            var now = DateTime.UtcNow;
+            var expires = now + leaseDuration;
+
+            await using var scope = _scopeFactory.CreateAsyncScope();
+            var ctx = scope.ServiceProvider.GetRequiredService<DbContext>();
+
+            await using var tx = await ctx.Database.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+
+            var updated = await ctx.Database.ExecuteSqlInterpolatedAsync(
+                $@"UPDATE OrionGuard_OutboxLocks
+                      SET HolderId = {holderId}, AcquiredOnUtc = {now}, ExpiresOnUtc = {expires}
+                    WHERE LockKey = {lockKey}
+                      AND (HolderId IS NULL OR ExpiresOnUtc <= {now})",
+                cancellationToken).ConfigureAwait(false);
+
+            if (updated == 0)
             {
-                await ctx.Database.ExecuteSqlInterpolatedAsync(
-                    $@"INSERT INTO OrionGuard_OutboxLocks (LockKey, HolderId, AcquiredOnUtc, ExpiresOnUtc)
-                       SELECT {lockKey}, {holderId}, {now}, {expires}
-                       WHERE NOT EXISTS (SELECT 1 FROM OrionGuard_OutboxLocks WHERE LockKey = {lockKey})",
-                    cancellationToken).ConfigureAwait(false);
+                try
+                {
+                    await ctx.Database.ExecuteSqlInterpolatedAsync(
+                        $@"INSERT INTO OrionGuard_OutboxLocks (LockKey, HolderId, AcquiredOnUtc, ExpiresOnUtc)
+                           SELECT {lockKey}, {holderId}, {now}, {expires}
+                           WHERE NOT EXISTS (SELECT 1 FROM OrionGuard_OutboxLocks WHERE LockKey = {lockKey})",
+                        cancellationToken).ConfigureAwait(false);
+                }
+                catch (DbUpdateException)
+                {
+                    await tx.RollbackAsync(cancellationToken).ConfigureAwait(false);
+                    return null;
+                }
             }
-            catch (DbUpdateException)
+
+            await tx.CommitAsync(cancellationToken).ConfigureAwait(false);
+
+            var ownerCheck = await ctx.Set<OutboxLock>().AsNoTracking()
+                .Where(x => x.LockKey == lockKey)
+                .Select(x => x.HolderId)
+                .FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);
+
+            if (ownerCheck != holderId)
             {
-                await tx.RollbackAsync(cancellationToken).ConfigureAwait(false);
                 return null;
             }
+
+            return new Handle(this, lockKey, holderId);
         }
-
-        await tx.CommitAsync(cancellationToken).ConfigureAwait(false);
-
-        var ownerCheck = await ctx.Set<OutboxLock>().AsNoTracking()
-            .Where(x => x.LockKey == lockKey)
-            .Select(x => x.HolderId)
-            .FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);
-
-        if (ownerCheck != holderId)
+        catch (Exception ex) when (IsMissingTable(ex))
         {
+            LogMissingTableOnce();
             return null;
         }
-
-        return new Handle(this, lockKey, holderId);
     }
 
     private async Task ReleaseAsync(string lockKey, Guid holderId, CancellationToken cancellationToken = default)
     {
-        await using var scope = _scopeFactory.CreateAsyncScope();
-        var ctx = scope.ServiceProvider.GetRequiredService<DbContext>();
-        var now = DateTime.UtcNow;
-        await ctx.Database.ExecuteSqlInterpolatedAsync(
-            $@"UPDATE OrionGuard_OutboxLocks
-                  SET HolderId = NULL, ExpiresOnUtc = {now}
-                WHERE LockKey = {lockKey} AND HolderId = {holderId}",
-            cancellationToken).ConfigureAwait(false);
+        try
+        {
+            await using var scope = _scopeFactory.CreateAsyncScope();
+            var ctx = scope.ServiceProvider.GetRequiredService<DbContext>();
+            var now = DateTime.UtcNow;
+            await ctx.Database.ExecuteSqlInterpolatedAsync(
+                $@"UPDATE OrionGuard_OutboxLocks
+                      SET HolderId = NULL, ExpiresOnUtc = {now}
+                    WHERE LockKey = {lockKey} AND HolderId = {holderId}",
+                cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (IsMissingTable(ex))
+        {
+            // table dropped between acquire and release — nothing to clean up.
+        }
+    }
+
+    private static bool IsMissingTable(Exception ex)
+    {
+        var msg = ex.Message;
+        if (string.IsNullOrEmpty(msg)) return false;
+        return msg.Contains("no such table", StringComparison.OrdinalIgnoreCase)
+            || msg.Contains("Invalid object name", StringComparison.OrdinalIgnoreCase)
+            || msg.Contains("does not exist", StringComparison.OrdinalIgnoreCase)
+            || msg.Contains("doesn't exist", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private void LogMissingTableOnce()
+    {
+        if (Interlocked.Exchange(ref _missingTableWarned, 1) == 0)
+        {
+            _logger?.LogWarning(
+                "OrionGuard_OutboxLocks table not found. Distributed locking is disabled until the v6.4.0 migration is applied. " +
+                "Single-instance consumers who do not want this migration should call opts.UseDistributedLock<NullDistributedLock>().");
+        }
     }
 
     private sealed class Handle(SkipLockedDistributedLock owner, string lockKey, Guid holderId) : IDistributedLockHandle

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Locking/SkipLockedDistributedLock.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Locking/SkipLockedDistributedLock.cs
@@ -1,0 +1,113 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Locking;
+
+/// <summary>
+/// Default DB-backed <see cref="IDistributedLock"/> implementation. Uses an <see cref="OutboxLock"/>
+/// row per lock key in the consumer's <c>OrionGuard_OutboxLocks</c> table. Provider-agnostic — all
+/// SQL is issued through EF Core. Lease-based; expired holders are taken over by fresh callers.
+/// </summary>
+public sealed class SkipLockedDistributedLock : IDistributedLock
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<SkipLockedDistributedLock>? _logger;
+
+    public SkipLockedDistributedLock(
+        IServiceScopeFactory scopeFactory,
+        ILogger<SkipLockedDistributedLock>? logger = null)
+    {
+        ArgumentNullException.ThrowIfNull(scopeFactory);
+        _scopeFactory = scopeFactory;
+        _logger = logger;
+    }
+
+    public async Task<IDistributedLockHandle?> TryAcquireAsync(
+        string lockKey,
+        TimeSpan leaseDuration,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(lockKey);
+        if (leaseDuration <= TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(leaseDuration), "Lease must be > 0.");
+
+        var holderId = Guid.NewGuid();
+        var now = DateTime.UtcNow;
+        var expires = now + leaseDuration;
+
+        await using var scope = _scopeFactory.CreateAsyncScope();
+        var ctx = scope.ServiceProvider.GetRequiredService<DbContext>();
+
+        await using var tx = await ctx.Database.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+
+        var updated = await ctx.Database.ExecuteSqlInterpolatedAsync(
+            $@"UPDATE OrionGuard_OutboxLocks
+                  SET HolderId = {holderId}, AcquiredOnUtc = {now}, ExpiresOnUtc = {expires}
+                WHERE LockKey = {lockKey}
+                  AND (HolderId IS NULL OR ExpiresOnUtc <= {now})",
+            cancellationToken).ConfigureAwait(false);
+
+        if (updated == 0)
+        {
+            try
+            {
+                await ctx.Database.ExecuteSqlInterpolatedAsync(
+                    $@"INSERT INTO OrionGuard_OutboxLocks (LockKey, HolderId, AcquiredOnUtc, ExpiresOnUtc)
+                       SELECT {lockKey}, {holderId}, {now}, {expires}
+                       WHERE NOT EXISTS (SELECT 1 FROM OrionGuard_OutboxLocks WHERE LockKey = {lockKey})",
+                    cancellationToken).ConfigureAwait(false);
+            }
+            catch (DbUpdateException)
+            {
+                await tx.RollbackAsync(cancellationToken).ConfigureAwait(false);
+                return null;
+            }
+        }
+
+        await tx.CommitAsync(cancellationToken).ConfigureAwait(false);
+
+        var ownerCheck = await ctx.Set<OutboxLock>().AsNoTracking()
+            .Where(x => x.LockKey == lockKey)
+            .Select(x => x.HolderId)
+            .FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);
+
+        if (ownerCheck != holderId)
+        {
+            return null;
+        }
+
+        return new Handle(this, lockKey, holderId);
+    }
+
+    private async Task ReleaseAsync(string lockKey, Guid holderId, CancellationToken cancellationToken = default)
+    {
+        await using var scope = _scopeFactory.CreateAsyncScope();
+        var ctx = scope.ServiceProvider.GetRequiredService<DbContext>();
+        var now = DateTime.UtcNow;
+        await ctx.Database.ExecuteSqlInterpolatedAsync(
+            $@"UPDATE OrionGuard_OutboxLocks
+                  SET HolderId = NULL, ExpiresOnUtc = {now}
+                WHERE LockKey = {lockKey} AND HolderId = {holderId}",
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    private sealed class Handle(SkipLockedDistributedLock owner, string lockKey, Guid holderId) : IDistributedLockHandle
+    {
+        public string LockKey => lockKey;
+
+        public async ValueTask DisposeAsync()
+        {
+            try
+            {
+                await owner.ReleaseAsync(lockKey, holderId).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                owner._logger?.LogWarning(ex,
+                    "Failed to release distributed lock '{LockKey}'. Lease will expire naturally.",
+                    lockKey);
+            }
+        }
+    }
+}

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Locking/SkipLockedDistributedLock.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Locking/SkipLockedDistributedLock.cs
@@ -9,6 +9,22 @@ namespace Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Locking;
 /// row per lock key in the consumer's <c>OrionGuard_OutboxLocks</c> table. Provider-agnostic — all
 /// SQL is issued through EF Core. Lease-based; expired holders are taken over by fresh callers.
 /// </summary>
+/// <remarks>
+/// <para>
+/// Concurrency contract: acquisition is correct but <b>best-effort and lease-bounded</b>, not a
+/// hard mutual-exclusion primitive. The conditional <c>UPDATE ... WHERE (HolderId IS NULL OR
+/// ExpiresOnUtc &lt;= now)</c> serializes concurrent acquirers via row locks on PostgreSQL, SQL
+/// Server, and MySQL; the post-commit owner-check confirms which acquirer won. Under contention
+/// the losers return <see langword="null"/> and retry on the next poll — brief lock starvation
+/// (one polling cycle) is possible but never double-ownership of a fresh lease.
+/// </para>
+/// <para>
+/// If a holder's lease expires before it disposes the handle (e.g. a batch outran
+/// <c>LockLeaseDuration</c>), another caller may take over. Outbox dispatch is therefore
+/// at-least-once: consumer event handlers must be idempotent. This is by design — see the
+/// v6.4.0 design spec, section 6.6.
+/// </para>
+/// </remarks>
 public sealed class SkipLockedDistributedLock : IDistributedLock
 {
     private readonly IServiceScopeFactory _scopeFactory;
@@ -70,6 +86,9 @@ public sealed class SkipLockedDistributedLock : IDistributedLock
 
             await tx.CommitAsync(cancellationToken).ConfigureAwait(false);
 
+            // Why: authoritative arbiter for the INSERT race. When the conditional UPDATE matched
+            // nothing we attempted an INSERT that inserts 0 rows if a concurrent caller won first;
+            // reading HolderId back tells us definitively whether this caller owns the lock.
             var ownerCheck = await ctx.Set<OutboxLock>().AsNoTracking()
                 .Where(x => x.LockKey == lockKey)
                 .Select(x => x.HolderId)

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/OutboxDispatcherHostedService.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/OutboxDispatcherHostedService.cs
@@ -155,13 +155,31 @@ public sealed class OutboxDispatcherHostedService : BackgroundService
             }
             try
             {
-                var type = Type.GetType(msg.EventType);
+                // Resolution: registry first, AQN fallback if enabled. Why: the registry decouples
+                // persisted payloads from internal type identity, while AQN preserves v6.3 source
+                // compatibility for consumers who have not yet adopted logical names.
+                Type? type;
+                if (typeMap.TryResolve(msg.EventType, out var resolved))
+                {
+                    type = resolved;
+                }
+                else if (typeMapOptions.AllowAssemblyQualifiedNameFallback)
+                {
+                    type = Type.GetType(msg.EventType);
+                }
+                else
+                {
+                    type = null;
+                }
+
                 if (type is null)
                 {
                     // Why: an unresolvable type cannot become resolvable without a redeployment,
-                    // so retrying is pointless. Dead-letter immediately with a clear error marker.
+                    // so retrying is pointless. Dead-letter immediately with a clear error marker
+                    // that records the current fallback state for operators.
                     msg.Error = $"TYPE_NOT_FOUND: cannot resolve event type '{msg.EventType}'. " +
-                                "Type was renamed, moved, or its assembly is not loaded.";
+                                $"Registry has no mapping and AQN fallback is " +
+                                $"{(typeMapOptions.AllowAssemblyQualifiedNameFallback ? "enabled but resolution failed" : "disabled")}.";
                     msg.ProcessedOnUtc = DateTime.UtcNow;
                     logger?.LogWarning(
                         "Outbox row {RowId} dead-lettered: type '{EventType}' could not be resolved.",

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/OutboxDispatcherHostedService.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/OutboxDispatcherHostedService.cs
@@ -6,6 +6,8 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Moongazing.OrionGuard.Domain.Events;
+using Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Locking;
+using Moongazing.OrionGuard.EntityFrameworkCore.Outbox.TypeMap;
 
 namespace Moongazing.OrionGuard.EntityFrameworkCore.Outbox;
 
@@ -28,20 +30,42 @@ public sealed class OutboxDispatcherHostedService : BackgroundService
 
     private readonly OutboxOptions options;
     private readonly IServiceScopeFactory scopeFactory;
+    private readonly IDistributedLock distributedLock;
+    private readonly OutboxTypeMapRegistry typeMap;
+    private readonly OutboxTypeMapOptions typeMapOptions;
     private readonly ILogger<OutboxDispatcherHostedService>? logger;
 
     /// <summary>Initializes a new worker.</summary>
     /// <param name="options">Outbox dispatch configuration.</param>
     /// <param name="scopeFactory">Factory used to create per-batch DI scopes for resolving <see cref="DbContext"/> and <see cref="IDomainEventDispatcher"/>.</param>
-    /// <param name="logger">Optional logger used to surface a startup warning about the single-instance assumption.</param>
+    /// <param name="distributedLock">
+    /// Distributed lock used to coordinate dispatcher instances. When <see langword="null"/>, a
+    /// <see cref="NullDistributedLock"/> is used (single-instance behaviour).
+    /// </param>
+    /// <param name="typeMap">
+    /// Logical-name registry consulted when resolving <see cref="OutboxMessage.EventType"/>. When
+    /// <see langword="null"/>, an empty registry is used and resolution falls back to AQN per
+    /// <paramref name="typeMapOptions"/>.
+    /// </param>
+    /// <param name="typeMapOptions">
+    /// Controls the AQN fallback behaviour when the registry has no mapping. When <see langword="null"/>,
+    /// defaults preserve v6.3 source compatibility (AQN fallback enabled).
+    /// </param>
+    /// <param name="logger">Optional logger used to surface startup and per-row diagnostic messages.</param>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="options"/> or <paramref name="scopeFactory"/> is <see langword="null"/>.</exception>
     public OutboxDispatcherHostedService(
         OutboxOptions options,
         IServiceScopeFactory scopeFactory,
+        IDistributedLock? distributedLock = null,
+        OutboxTypeMapRegistry? typeMap = null,
+        OutboxTypeMapOptions? typeMapOptions = null,
         ILogger<OutboxDispatcherHostedService>? logger = null)
     {
         this.options = options ?? throw new ArgumentNullException(nameof(options));
         this.scopeFactory = scopeFactory ?? throw new ArgumentNullException(nameof(scopeFactory));
+        this.distributedLock = distributedLock ?? new NullDistributedLock();
+        this.typeMap = typeMap ?? new OutboxTypeMapRegistry();
+        this.typeMapOptions = typeMapOptions ?? new OutboxTypeMapOptions();
         this.logger = logger;
     }
 

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/OutboxDispatcherHostedService.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/OutboxDispatcherHostedService.cs
@@ -18,15 +18,15 @@ namespace Moongazing.OrionGuard.EntityFrameworkCore.Outbox;
 /// after <see cref="OutboxOptions.MaxRetries"/> attempts the row is dead-lettered (marked processed).
 /// </summary>
 /// <remarks>
-/// IMPORTANT: This v6.3.0 implementation assumes a single instance per database.
-/// Concurrent instances will double-dispatch events because there is no row-level
-/// locking. If you scale horizontally (e.g. Kubernetes with replicas &gt; 1),
-/// either pin the worker to one replica via a leader-election mechanism, or run
-/// it in a dedicated singleton service. Distributed locking lands in v6.4.
+/// Multi-instance safety: at startup the worker resolves an <see cref="IDistributedLock"/>
+/// (default <see cref="SkipLockedDistributedLock"/>) and acquires <see cref="OutboxOptions.LockKey"/>
+/// before each batch. Instances that fail to acquire the lock sleep and retry, so only one replica
+/// dispatches at a time. Pin to <see cref="NullDistributedLock"/> for single-instance deployments
+/// that do not want to apply the <c>OrionGuard_OutboxLocks</c> migration.
 /// </remarks>
 public sealed class OutboxDispatcherHostedService : BackgroundService
 {
-    private static readonly ActivitySource OutboxActivitySource = new("Moongazing.OrionGuard.DomainEvents", "6.3.0");
+    private static readonly ActivitySource OutboxActivitySource = new("Moongazing.OrionGuard.DomainEvents", "6.4.0");
 
     private readonly OutboxOptions options;
     private readonly IServiceScopeFactory scopeFactory;
@@ -76,15 +76,26 @@ public sealed class OutboxDispatcherHostedService : BackgroundService
     [RequiresDynamicCode("JsonSerializer.Deserialize(string, Type) requires runtime code generation under AOT. Use System.Text.Json source generation for full AOT support.")]
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        logger?.LogWarning(
-            "OrionGuard outbox dispatcher started. NOTE: this v6.3.0 implementation assumes a SINGLE instance per database. " +
-            "Running multiple instances concurrently will double-dispatch every event. " +
-            "Distributed locking lands in v6.4.");
+        logger?.LogInformation(
+            "OrionGuard outbox dispatcher started with distributed locking key '{LockKey}' (lease {Lease}).",
+            options.LockKey, options.LockLeaseDuration);
 
         while (!stoppingToken.IsCancellationRequested)
         {
             try
             {
+                await using var handle = await distributedLock.TryAcquireAsync(
+                    options.LockKey,
+                    options.LockLeaseDuration,
+                    stoppingToken).ConfigureAwait(false);
+
+                if (handle is null)
+                {
+                    // Why: another instance holds the lease. Sleep and retry — do not dispatch.
+                    await Task.Delay(options.PollingInterval, stoppingToken).ConfigureAwait(false);
+                    continue;
+                }
+
                 await ProcessBatchAsync(stoppingToken).ConfigureAwait(false);
             }
             catch (OperationCanceledException)

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/OutboxOptions.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/OutboxOptions.cs
@@ -7,6 +7,8 @@ public sealed class OutboxOptions
     private int batchSize = 100;
     private int maxRetries = 5;
     private string tableName = "OrionGuard_Outbox";
+    private string lockKey = "orion_guard_outbox_dispatcher";
+    private TimeSpan lockLeaseDuration = TimeSpan.FromSeconds(30);
 
     /// <summary>How frequently the worker polls for unprocessed rows. Must be &gt; 0. Default 5s.</summary>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when set to a non-positive value.</exception>
@@ -68,6 +70,43 @@ public sealed class OutboxOptions
                 throw new ArgumentException($"{nameof(TableName)} cannot be null or whitespace.", nameof(value));
             }
             tableName = value;
+        }
+    }
+
+    /// <summary>
+    /// Lock key used by <see cref="Locking.IDistributedLock"/> to coordinate dispatcher instances.
+    /// Cannot be null or whitespace. Default <c>orion_guard_outbox_dispatcher</c>.
+    /// </summary>
+    /// <exception cref="ArgumentException">Thrown when set to null, empty, or whitespace.</exception>
+    public string LockKey
+    {
+        get => lockKey;
+        set
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                throw new ArgumentException($"{nameof(LockKey)} cannot be null or whitespace.", nameof(value));
+            }
+            lockKey = value;
+        }
+    }
+
+    /// <summary>
+    /// Lease duration for the distributed lock. Must exceed the wall-clock cost of a single
+    /// <see cref="OutboxDispatcherHostedService.ProcessBatchAsync"/> call. Must be &gt; 0. Default 30s.
+    /// </summary>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when set to a non-positive value.</exception>
+    public TimeSpan LockLeaseDuration
+    {
+        get => lockLeaseDuration;
+        set
+        {
+            if (value <= TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(nameof(value), value,
+                    $"{nameof(LockLeaseDuration)} must be greater than zero.");
+            }
+            lockLeaseDuration = value;
         }
     }
 }

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/TypeMap/OutboxTypeMapOptions.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/TypeMap/OutboxTypeMapOptions.cs
@@ -1,0 +1,12 @@
+namespace Moongazing.OrionGuard.EntityFrameworkCore.Outbox.TypeMap;
+
+/// <summary>Controls fallback behaviour when an outbox row's <c>EventType</c> is not in the registry.</summary>
+public sealed class OutboxTypeMapOptions
+{
+    /// <summary>
+    /// When true, the dispatcher falls back to <see cref="Type.GetType(string)"/> for event types not
+    /// registered in the <see cref="OutboxTypeMapRegistry"/>. Default <see langword="true"/> for v6.3 source compatibility.
+    /// Set false for AOT-only deployments.
+    /// </summary>
+    public bool AllowAssemblyQualifiedNameFallback { get; set; } = true;
+}

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/TypeMap/OutboxTypeMapRegistry.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/TypeMap/OutboxTypeMapRegistry.cs
@@ -1,0 +1,46 @@
+using System.Diagnostics.CodeAnalysis;
+using Moongazing.OrionGuard.Domain.Events;
+
+namespace Moongazing.OrionGuard.EntityFrameworkCore.Outbox.TypeMap;
+
+/// <summary>
+/// Maps stable logical names (e.g. <c>"user.registered"</c>) to CLR event types. Used by the outbox
+/// dispatcher to avoid <see cref="Type.GetType(string)"/> reflection and to decouple persisted
+/// payloads from internal type identity. Populated once at startup; no thread-safety on <c>Map</c>.
+/// </summary>
+public sealed class OutboxTypeMapRegistry
+{
+    private readonly Dictionary<string, Type> _byName = new(StringComparer.Ordinal);
+    private readonly Dictionary<Type, string> _byType = new();
+
+    /// <summary>Maps an event type to a logical name. Throws on collision (same name to different type, or vice versa).</summary>
+    public OutboxTypeMapRegistry Map<TEvent>(string logicalName) where TEvent : IDomainEvent
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(logicalName);
+
+        var type = typeof(TEvent);
+
+        if (_byName.TryGetValue(logicalName, out var existingType) && existingType != type)
+        {
+            throw new InvalidOperationException(
+                $"Outbox type map collision: '{logicalName}' is already mapped to {existingType.FullName}.");
+        }
+        if (_byType.TryGetValue(type, out var existingName) && existingName != logicalName)
+        {
+            throw new InvalidOperationException(
+                $"Outbox type map collision: {type.FullName} is already mapped to '{existingName}'.");
+        }
+
+        _byName[logicalName] = type;
+        _byType[type] = logicalName;
+        return this;
+    }
+
+    /// <summary>Attempts to resolve a logical name to its registered CLR type.</summary>
+    public bool TryResolve(string logicalName, [NotNullWhen(true)] out Type? type)
+        => _byName.TryGetValue(logicalName, out type);
+
+    /// <summary>Attempts to resolve a CLR type to its registered logical name.</summary>
+    public bool TryGetLogicalName(Type type, [NotNullWhen(true)] out string? logicalName)
+        => _byType.TryGetValue(type, out logicalName);
+}

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/ServiceCollectionExtensions.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/ServiceCollectionExtensions.cs
@@ -26,11 +26,11 @@ public static class ServiceCollectionExtensions
     /// inside their <c>OnModelCreating</c> override using the configured <see cref="OutboxOptions.TableName"/>;
     /// the <see cref="OutboxDispatcherHostedService"/> is registered automatically.
     /// <para>
-    /// IMPORTANT: The v6.3.0 outbox dispatcher assumes a single instance per database.
-    /// Concurrent instances will double-dispatch events because there is no row-level
-    /// locking. If you scale horizontally (e.g. Kubernetes with replicas &gt; 1),
-    /// either pin the worker to one replica via a leader-election mechanism, or run
-    /// it in a dedicated singleton service. Distributed locking lands in v6.4.
+    /// Multi-instance deployments are safe by default: the dispatcher uses
+    /// <see cref="SkipLockedDistributedLock"/> against the <c>OrionGuard_OutboxLocks</c> table so
+    /// only one replica dispatches at a time. Single-instance consumers who do not want this
+    /// migration can opt into <see cref="NullDistributedLock"/> by registering it before calling
+    /// this method.
     /// </para>
     /// </remarks>
     public static IServiceCollection AddOrionGuardEfCore<TDbContext>(

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/ServiceCollectionExtensions.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/ServiceCollectionExtensions.cs
@@ -64,6 +64,14 @@ public static class ServiceCollectionExtensions
                 sp.GetRequiredService<OutboxTypeMapOptions>(),
                 sp.GetService<ILogger<OutboxDispatcherHostedService>>()));
         }
+
+        // Apply fluent customizations (UseDistributedLock / UseOutboxTypeMap / UseOutboxArchival)
+        // last so they can Replace the defaults registered above.
+        foreach (var customize in options.ServiceCustomizations)
+        {
+            customize(services);
+        }
+
         return services;
     }
 }

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/ServiceCollectionExtensions.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/ServiceCollectionExtensions.cs
@@ -4,6 +4,8 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Moongazing.OrionGuard.EntityFrameworkCore.Outbox;
+using Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Locking;
+using Moongazing.OrionGuard.EntityFrameworkCore.Outbox.TypeMap;
 
 namespace Moongazing.OrionGuard.EntityFrameworkCore;
 
@@ -47,9 +49,19 @@ public static class ServiceCollectionExtensions
 
         if (options.Strategy == DomainEventDispatchStrategy.Outbox)
         {
+            // Default outbox infrastructure: DB-backed distributed lock + empty logical-name
+            // registry with AQN fallback enabled (v6.3 source-compatible). Consumers can override
+            // by registering their own implementations BEFORE calling AddOrionGuardEfCore.
+            services.TryAddSingleton<IDistributedLock, SkipLockedDistributedLock>();
+            services.TryAddSingleton(new OutboxTypeMapRegistry());
+            services.TryAddSingleton(new OutboxTypeMapOptions());
+
             services.AddHostedService(sp => new OutboxDispatcherHostedService(
                 sp.GetRequiredService<OutboxOptions>(),
                 sp.GetRequiredService<IServiceScopeFactory>(),
+                sp.GetRequiredService<IDistributedLock>(),
+                sp.GetRequiredService<OutboxTypeMapRegistry>(),
+                sp.GetRequiredService<OutboxTypeMapOptions>(),
                 sp.GetService<ILogger<OutboxDispatcherHostedService>>()));
         }
         return services;

--- a/src/Moongazing.OrionGuard.Generators/Moongazing.OrionGuard.Generators.csproj
+++ b/src/Moongazing.OrionGuard.Generators/Moongazing.OrionGuard.Generators.csproj
@@ -8,7 +8,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>CS1591</NoWarn>
     <PackageId>OrionGuard.Generators</PackageId>
-    <Version>6.3.0</Version>
+    <Version>6.4.0</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Source generator for OrionGuard. Generates [GenerateValidator] validators, [StronglyTypedId&lt;TValue&gt;] strongly-typed id types (EF Core ValueConverter, System.Text.Json JsonConverter, TypeConverter companions), and supports NativeAOT-compatible reflection-free workflows.</Description>
     <PackageTags>guard;validation;source-generator;roslyn;nativeaot;codegen;ddd;strongly-typed-id</PackageTags>

--- a/src/Moongazing.OrionGuard.Generators/StronglyTypedIds/StronglyTypedIdAttribute.cs
+++ b/src/Moongazing.OrionGuard.Generators/StronglyTypedIds/StronglyTypedIdAttribute.cs
@@ -17,11 +17,16 @@ namespace Moongazing.OrionGuard.Domain.Primitives
 {
     /// <summary>
     /// Marks a readonly partial struct as a strongly-typed id backed by the specified primitive type.
-    /// The OrionGuard source generator emits equality, comparison, conversion members, as well as
-    /// EF Core ValueConverter, System.Text.Json converter, and TypeConverter companion types.
     /// </summary>
+    /// <remarks>
+    /// DEPRECATED. This generator is superseded by the standalone OrionKey package. Install
+    /// the OrionKey NuGet package and use [OrionId&lt;TValue&gt;] or [OrionId&lt;TValue, TStrategy&gt;]
+    /// instead. The OrionGuard generator still works but will be removed in v7.0.0.
+    /// See https://www.nuget.org/packages/OrionKey.
+    /// </remarks>
     /// <typeparam name=""TValue"">Underlying primitive type. Supported: System.Guid, int, long,
     /// string, System.Ulid (net9.0+).</typeparam>
+    [System.Obsolete(""OrionGuard's [StronglyTypedId] is superseded by the standalone OrionKey package. Install OrionKey and use [OrionId<TValue>] or [OrionId<TValue, TStrategy>] instead - see https://www.nuget.org/packages/OrionKey. OrionGuard's generator will be removed in v7.0.0."")]
     [System.AttributeUsage(System.AttributeTargets.Struct, Inherited = false, AllowMultiple = false)]
     internal sealed class StronglyTypedIdAttribute<TValue> : System.Attribute { }
 }

--- a/src/Moongazing.OrionGuard.Grpc/Moongazing.OrionGuard.Grpc.csproj
+++ b/src/Moongazing.OrionGuard.Grpc/Moongazing.OrionGuard.Grpc.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Grpc</PackageId>
-    <Version>6.3.0</Version>
+    <Version>6.4.0</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>gRPC integration for OrionGuard validation library. Provides server interceptor for automatic request validation in gRPC services.</Description>
     <PackageTags>guard;validation;grpc;interceptor;protobuf;microservices</PackageTags>

--- a/src/Moongazing.OrionGuard.MediatR/Moongazing.OrionGuard.MediatR.csproj
+++ b/src/Moongazing.OrionGuard.MediatR/Moongazing.OrionGuard.MediatR.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.MediatR</PackageId>
-    <Version>6.3.0</Version>
+    <Version>6.4.0</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>MediatR integration for OrionGuard validation library. Provides ValidationBehavior pipeline behavior for automatic request validation in CQRS pipelines.</Description>
     <PackageTags>guard;validation;mediatr;cqrs;pipeline;behavior</PackageTags>

--- a/src/Moongazing.OrionGuard.OpenTelemetry/DomainEvents/OrionGuardDomainEventTelemetry.cs
+++ b/src/Moongazing.OrionGuard.OpenTelemetry/DomainEvents/OrionGuardDomainEventTelemetry.cs
@@ -15,8 +15,8 @@ public static class OrionGuardDomainEventTelemetry
     /// <summary>The Meter name registered for domain-event metrics.</summary>
     public const string MeterName = "Moongazing.OrionGuard.DomainEvents";
 
-    internal static readonly ActivitySource ActivitySource = new(ActivitySourceName, "6.3.0");
-    internal static readonly Meter Meter = new(MeterName, "6.3.0");
+    internal static readonly ActivitySource ActivitySource = new(ActivitySourceName, "6.4.0");
+    internal static readonly Meter Meter = new(MeterName, "6.4.0");
 
     internal static readonly Counter<long> EventsDispatched = Meter.CreateCounter<long>(
         "orionguard.domain_events.dispatched", unit: "events", description: "Total domain events dispatched");

--- a/src/Moongazing.OrionGuard.OpenTelemetry/Moongazing.OrionGuard.OpenTelemetry.csproj
+++ b/src/Moongazing.OrionGuard.OpenTelemetry/Moongazing.OrionGuard.OpenTelemetry.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.OpenTelemetry</PackageId>
-    <Version>6.3.0</Version>
+    <Version>6.4.0</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>OpenTelemetry integration for OrionGuard validation library. Provides validation metrics (success/failure rates, latency) and distributed tracing spans.</Description>
     <PackageTags>guard;validation;opentelemetry;metrics;tracing;observability</PackageTags>

--- a/src/Moongazing.OrionGuard.SignalR/Moongazing.OrionGuard.SignalR.csproj
+++ b/src/Moongazing.OrionGuard.SignalR/Moongazing.OrionGuard.SignalR.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.SignalR</PackageId>
-    <Version>6.3.0</Version>
+    <Version>6.4.0</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>SignalR integration for OrionGuard validation library. Provides Hub filter for automatic method parameter validation.</Description>
     <PackageTags>guard;validation;signalr;realtime;hub;filter</PackageTags>

--- a/src/Moongazing.OrionGuard.Swagger/Moongazing.OrionGuard.Swagger.csproj
+++ b/src/Moongazing.OrionGuard.Swagger/Moongazing.OrionGuard.Swagger.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Swagger</PackageId>
-    <Version>6.3.0</Version>
+    <Version>6.4.0</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Swagger/OpenAPI integration for OrionGuard. Auto-generates OpenAPI constraints from OrionGuard validation attributes.</Description>
     <PackageTags>guard;validation;swagger;openapi;swashbuckle</PackageTags>

--- a/src/Moongazing.OrionGuard.Testing/Moongazing.OrionGuard.Testing.csproj
+++ b/src/Moongazing.OrionGuard.Testing/Moongazing.OrionGuard.Testing.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Testing</PackageId>
-    <Version>6.3.0</Version>
+    <Version>6.4.0</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Testing helpers for OrionGuard. Provides DomainEventCapture and InMemoryDomainEventDispatcher with framework-agnostic assertions (no xUnit / NUnit / FluentAssertions dependency). Works with any test runner.</Description>
     <PackageTags>guard;validation;testing;ddd;domain-events;assertions;test-helpers</PackageTags>

--- a/src/Moongazing.OrionGuard/Core/Guard.cs
+++ b/src/Moongazing.OrionGuard/Core/Guard.cs
@@ -1,9 +1,13 @@
-﻿using Moongazing.OrionGuard.Exceptions;
+﻿using Moongazing.OrionGuard.Domain.Exceptions;
+using Moongazing.OrionGuard.Domain.Rules;
+using Moongazing.OrionGuard.Exceptions;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Moongazing.OrionGuard.Core;
 
@@ -78,6 +82,41 @@ public static class Guard
     {
         if (value)
             ThrowHelper.ThrowTrue(parameterName);
+    }
+
+    /// <summary>
+    /// Evaluates a synchronous business rule and throws <see cref="BusinessRuleValidationException"/>
+    /// when the rule reports itself broken.
+    /// </summary>
+    /// <param name="rule">The rule to evaluate. Cannot be null.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="rule"/> is null.</exception>
+    /// <exception cref="BusinessRuleValidationException">Thrown when the rule is broken.</exception>
+    public static void AgainstBrokenRule(IBusinessRule rule)
+    {
+        ArgumentNullException.ThrowIfNull(rule);
+        if (rule.IsBroken())
+        {
+            throw new BusinessRuleValidationException(rule);
+        }
+    }
+
+    /// <summary>
+    /// Evaluates an asynchronous business rule and throws <see cref="BusinessRuleValidationException"/>
+    /// when the rule reports itself broken.
+    /// </summary>
+    /// <param name="rule">The rule to evaluate. Cannot be null.</param>
+    /// <param name="cancellationToken">A token to observe while waiting for the task to complete.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="rule"/> is null.</exception>
+    /// <exception cref="BusinessRuleValidationException">Thrown when the rule is broken.</exception>
+    public static async Task AgainstBrokenRuleAsync(
+        IAsyncBusinessRule rule,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(rule);
+        if (await rule.IsBrokenAsync(cancellationToken).ConfigureAwait(false))
+        {
+            throw new BusinessRuleValidationException(rule);
+        }
     }
 
     public static void AgainstUninitializedProperties<T>(this T obj, string parameterName)

--- a/src/Moongazing.OrionGuard/Domain/Primitives/Entity.cs
+++ b/src/Moongazing.OrionGuard/Domain/Primitives/Entity.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Moongazing.OrionGuard.Core;
 using Moongazing.OrionGuard.Domain.Exceptions;
 using Moongazing.OrionGuard.Domain.Rules;
 
@@ -78,34 +79,21 @@ public abstract class Entity<TId> : IEquatable<Entity<TId>>
 
     /// <summary>
     /// Enforces a synchronous business rule. Throws <see cref="BusinessRuleValidationException"/>
-    /// if the rule reports itself as broken.
+    /// if the rule reports itself as broken. Delegates to <see cref="Guard.AgainstBrokenRule"/>.
     /// </summary>
     /// <param name="rule">The business rule to validate. Cannot be null.</param>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="rule"/> is null.</exception>
     /// <exception cref="BusinessRuleValidationException">Thrown when the rule is broken.</exception>
-    protected static void CheckRule(IBusinessRule rule)
-    {
-        ArgumentNullException.ThrowIfNull(rule);
-        if (rule.IsBroken())
-        {
-            throw new BusinessRuleValidationException(rule);
-        }
-    }
+    protected static void CheckRule(IBusinessRule rule) => Guard.AgainstBrokenRule(rule);
 
     /// <summary>
     /// Enforces an asynchronous business rule. Throws <see cref="BusinessRuleValidationException"/>
-    /// if the rule reports itself as broken.
+    /// if the rule reports itself as broken. Delegates to <see cref="Guard.AgainstBrokenRuleAsync"/>.
     /// </summary>
     /// <param name="rule">The asynchronous business rule to validate. Cannot be null.</param>
-    /// <param name="cancellationToken">The cancellation token that can be used to cancel the validation.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="rule"/> is null.</exception>
     /// <exception cref="BusinessRuleValidationException">Thrown when the rule is broken.</exception>
-    protected static async Task CheckRuleAsync(IAsyncBusinessRule rule, CancellationToken cancellationToken = default)
-    {
-        ArgumentNullException.ThrowIfNull(rule);
-        if (await rule.IsBrokenAsync(cancellationToken).ConfigureAwait(false))
-        {
-            throw new BusinessRuleValidationException(rule);
-        }
-    }
+    protected static Task CheckRuleAsync(IAsyncBusinessRule rule, CancellationToken cancellationToken = default)
+        => Guard.AgainstBrokenRuleAsync(rule, cancellationToken);
 }

--- a/src/Moongazing.OrionGuard/Domain/Rules/AsyncBusinessRule.cs
+++ b/src/Moongazing.OrionGuard/Domain/Rules/AsyncBusinessRule.cs
@@ -1,0 +1,20 @@
+namespace Moongazing.OrionGuard.Domain.Rules;
+
+/// <summary>
+/// Abstract base for asynchronous business rules. Subclasses implement <see cref="IsBrokenAsync"/>
+/// and <see cref="DefaultMessage"/>; <see cref="MessageKey"/> defaults to the CLR type name.
+/// </summary>
+public abstract class AsyncBusinessRule : IAsyncBusinessRule
+{
+    /// <inheritdoc />
+    public abstract Task<bool> IsBrokenAsync(CancellationToken cancellationToken = default);
+
+    /// <inheritdoc />
+    public abstract string DefaultMessage { get; }
+
+    /// <inheritdoc />
+    public virtual string MessageKey => GetType().Name;
+
+    /// <inheritdoc />
+    public virtual object[]? MessageArgs => null;
+}

--- a/src/Moongazing.OrionGuard/Domain/Rules/BusinessRule.cs
+++ b/src/Moongazing.OrionGuard/Domain/Rules/BusinessRule.cs
@@ -1,0 +1,20 @@
+namespace Moongazing.OrionGuard.Domain.Rules;
+
+/// <summary>
+/// Abstract base for synchronous business rules. Subclasses implement <see cref="IsBroken"/> and
+/// <see cref="DefaultMessage"/>; <see cref="MessageKey"/> defaults to the CLR type name.
+/// </summary>
+public abstract class BusinessRule : IBusinessRule
+{
+    /// <inheritdoc />
+    public abstract bool IsBroken();
+
+    /// <inheritdoc />
+    public abstract string DefaultMessage { get; }
+
+    /// <inheritdoc />
+    public virtual string MessageKey => GetType().Name;
+
+    /// <inheritdoc />
+    public virtual object[]? MessageArgs => null;
+}

--- a/src/Moongazing.OrionGuard/Moongazing.OrionGuard.csproj
+++ b/src/Moongazing.OrionGuard/Moongazing.OrionGuard.csproj
@@ -16,7 +16,7 @@
 		<OutputType>Library</OutputType>
 
 		<PackageId>OrionGuard</PackageId>
-		<Version>6.3.0</Version>
+		<Version>6.4.0</Version>
 		<Authors>Tunahan Ali Ozturk</Authors>
 		<Company>Tunahan Ali Ozturk</Company>
 		<GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/tests/Moongazing.OrionGuard.AspNetCore.Tests/ExceptionHandling/OrionGuardExceptionHandler_BusinessRuleTests.cs
+++ b/tests/Moongazing.OrionGuard.AspNetCore.Tests/ExceptionHandling/OrionGuardExceptionHandler_BusinessRuleTests.cs
@@ -1,0 +1,76 @@
+using System.Text;
+using System.Text.Json;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moongazing.OrionGuard.AspNetCore.ExceptionHandling;
+using Moongazing.OrionGuard.AspNetCore.Options;
+using Moongazing.OrionGuard.Domain.Exceptions;
+using Moongazing.OrionGuard.Domain.Rules;
+
+namespace Moongazing.OrionGuard.AspNetCore.Tests.ExceptionHandling;
+
+public class OrionGuardExceptionHandler_BusinessRuleTests
+{
+    private sealed class BrokenRule : BusinessRule
+    {
+        public override bool IsBroken() => true;
+        public override string DefaultMessage => "Order must have at least one item.";
+    }
+
+    private static (HttpContext ctx, MemoryStream body) NewContext()
+    {
+        var ctx = new DefaultHttpContext();
+        var body = new MemoryStream();
+        ctx.Response.Body = body;
+        return (ctx, body);
+    }
+
+    [Fact]
+    public async Task TryHandleAsync_ShouldReturn422_WhenUseProblemDetailsTrueAndDefaults()
+    {
+        var (ctx, body) = NewContext();
+        var options = new OrionGuardAspNetCoreOptions { UseProblemDetails = true };
+        var handler = new OrionGuardExceptionHandler(NullLogger<OrionGuardExceptionHandler>.Instance, options);
+
+        var handled = await handler.TryHandleAsync(ctx, new BusinessRuleValidationException(new BrokenRule()), CancellationToken.None);
+
+        Assert.True(handled);
+        Assert.Equal(StatusCodes.Status422UnprocessableEntity, ctx.Response.StatusCode);
+
+        body.Position = 0;
+        var pd = JsonSerializer.Deserialize<ValidationProblemDetails>(body, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        Assert.NotNull(pd);
+        Assert.True(pd!.Errors.ContainsKey(nameof(BrokenRule)));
+    }
+
+    [Fact]
+    public async Task TryHandleAsync_ShouldRespectCustomStatusCode()
+    {
+        var (ctx, body) = NewContext();
+        var options = new OrionGuardAspNetCoreOptions { UseProblemDetails = true, BusinessRuleStatusCode = StatusCodes.Status400BadRequest };
+        var handler = new OrionGuardExceptionHandler(NullLogger<OrionGuardExceptionHandler>.Instance, options);
+
+        await handler.TryHandleAsync(ctx, new BusinessRuleValidationException(new BrokenRule()), CancellationToken.None);
+
+        Assert.Equal(StatusCodes.Status400BadRequest, ctx.Response.StatusCode);
+    }
+
+    [Fact]
+    public async Task TryHandleAsync_ShouldFallBackToSimpleJson_WhenUseProblemDetailsFalse()
+    {
+        var (ctx, body) = NewContext();
+        var options = new OrionGuardAspNetCoreOptions { UseProblemDetails = false };
+        var handler = new OrionGuardExceptionHandler(NullLogger<OrionGuardExceptionHandler>.Instance, options);
+
+        var handled = await handler.TryHandleAsync(ctx, new BusinessRuleValidationException(new BrokenRule()), CancellationToken.None);
+
+        Assert.True(handled);
+        Assert.Equal(StatusCodes.Status422UnprocessableEntity, ctx.Response.StatusCode);
+
+        body.Position = 0;
+        var json = Encoding.UTF8.GetString(body.ToArray());
+        Assert.Contains(nameof(BrokenRule), json);
+        Assert.Contains("Order must have at least one item.", json);
+    }
+}

--- a/tests/Moongazing.OrionGuard.AspNetCore.Tests/Moongazing.OrionGuard.AspNetCore.Tests.csproj
+++ b/tests/Moongazing.OrionGuard.AspNetCore.Tests/Moongazing.OrionGuard.AspNetCore.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Moongazing.OrionGuard.AspNetCore\Moongazing.OrionGuard.AspNetCore.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Moongazing.OrionGuard.AspNetCore.Tests/ProblemDetails/OrionGuardProblemDetailsFactory_BusinessRuleTests.cs
+++ b/tests/Moongazing.OrionGuard.AspNetCore.Tests/ProblemDetails/OrionGuardProblemDetailsFactory_BusinessRuleTests.cs
@@ -1,0 +1,44 @@
+using Microsoft.AspNetCore.Http;
+using Moongazing.OrionGuard.AspNetCore.ProblemDetails;
+using Moongazing.OrionGuard.Domain.Exceptions;
+using Moongazing.OrionGuard.Domain.Rules;
+
+namespace Moongazing.OrionGuard.AspNetCore.Tests.ProblemDetails;
+
+public class OrionGuardProblemDetailsFactory_BusinessRuleTests
+{
+    private sealed class BrokenRule : BusinessRule
+    {
+        public override bool IsBroken() => true;
+        public override string DefaultMessage => "Order must have at least one item.";
+    }
+
+    [Fact]
+    public void Create_ShouldUse422_AsDefaultStatus()
+    {
+        var pd = OrionGuardProblemDetailsFactory.Create(new BusinessRuleValidationException(new BrokenRule()));
+        Assert.Equal(StatusCodes.Status422UnprocessableEntity, pd.Status);
+    }
+
+    [Fact]
+    public void Create_ShouldUseRuleSpecificType()
+    {
+        var pd = OrionGuardProblemDetailsFactory.Create(new BusinessRuleValidationException(new BrokenRule()));
+        Assert.Equal("https://moongazing.dev/orionguard/problems/business-rule-violation", pd.Type);
+    }
+
+    [Fact]
+    public void Create_ShouldKeyErrorsByRuleName()
+    {
+        var pd = OrionGuardProblemDetailsFactory.Create(new BusinessRuleValidationException(new BrokenRule()));
+        Assert.True(pd.Errors.ContainsKey(nameof(BrokenRule)));
+        Assert.Equal(new[] { "Order must have at least one item." }, pd.Errors[nameof(BrokenRule)]);
+    }
+
+    [Fact]
+    public void Create_ShouldUseBusinessRuleViolationTitle()
+    {
+        var pd = OrionGuardProblemDetailsFactory.Create(new BusinessRuleValidationException(new BrokenRule()));
+        Assert.Equal("Business Rule Violation", pd.Title);
+    }
+}

--- a/tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/Archival/OutboxArchivalHostedServiceTests.cs
+++ b/tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/Archival/OutboxArchivalHostedServiceTests.cs
@@ -140,6 +140,12 @@ public class OutboxArchivalHostedServiceTests : IAsyncLifetime
     }
 
     [Fact]
+    public void OutboxArchivalOptions_LockLeaseDuration_ShouldDefaultToFiveMinutes()
+    {
+        Assert.Equal(TimeSpan.FromMinutes(5), new OutboxArchivalOptions().LockLeaseDuration);
+    }
+
+    [Fact]
     public async Task ArchiveBatchAsync_ShouldRespectBatchSize()
     {
         var rows = Enumerable.Range(0, 20)

--- a/tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/Archival/OutboxArchivalHostedServiceTests.cs
+++ b/tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/Archival/OutboxArchivalHostedServiceTests.cs
@@ -1,0 +1,157 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moongazing.OrionGuard.EntityFrameworkCore.Outbox;
+using Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Archival;
+using Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Locking;
+
+namespace Moongazing.OrionGuard.EntityFrameworkCore.Tests.Outbox.Archival;
+
+public sealed class ArchivalTestFixture : IAsyncDisposable
+{
+    public SqliteConnection Connection { get; }
+    public IServiceProvider Services { get; }
+
+    public ArchivalTestFixture()
+    {
+        Connection = new SqliteConnection("Filename=:memory:");
+        Connection.Open();
+
+        var services = new ServiceCollection();
+        services.AddDbContext<ArchivalTestDbContext>(o => o.UseSqlite(Connection));
+        services.AddScoped<DbContext>(sp => sp.GetRequiredService<ArchivalTestDbContext>());
+        Services = services.BuildServiceProvider();
+
+        using var scope = Services.CreateScope();
+        var ctx = scope.ServiceProvider.GetRequiredService<ArchivalTestDbContext>();
+        ctx.Database.EnsureCreated();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await Connection.DisposeAsync();
+        if (Services is IDisposable d)
+        {
+            d.Dispose();
+        }
+    }
+}
+
+public sealed class ArchivalTestDbContext(DbContextOptions<ArchivalTestDbContext> options) : DbContext(options)
+{
+    public DbSet<OutboxMessage> Outbox => Set<OutboxMessage>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+        => modelBuilder.ApplyConfiguration(new OutboxMessageEntityTypeConfiguration("OrionGuard_Outbox"));
+}
+
+public class OutboxArchivalHostedServiceTests : IAsyncLifetime
+{
+    private ArchivalTestFixture fixture = default!;
+
+    public Task InitializeAsync()
+    {
+        fixture = new ArchivalTestFixture();
+        return Task.CompletedTask;
+    }
+
+    public async Task DisposeAsync() => await fixture.DisposeAsync();
+
+    private OutboxArchivalHostedService NewSvc(OutboxArchivalOptions opts) =>
+        new(opts,
+            fixture.Services.GetRequiredService<IServiceScopeFactory>(),
+            new NullDistributedLock(),
+            NullLogger<OutboxArchivalHostedService>.Instance);
+
+    private async Task SeedAsync(params OutboxMessage[] rows)
+    {
+        using var scope = fixture.Services.CreateScope();
+        var ctx = scope.ServiceProvider.GetRequiredService<ArchivalTestDbContext>();
+        ctx.Outbox.AddRange(rows);
+        await ctx.SaveChangesAsync();
+    }
+
+    private async Task<int> CountAsync()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var ctx = scope.ServiceProvider.GetRequiredService<ArchivalTestDbContext>();
+        return await ctx.Outbox.CountAsync();
+    }
+
+    private static OutboxMessage Row(DateTime? processedOnUtc, string? error = null) => new()
+    {
+        EventType = "test",
+        Payload = "{}",
+        OccurredOnUtc = processedOnUtc ?? DateTime.UtcNow,
+        ProcessedOnUtc = processedOnUtc,
+        Error = error,
+    };
+
+    [Fact]
+    public async Task ArchiveBatchAsync_ShouldDeleteRowsOlderThanRetention()
+    {
+        await SeedAsync(
+            Row(DateTime.UtcNow.AddDays(-45)),
+            Row(DateTime.UtcNow.AddDays(-5)),
+            Row(processedOnUtc: null));
+
+        var svc = NewSvc(new OutboxArchivalOptions
+        {
+            RetentionPeriod = TimeSpan.FromDays(30),
+            BatchSize = 10,
+            PreserveDeadLetters = true,
+        });
+
+        var deleted = await svc.ArchiveBatchAsync(CancellationToken.None);
+
+        Assert.Equal(1, deleted);
+        Assert.Equal(2, await CountAsync());
+    }
+
+    [Fact]
+    public async Task ArchiveBatchAsync_ShouldPreserveDeadLetters_WhenPreserveDeadLettersIsTrue()
+    {
+        await SeedAsync(
+            Row(DateTime.UtcNow.AddDays(-45)),
+            Row(DateTime.UtcNow.AddDays(-45), error: "boom"));
+
+        var svc = NewSvc(new OutboxArchivalOptions { PreserveDeadLetters = true });
+
+        var deleted = await svc.ArchiveBatchAsync(CancellationToken.None);
+
+        Assert.Equal(1, deleted);
+        Assert.Equal(1, await CountAsync());
+    }
+
+    [Fact]
+    public async Task ArchiveBatchAsync_ShouldDeleteDeadLetters_WhenPreserveDeadLettersIsFalse()
+    {
+        await SeedAsync(
+            Row(DateTime.UtcNow.AddDays(-45)),
+            Row(DateTime.UtcNow.AddDays(-45), error: "boom"));
+
+        var svc = NewSvc(new OutboxArchivalOptions { PreserveDeadLetters = false });
+
+        var deleted = await svc.ArchiveBatchAsync(CancellationToken.None);
+
+        Assert.Equal(2, deleted);
+        Assert.Equal(0, await CountAsync());
+    }
+
+    [Fact]
+    public async Task ArchiveBatchAsync_ShouldRespectBatchSize()
+    {
+        var rows = Enumerable.Range(0, 20)
+            .Select(i => Row(DateTime.UtcNow.AddDays(-45).AddSeconds(-i)))
+            .ToArray();
+        await SeedAsync(rows);
+
+        var svc = NewSvc(new OutboxArchivalOptions { BatchSize = 5 });
+
+        var deleted = await svc.ArchiveBatchAsync(CancellationToken.None);
+
+        Assert.Equal(5, deleted);
+        Assert.Equal(15, await CountAsync());
+    }
+}

--- a/tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/Locking/LockingTestFixture.cs
+++ b/tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/Locking/LockingTestFixture.cs
@@ -1,0 +1,41 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Locking;
+
+namespace Moongazing.OrionGuard.EntityFrameworkCore.Tests.Outbox.Locking;
+
+public sealed class LockingTestFixture : IAsyncDisposable
+{
+    public SqliteConnection Connection { get; }
+    public IServiceProvider Services { get; }
+
+    public LockingTestFixture()
+    {
+        Connection = new SqliteConnection("Filename=:memory:");
+        Connection.Open();
+
+        var services = new ServiceCollection();
+        services.AddDbContext<LockingTestDbContext>(o => o.UseSqlite(Connection));
+        services.AddScoped<DbContext>(sp => sp.GetRequiredService<LockingTestDbContext>());
+        Services = services.BuildServiceProvider();
+
+        using var scope = Services.CreateScope();
+        var ctx = scope.ServiceProvider.GetRequiredService<LockingTestDbContext>();
+        ctx.Database.EnsureCreated();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await Connection.DisposeAsync();
+        if (Services is IDisposable d) d.Dispose();
+    }
+}
+
+public sealed class LockingTestDbContext(DbContextOptions<LockingTestDbContext> options) : DbContext(options)
+{
+    public DbSet<OutboxLock> Locks => Set<OutboxLock>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+        => modelBuilder.ApplyConfiguration(new OutboxLockEntityTypeConfiguration());
+}

--- a/tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/Locking/NullDistributedLockTests.cs
+++ b/tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/Locking/NullDistributedLockTests.cs
@@ -1,0 +1,33 @@
+using Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Locking;
+
+namespace Moongazing.OrionGuard.EntityFrameworkCore.Tests.Outbox.Locking;
+
+public class NullDistributedLockTests
+{
+    [Fact]
+    public async Task TryAcquireAsync_ShouldAlwaysReturnHandle()
+    {
+        var @lock = new NullDistributedLock();
+        var handle = await @lock.TryAcquireAsync("k", TimeSpan.FromMinutes(1));
+        Assert.NotNull(handle);
+        Assert.Equal("k", handle!.LockKey);
+    }
+
+    [Fact]
+    public async Task TryAcquireAsync_ShouldReturnHandleEvenOnRepeatedCalls()
+    {
+        var @lock = new NullDistributedLock();
+        var first = await @lock.TryAcquireAsync("k", TimeSpan.FromMinutes(1));
+        var second = await @lock.TryAcquireAsync("k", TimeSpan.FromMinutes(1));
+        Assert.NotNull(first);
+        Assert.NotNull(second);
+    }
+
+    [Fact]
+    public async Task DisposeAsync_ShouldNotThrow()
+    {
+        var @lock = new NullDistributedLock();
+        var handle = await @lock.TryAcquireAsync("k", TimeSpan.FromSeconds(1));
+        await handle!.DisposeAsync();
+    }
+}

--- a/tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/Locking/SkipLockedDistributedLockConcurrencyTests.cs
+++ b/tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/Locking/SkipLockedDistributedLockConcurrencyTests.cs
@@ -1,0 +1,30 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Locking;
+
+namespace Moongazing.OrionGuard.EntityFrameworkCore.Tests.Outbox.Locking;
+
+public class SkipLockedDistributedLockConcurrencyTests : IAsyncLifetime
+{
+    private LockingTestFixture _fx = default!;
+
+    public Task InitializeAsync() { _fx = new LockingTestFixture(); return Task.CompletedTask; }
+    public async Task DisposeAsync() => await _fx.DisposeAsync();
+
+    [Fact]
+    public async Task TryAcquireAsync_ShouldHandOutExactlyOneHandle_AcrossFiveParallelCallers()
+    {
+        var @lock = new SkipLockedDistributedLock(
+            _fx.Services.GetRequiredService<IServiceScopeFactory>(),
+            NullLogger<SkipLockedDistributedLock>.Instance);
+
+        var tasks = Enumerable.Range(0, 5)
+            .Select(_ => @lock.TryAcquireAsync("k", TimeSpan.FromSeconds(30)))
+            .ToArray();
+
+        var handles = await Task.WhenAll(tasks);
+
+        Assert.Equal(1, handles.Count(h => h is not null));
+        Assert.Equal(4, handles.Count(h => h is null));
+    }
+}

--- a/tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/Locking/SkipLockedDistributedLockTests.cs
+++ b/tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/Locking/SkipLockedDistributedLockTests.cs
@@ -1,0 +1,50 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Locking;
+
+namespace Moongazing.OrionGuard.EntityFrameworkCore.Tests.Outbox.Locking;
+
+public class SkipLockedDistributedLockTests : IAsyncLifetime
+{
+    private LockingTestFixture _fx = default!;
+
+    public Task InitializeAsync() { _fx = new LockingTestFixture(); return Task.CompletedTask; }
+    public async Task DisposeAsync() => await _fx.DisposeAsync();
+
+    private SkipLockedDistributedLock NewLock() =>
+        new(_fx.Services.GetRequiredService<IServiceScopeFactory>(), NullLogger<SkipLockedDistributedLock>.Instance);
+
+    [Fact]
+    public async Task TryAcquireAsync_ShouldReturnHandle_WhenSlotIsFree()
+    {
+        var @lock = NewLock();
+        var handle = await @lock.TryAcquireAsync("k", TimeSpan.FromSeconds(30));
+        Assert.NotNull(handle);
+        Assert.Equal("k", handle!.LockKey);
+    }
+
+    [Fact]
+    public async Task TryAcquireAsync_ShouldReturnNull_WhenSlotIsHeld()
+    {
+        var @lock = NewLock();
+        var first = await @lock.TryAcquireAsync("k", TimeSpan.FromSeconds(30));
+        Assert.NotNull(first);
+
+        var second = await @lock.TryAcquireAsync("k", TimeSpan.FromSeconds(30));
+        Assert.Null(second);
+    }
+
+    [Fact]
+    public async Task TryAcquireAsync_ShouldSucceedAgain_AfterFirstHandleIsDisposed()
+    {
+        var @lock = NewLock();
+        var first = await @lock.TryAcquireAsync("k", TimeSpan.FromSeconds(30));
+        Assert.NotNull(first);
+        await first!.DisposeAsync();
+
+        var second = await @lock.TryAcquireAsync("k", TimeSpan.FromSeconds(30));
+        Assert.NotNull(second);
+    }
+}

--- a/tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/Locking/SkipLockedDistributedLockTests.cs
+++ b/tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/Locking/SkipLockedDistributedLockTests.cs
@@ -77,4 +77,36 @@ public class SkipLockedDistributedLockTests : IAsyncLifetime
         var third = await @lock.TryAcquireAsync("k", TimeSpan.FromSeconds(30));
         Assert.Null(third);
     }
+
+    private sealed class NoLockTableDbContext(DbContextOptions<NoLockTableDbContext> options) : DbContext(options)
+    {
+    }
+
+    [Fact]
+    public async Task TryAcquireAsync_ShouldReturnNull_WhenLockTableIsMissing()
+    {
+        await using var connection = new SqliteConnection("Filename=:memory:");
+        await connection.OpenAsync();
+
+        var services = new ServiceCollection();
+        services.AddDbContext<NoLockTableDbContext>(o => o.UseSqlite(connection));
+        services.AddScoped<DbContext>(sp => sp.GetRequiredService<NoLockTableDbContext>());
+        await using var sp = services.BuildServiceProvider();
+
+        using (var scope = sp.CreateScope())
+        {
+            var ctx = scope.ServiceProvider.GetRequiredService<NoLockTableDbContext>();
+            await ctx.Database.EnsureCreatedAsync();
+        }
+
+        var @lock = new SkipLockedDistributedLock(
+            sp.GetRequiredService<IServiceScopeFactory>(),
+            NullLogger<SkipLockedDistributedLock>.Instance);
+
+        var handle = await @lock.TryAcquireAsync("k", TimeSpan.FromSeconds(30));
+        Assert.Null(handle);
+
+        var handle2 = await @lock.TryAcquireAsync("k", TimeSpan.FromSeconds(30));
+        Assert.Null(handle2);
+    }
 }

--- a/tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/Locking/SkipLockedDistributedLockTests.cs
+++ b/tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/Locking/SkipLockedDistributedLockTests.cs
@@ -47,4 +47,34 @@ public class SkipLockedDistributedLockTests : IAsyncLifetime
         var second = await @lock.TryAcquireAsync("k", TimeSpan.FromSeconds(30));
         Assert.NotNull(second);
     }
+
+    [Fact]
+    public async Task TryAcquireAsync_ShouldTakeOver_WhenLeaseHasExpired()
+    {
+        var @lock = NewLock();
+        var first = await @lock.TryAcquireAsync("k", TimeSpan.FromMilliseconds(50));
+        Assert.NotNull(first);
+
+        await Task.Delay(150);
+
+        var second = await @lock.TryAcquireAsync("k", TimeSpan.FromSeconds(30));
+        Assert.NotNull(second);
+    }
+
+    [Fact]
+    public async Task DisposingExpiredHandle_ShouldBeNoOp_WhenAnotherHolderHasTakenOver()
+    {
+        var @lock = NewLock();
+        var first = await @lock.TryAcquireAsync("k", TimeSpan.FromMilliseconds(50));
+        Assert.NotNull(first);
+        await Task.Delay(150);
+
+        var second = await @lock.TryAcquireAsync("k", TimeSpan.FromSeconds(30));
+        Assert.NotNull(second);
+
+        await first!.DisposeAsync();
+
+        var third = await @lock.TryAcquireAsync("k", TimeSpan.FromSeconds(30));
+        Assert.Null(third);
+    }
 }

--- a/tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/TypeMap/OutboxInterceptor_TypeMapWriterTests.cs
+++ b/tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/TypeMap/OutboxInterceptor_TypeMapWriterTests.cs
@@ -1,0 +1,71 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Moongazing.OrionGuard.DependencyInjection;
+using Moongazing.OrionGuard.Domain.Events;
+using Moongazing.OrionGuard.EntityFrameworkCore.Outbox.TypeMap;
+using Moongazing.OrionGuard.EntityFrameworkCore.Tests.TestFixtures;
+using Moongazing.OrionGuard.Testing.DomainEvents;
+
+namespace Moongazing.OrionGuard.EntityFrameworkCore.Tests.Outbox.TypeMap;
+
+public class OutboxInterceptor_TypeMapWriterTests
+{
+    private static ServiceProvider BuildSp(OutboxTypeMapRegistry? typeMap)
+    {
+        var services = new ServiceCollection();
+        services.AddOrionGuardDomainEvents();
+        var existing = services.Single(d => d.ServiceType == typeof(IDomainEventDispatcher));
+        services.Remove(existing);
+        services.AddSingleton<IDomainEventDispatcher>(new InMemoryDomainEventDispatcher());
+
+        services.AddSingleton(new OrionGuardEfCoreOptions().UseOutbox());
+        services.AddScoped<DomainEventCollector>();
+
+        if (typeMap is not null)
+        {
+            services.AddSingleton(typeMap);
+        }
+
+        services.AddDbContext<TestDbContext>((sp, o) =>
+            o.UseSqlite("DataSource=:memory:")
+             .AddInterceptors(new DomainEventSaveChangesInterceptor(sp)));
+        return services.BuildServiceProvider();
+    }
+
+    [Fact]
+    public async Task SaveChanges_OutboxMode_WritesLogicalName_WhenTypeMapRegistered()
+    {
+        var typeMap = new OutboxTypeMapRegistry().Map<OrderShipped>("order.shipped");
+        await using var sp = BuildSp(typeMap);
+        await using var scope = sp.CreateAsyncScope();
+        var ctx = scope.ServiceProvider.GetRequiredService<TestDbContext>();
+        await ctx.Database.OpenConnectionAsync();
+        await ctx.Database.EnsureCreatedAsync();
+
+        var order = new Order(Guid.NewGuid());
+        ctx.Orders.Add(order);
+        order.Ship();
+        await ctx.SaveChangesAsync();
+
+        var row = Assert.Single(await ctx.OutboxMessages.AsNoTracking().ToListAsync());
+        Assert.Equal("order.shipped", row.EventType);
+    }
+
+    [Fact]
+    public async Task SaveChanges_OutboxMode_FallsBackToAssemblyQualifiedName_WhenNoTypeMapRegistered()
+    {
+        await using var sp = BuildSp(typeMap: null);
+        await using var scope = sp.CreateAsyncScope();
+        var ctx = scope.ServiceProvider.GetRequiredService<TestDbContext>();
+        await ctx.Database.OpenConnectionAsync();
+        await ctx.Database.EnsureCreatedAsync();
+
+        var order = new Order(Guid.NewGuid());
+        ctx.Orders.Add(order);
+        order.Ship();
+        await ctx.SaveChangesAsync();
+
+        var row = Assert.Single(await ctx.OutboxMessages.AsNoTracking().ToListAsync());
+        Assert.Equal(typeof(OrderShipped).AssemblyQualifiedName, row.EventType);
+    }
+}

--- a/tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/TypeMap/OutboxTypeMapRegistryTests.cs
+++ b/tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/TypeMap/OutboxTypeMapRegistryTests.cs
@@ -1,0 +1,57 @@
+using Moongazing.OrionGuard.Domain.Events;
+using Moongazing.OrionGuard.EntityFrameworkCore.Outbox.TypeMap;
+
+namespace Moongazing.OrionGuard.EntityFrameworkCore.Tests.Outbox.TypeMap;
+
+public class OutboxTypeMapRegistryTests
+{
+    private sealed record UserRegistered : DomainEventBase;
+    private sealed record OrderPlaced : DomainEventBase;
+
+    [Fact]
+    public void Map_ShouldStoreRoundTrip()
+    {
+        var r = new OutboxTypeMapRegistry().Map<UserRegistered>("user.registered");
+
+        Assert.True(r.TryResolve("user.registered", out var t));
+        Assert.Equal(typeof(UserRegistered), t);
+
+        Assert.True(r.TryGetLogicalName(typeof(UserRegistered), out var name));
+        Assert.Equal("user.registered", name);
+    }
+
+    [Fact]
+    public void TryResolve_ShouldReturnFalse_WhenLogicalNameUnknown()
+    {
+        var r = new OutboxTypeMapRegistry();
+        Assert.False(r.TryResolve("nope", out var t));
+        Assert.Null(t);
+    }
+
+    [Fact]
+    public void Map_ShouldThrow_WhenSameNameMapsToDifferentType()
+    {
+        var r = new OutboxTypeMapRegistry().Map<UserRegistered>("evt");
+        Assert.Throws<InvalidOperationException>(() => r.Map<OrderPlaced>("evt"));
+    }
+
+    [Fact]
+    public void Map_ShouldThrow_WhenSameTypeMapsToDifferentName()
+    {
+        var r = new OutboxTypeMapRegistry().Map<UserRegistered>("a");
+        Assert.Throws<InvalidOperationException>(() => r.Map<UserRegistered>("b"));
+    }
+
+    [Fact]
+    public void Map_ShouldBeIdempotent_WhenSameTypeAndSameName()
+    {
+        var r = new OutboxTypeMapRegistry().Map<UserRegistered>("u");
+        r.Map<UserRegistered>("u"); // no throw
+    }
+
+    [Fact]
+    public void OutboxTypeMapOptions_AllowAssemblyQualifiedNameFallback_ShouldDefaultTrue()
+    {
+        Assert.True(new OutboxTypeMapOptions().AllowAssemblyQualifiedNameFallback);
+    }
+}

--- a/tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/OutboxDispatcherTests.cs
+++ b/tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/OutboxDispatcherTests.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Moongazing.OrionGuard.DependencyInjection;
 using Moongazing.OrionGuard.Domain.Events;
 using Moongazing.OrionGuard.EntityFrameworkCore.Outbox;
+using Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Locking;
 using Moongazing.OrionGuard.EntityFrameworkCore.Tests.TestFixtures;
 using Moongazing.OrionGuard.Testing.DomainEvents;
 
@@ -244,6 +245,51 @@ public class OutboxDispatcherTests
         Assert.Throws<ArgumentException>(() => new OutboxOptions { TableName = null! });
         Assert.Throws<ArgumentException>(() => new OutboxOptions { TableName = "" });
         Assert.Throws<ArgumentException>(() => new OutboxOptions { TableName = "   " });
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenDistributedLockReturnsNull_DoesNotDispatch()
+    {
+        var dispatcher = new InMemoryDomainEventDispatcher();
+        var opts = new OutboxOptions { PollingInterval = TimeSpan.FromMilliseconds(20), BatchSize = 10, MaxRetries = 2 };
+        await using var sp = BuildSp(dispatcher, opts);
+        await using var scope = sp.CreateAsyncScope();
+        var ctx = scope.ServiceProvider.GetRequiredService<TestDbContext>();
+        await ctx.Database.OpenConnectionAsync();
+        await ctx.Database.EnsureCreatedAsync();
+
+        await SeedOutboxRowAsync(ctx, new OrderShipped(Guid.NewGuid()));
+
+        var alwaysBusy = new AlwaysBusyLock();
+        var worker = new OutboxDispatcherHostedService(
+            sp.GetRequiredService<OutboxOptions>(),
+            sp.GetRequiredService<IServiceScopeFactory>(),
+            distributedLock: alwaysBusy);
+
+        using var cts = new CancellationTokenSource();
+        await worker.StartAsync(cts.Token);
+        await Task.Delay(200);
+        await cts.CancelAsync();
+        await worker.StopAsync(default);
+
+        // Lock was attempted multiple times; nothing dispatched; row unprocessed.
+        Assert.True(alwaysBusy.AttemptCount > 0, "Expected at least one TryAcquire attempt.");
+        Assert.Empty(dispatcher.Captured);
+        var row = await ctx.OutboxMessages.AsNoTracking().SingleAsync();
+        Assert.Null(row.ProcessedOnUtc);
+    }
+
+    private sealed class AlwaysBusyLock : IDistributedLock
+    {
+        private int _attempts;
+        public int AttemptCount => Volatile.Read(ref _attempts);
+
+        public Task<IDistributedLockHandle?> TryAcquireAsync(
+            string lockKey, TimeSpan leaseDuration, CancellationToken cancellationToken = default)
+        {
+            Interlocked.Increment(ref _attempts);
+            return Task.FromResult<IDistributedLockHandle?>(null);
+        }
     }
 
     private sealed class ThrowingDispatcher : IDomainEventDispatcher

--- a/tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/OutboxDispatcherTests.cs
+++ b/tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/OutboxDispatcherTests.cs
@@ -6,6 +6,7 @@ using Moongazing.OrionGuard.DependencyInjection;
 using Moongazing.OrionGuard.Domain.Events;
 using Moongazing.OrionGuard.EntityFrameworkCore.Outbox;
 using Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Locking;
+using Moongazing.OrionGuard.EntityFrameworkCore.Outbox.TypeMap;
 using Moongazing.OrionGuard.EntityFrameworkCore.Tests.TestFixtures;
 using Moongazing.OrionGuard.Testing.DomainEvents;
 
@@ -245,6 +246,95 @@ public class OutboxDispatcherTests
         Assert.Throws<ArgumentException>(() => new OutboxOptions { TableName = null! });
         Assert.Throws<ArgumentException>(() => new OutboxOptions { TableName = "" });
         Assert.Throws<ArgumentException>(() => new OutboxOptions { TableName = "   " });
+    }
+
+    [Fact]
+    public async Task ProcessBatch_RegistryResolvesLogicalName_Dispatches()
+    {
+        var dispatcher = new InMemoryDomainEventDispatcher();
+        await using var sp = BuildSp(dispatcher);
+        await using var scope = sp.CreateAsyncScope();
+        var ctx = scope.ServiceProvider.GetRequiredService<TestDbContext>();
+        await ctx.Database.OpenConnectionAsync();
+        await ctx.Database.EnsureCreatedAsync();
+
+        // Row uses logical name, NOT AQN. Only the registry can resolve it.
+        var evt = new OrderShipped(Guid.NewGuid());
+        ctx.OutboxMessages.Add(new OutboxMessage
+        {
+            EventType = "order.shipped",
+            Payload = JsonSerializer.Serialize(evt, evt.GetType()),
+            OccurredOnUtc = evt.OccurredOnUtc,
+        });
+        await ctx.SaveChangesAsync();
+
+        var registry = new OutboxTypeMapRegistry().Map<OrderShipped>("order.shipped");
+        var worker = new OutboxDispatcherHostedService(
+            sp.GetRequiredService<OutboxOptions>(),
+            sp.GetRequiredService<IServiceScopeFactory>(),
+            typeMap: registry);
+
+        await worker.ProcessBatchAsync(default);
+
+        Assert.Single(dispatcher.Captured);
+        var row = await ctx.OutboxMessages.AsNoTracking().SingleAsync();
+        Assert.NotNull(row.ProcessedOnUtc);
+        Assert.Null(row.Error);
+    }
+
+    [Fact]
+    public async Task ProcessBatch_RegistryEmpty_AqnFallbackEnabled_DispatchesViaAqn()
+    {
+        var dispatcher = new InMemoryDomainEventDispatcher();
+        await using var sp = BuildSp(dispatcher);
+        await using var scope = sp.CreateAsyncScope();
+        var ctx = scope.ServiceProvider.GetRequiredService<TestDbContext>();
+        await ctx.Database.OpenConnectionAsync();
+        await ctx.Database.EnsureCreatedAsync();
+
+        // Default behaviour (existing tests): AQN-stamped row, empty registry, AQN fallback on.
+        await SeedOutboxRowAsync(ctx, new OrderShipped(Guid.NewGuid()));
+
+        var worker = new OutboxDispatcherHostedService(
+            sp.GetRequiredService<OutboxOptions>(),
+            sp.GetRequiredService<IServiceScopeFactory>(),
+            typeMap: new OutboxTypeMapRegistry(),
+            typeMapOptions: new OutboxTypeMapOptions { AllowAssemblyQualifiedNameFallback = true });
+
+        await worker.ProcessBatchAsync(default);
+
+        Assert.Single(dispatcher.Captured);
+        var row = await ctx.OutboxMessages.AsNoTracking().SingleAsync();
+        Assert.NotNull(row.ProcessedOnUtc);
+    }
+
+    [Fact]
+    public async Task ProcessBatch_RegistryEmpty_AqnFallbackDisabled_DeadLetters()
+    {
+        var dispatcher = new InMemoryDomainEventDispatcher();
+        await using var sp = BuildSp(dispatcher);
+        await using var scope = sp.CreateAsyncScope();
+        var ctx = scope.ServiceProvider.GetRequiredService<TestDbContext>();
+        await ctx.Database.OpenConnectionAsync();
+        await ctx.Database.EnsureCreatedAsync();
+
+        // AQN-stamped row, but registry is empty and AQN fallback is disabled.
+        await SeedOutboxRowAsync(ctx, new OrderShipped(Guid.NewGuid()));
+
+        var worker = new OutboxDispatcherHostedService(
+            sp.GetRequiredService<OutboxOptions>(),
+            sp.GetRequiredService<IServiceScopeFactory>(),
+            typeMap: new OutboxTypeMapRegistry(),
+            typeMapOptions: new OutboxTypeMapOptions { AllowAssemblyQualifiedNameFallback = false });
+
+        await worker.ProcessBatchAsync(default);
+
+        Assert.Empty(dispatcher.Captured);
+        var row = await ctx.OutboxMessages.AsNoTracking().SingleAsync();
+        Assert.NotNull(row.ProcessedOnUtc);   // dead-lettered
+        Assert.NotNull(row.Error);
+        Assert.StartsWith("TYPE_NOT_FOUND:", row.Error);
+        Assert.Contains("AQN fallback is disabled", row.Error);
     }
 
     [Fact]

--- a/tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/ServiceCollectionExtensions_v6_4_Tests.cs
+++ b/tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/ServiceCollectionExtensions_v6_4_Tests.cs
@@ -1,0 +1,78 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Archival;
+using Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Locking;
+using Moongazing.OrionGuard.EntityFrameworkCore.Outbox.TypeMap;
+
+namespace Moongazing.OrionGuard.EntityFrameworkCore.Tests;
+
+public class ServiceCollectionExtensions_v6_4_Tests
+{
+    private sealed class TestDbContext(DbContextOptions<TestDbContext> options) : DbContext(options) { }
+
+    private static IServiceCollection Bootstrap(Action<OrionGuardEfCoreOptions>? configure = null)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddDbContext<TestDbContext>(o => o.UseSqlite("Filename=:memory:"));
+        services.AddOrionGuardEfCore<TestDbContext>(o =>
+        {
+            o.UseOutbox();
+            configure?.Invoke(o);
+        });
+        return services;
+    }
+
+    [Fact]
+    public void AddOrionGuardEfCore_ShouldRegister_SkipLockedDistributedLock_ByDefault_InOutboxMode()
+    {
+        using var sp = Bootstrap().BuildServiceProvider();
+        var @lock = sp.GetRequiredService<IDistributedLock>();
+        Assert.IsType<SkipLockedDistributedLock>(@lock);
+    }
+
+    [Fact]
+    public void AddOrionGuardEfCore_ShouldHonor_UseDistributedLock_Override()
+    {
+        using var sp = Bootstrap(o => o.UseDistributedLock<NullDistributedLock>()).BuildServiceProvider();
+        var @lock = sp.GetRequiredService<IDistributedLock>();
+        Assert.IsType<NullDistributedLock>(@lock);
+    }
+
+    [Fact]
+    public void AddOrionGuardEfCore_ShouldRegister_EmptyTypeMapRegistry_ByDefault_InOutboxMode()
+    {
+        using var sp = Bootstrap().BuildServiceProvider();
+        var registry = sp.GetRequiredService<OutboxTypeMapRegistry>();
+        Assert.NotNull(registry);
+        Assert.False(registry.TryResolve("anything", out _));
+    }
+
+    [Fact]
+    public void AddOrionGuardEfCore_ShouldRegister_DefaultTypeMapOptions_InOutboxMode()
+    {
+        using var sp = Bootstrap().BuildServiceProvider();
+        var options = sp.GetRequiredService<OutboxTypeMapOptions>();
+        Assert.True(options.AllowAssemblyQualifiedNameFallback);
+    }
+
+    [Fact]
+    public void AddOrionGuardEfCore_ShouldNotRegister_OutboxArchivalHostedService_Without_OptIn()
+    {
+        using var sp = Bootstrap().BuildServiceProvider();
+        var hosted = sp.GetServices<IHostedService>();
+        Assert.DoesNotContain(hosted, h => h is OutboxArchivalHostedService);
+    }
+
+    [Fact]
+    public void AddOrionGuardEfCore_ShouldRegister_OutboxArchivalHostedService_When_OptedIn()
+    {
+        using var sp = Bootstrap(o => o.UseOutboxArchival(a => a.RetentionPeriod = TimeSpan.FromDays(7))).BuildServiceProvider();
+        var hosted = sp.GetServices<IHostedService>();
+        Assert.Contains(hosted, h => h is OutboxArchivalHostedService);
+
+        var options = sp.GetRequiredService<OutboxArchivalOptions>();
+        Assert.Equal(TimeSpan.FromDays(7), options.RetentionPeriod);
+    }
+}

--- a/tests/Moongazing.OrionGuard.Generators.Tests/StronglyTypedIdDeprecationTests.cs
+++ b/tests/Moongazing.OrionGuard.Generators.Tests/StronglyTypedIdDeprecationTests.cs
@@ -1,0 +1,46 @@
+namespace Moongazing.OrionGuard.Generators.Tests;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Moongazing.OrionGuard.Generators.StronglyTypedIds;
+
+public class StronglyTypedIdDeprecationTests
+{
+    [Fact]
+    public void StronglyTypedIdAttribute_ShouldRaiseCS0618_WhenApplied()
+    {
+        const string source = """
+            using Moongazing.OrionGuard.Domain.Primitives;
+
+            namespace App
+            {
+                [StronglyTypedId<System.Guid>]
+                public readonly partial struct OrderId { }
+            }
+            """;
+
+        var syntaxTree = CSharpSyntaxTree.ParseText(source);
+
+        var references = AppDomain.CurrentDomain.GetAssemblies()
+            .Where(a => !a.IsDynamic && !string.IsNullOrEmpty(a.Location))
+            .Select(a => (MetadataReference)MetadataReference.CreateFromFile(a.Location))
+            .ToList();
+
+        var compilation = CSharpCompilation.Create(
+            "DeprecationTestAssembly",
+            new[] { syntaxTree },
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        CSharpGeneratorDriver
+            .Create(new StronglyTypedIdGenerator().AsSourceGenerator())
+            .RunGeneratorsAndUpdateCompilation(compilation, out var updatedCompilation, out _);
+
+        var cs0618 = updatedCompilation.GetDiagnostics()
+            .Where(d => d.Id == "CS0618")
+            .ToArray();
+
+        Assert.NotEmpty(cs0618);
+        Assert.Contains(cs0618, d => d.GetMessage().Contains("OrionKey"));
+    }
+}

--- a/tests/Moongazing.OrionGuard.Tests/Core/Guard_AgainstBrokenRuleTests.cs
+++ b/tests/Moongazing.OrionGuard.Tests/Core/Guard_AgainstBrokenRuleTests.cs
@@ -1,0 +1,84 @@
+using Moongazing.OrionGuard.Core;
+using Moongazing.OrionGuard.Domain.Exceptions;
+using Moongazing.OrionGuard.Domain.Rules;
+
+namespace Moongazing.OrionGuard.Tests.Core;
+
+public class Guard_AgainstBrokenRuleTests
+{
+    private sealed class StubRule(bool isBroken) : BusinessRule
+    {
+        public override bool IsBroken() => isBroken;
+        public override string DefaultMessage => "stub broken";
+    }
+
+    private sealed class StubAsyncRule(bool isBroken) : AsyncBusinessRule
+    {
+        public override Task<bool> IsBrokenAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(isBroken);
+        public override string DefaultMessage => "stub broken async";
+    }
+
+    [Fact]
+    public void AgainstBrokenRule_ShouldNotThrow_WhenRuleIsNotBroken()
+    {
+        Guard.AgainstBrokenRule(new StubRule(false));
+    }
+
+    [Fact]
+    public void AgainstBrokenRule_ShouldThrowBusinessRuleValidationException_WhenRuleIsBroken()
+    {
+        var ex = Assert.Throws<BusinessRuleValidationException>(
+            () => Guard.AgainstBrokenRule(new StubRule(true)));
+        Assert.Equal(nameof(StubRule), ex.RuleName);
+        Assert.Equal(nameof(StubRule), ex.MessageKey);
+        Assert.Equal("stub broken", ex.Message);
+    }
+
+    [Fact]
+    public void AgainstBrokenRule_ShouldThrow_WhenRuleIsNull()
+    {
+        Assert.Throws<ArgumentNullException>(() => Guard.AgainstBrokenRule(null!));
+    }
+
+    [Fact]
+    public async Task AgainstBrokenRuleAsync_ShouldNotThrow_WhenRuleIsNotBroken()
+    {
+        await Guard.AgainstBrokenRuleAsync(new StubAsyncRule(false));
+    }
+
+    [Fact]
+    public async Task AgainstBrokenRuleAsync_ShouldThrowBusinessRuleValidationException_WhenRuleIsBroken()
+    {
+        var ex = await Assert.ThrowsAsync<BusinessRuleValidationException>(
+            () => Guard.AgainstBrokenRuleAsync(new StubAsyncRule(true)));
+        Assert.Equal(nameof(StubAsyncRule), ex.RuleName);
+        Assert.Equal("stub broken async", ex.Message);
+    }
+
+    [Fact]
+    public async Task AgainstBrokenRuleAsync_ShouldThrow_WhenRuleIsNull()
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            () => Guard.AgainstBrokenRuleAsync(null!));
+    }
+
+    [Fact]
+    public async Task AgainstBrokenRuleAsync_ShouldRespectCancellation()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => Guard.AgainstBrokenRuleAsync(new CancelObservingRule(), cts.Token));
+    }
+
+    private sealed class CancelObservingRule : AsyncBusinessRule
+    {
+        public override Task<bool> IsBrokenAsync(CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(false);
+        }
+        public override string DefaultMessage => "x";
+    }
+}

--- a/tests/Moongazing.OrionGuard.Tests/Domain/Primitives/EntityCheckRuleDelegationTests.cs
+++ b/tests/Moongazing.OrionGuard.Tests/Domain/Primitives/EntityCheckRuleDelegationTests.cs
@@ -1,0 +1,66 @@
+using Moongazing.OrionGuard.Domain.Exceptions;
+using Moongazing.OrionGuard.Domain.Primitives;
+using Moongazing.OrionGuard.Domain.Rules;
+
+namespace Moongazing.OrionGuard.Tests.Domain.Primitives;
+
+public class EntityCheckRuleDelegationTests
+{
+    private sealed class TestEntity : Entity<int>
+    {
+        public TestEntity(int id) : base(id) { }
+
+        public void EnforceSync(IBusinessRule rule) => CheckRule(rule);
+        public Task EnforceAsync(IAsyncBusinessRule rule, CancellationToken ct = default)
+            => CheckRuleAsync(rule, ct);
+    }
+
+    private sealed class StubRule(bool isBroken) : BusinessRule
+    {
+        public override bool IsBroken() => isBroken;
+        public override string DefaultMessage => "broken";
+    }
+
+    private sealed class StubAsyncRule(bool isBroken) : AsyncBusinessRule
+    {
+        public override Task<bool> IsBrokenAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(isBroken);
+        public override string DefaultMessage => "broken async";
+    }
+
+    [Fact]
+    public void CheckRule_ShouldNotThrow_WhenRuleIsNotBroken()
+    {
+        new TestEntity(1).EnforceSync(new StubRule(false));
+    }
+
+    [Fact]
+    public void CheckRule_ShouldThrowBusinessRuleValidationException_WhenRuleIsBroken()
+    {
+        var ex = Assert.Throws<BusinessRuleValidationException>(
+            () => new TestEntity(1).EnforceSync(new StubRule(true)));
+        Assert.Equal(nameof(StubRule), ex.RuleName);
+        Assert.Equal("broken", ex.Message);
+    }
+
+    [Fact]
+    public void CheckRule_ShouldThrow_WhenRuleIsNull()
+    {
+        Assert.Throws<ArgumentNullException>(() => new TestEntity(1).EnforceSync(null!));
+    }
+
+    [Fact]
+    public async Task CheckRuleAsync_ShouldThrowBusinessRuleValidationException_WhenRuleIsBroken()
+    {
+        var ex = await Assert.ThrowsAsync<BusinessRuleValidationException>(
+            () => new TestEntity(1).EnforceAsync(new StubAsyncRule(true)));
+        Assert.Equal(nameof(StubAsyncRule), ex.RuleName);
+    }
+
+    [Fact]
+    public async Task CheckRuleAsync_ShouldThrow_WhenRuleIsNull()
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            () => new TestEntity(1).EnforceAsync(null!));
+    }
+}

--- a/tests/Moongazing.OrionGuard.Tests/Domain/Rules/AsyncBusinessRuleTests.cs
+++ b/tests/Moongazing.OrionGuard.Tests/Domain/Rules/AsyncBusinessRuleTests.cs
@@ -1,0 +1,46 @@
+using Moongazing.OrionGuard.Domain.Rules;
+
+namespace Moongazing.OrionGuard.Tests.Domain.Rules;
+
+public class AsyncBusinessRuleTests
+{
+    private sealed class UniqueEmailRule(bool isBroken) : AsyncBusinessRule
+    {
+        public override Task<bool> IsBrokenAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(isBroken);
+        public override string DefaultMessage => "Email must be unique.";
+    }
+
+    [Fact]
+    public async Task IsBrokenAsync_ShouldReturnSubclassImplementation()
+    {
+        Assert.True(await new UniqueEmailRule(true).IsBrokenAsync());
+        Assert.False(await new UniqueEmailRule(false).IsBrokenAsync());
+    }
+
+    [Fact]
+    public void MessageKey_ShouldDefaultToTypeName()
+    {
+        var rule = new UniqueEmailRule(true);
+        Assert.Equal(nameof(UniqueEmailRule), rule.MessageKey);
+    }
+
+    [Fact]
+    public async Task IsBrokenAsync_ShouldRespectCancellation()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        var rule = new ThrowingRule();
+        await Assert.ThrowsAsync<OperationCanceledException>(() => rule.IsBrokenAsync(cts.Token));
+    }
+
+    private sealed class ThrowingRule : AsyncBusinessRule
+    {
+        public override Task<bool> IsBrokenAsync(CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(false);
+        }
+        public override string DefaultMessage => "x";
+    }
+}

--- a/tests/Moongazing.OrionGuard.Tests/Domain/Rules/BusinessRuleTests.cs
+++ b/tests/Moongazing.OrionGuard.Tests/Domain/Rules/BusinessRuleTests.cs
@@ -1,0 +1,58 @@
+using Moongazing.OrionGuard.Domain.Rules;
+
+namespace Moongazing.OrionGuard.Tests.Domain.Rules;
+
+public class BusinessRuleTests
+{
+    private sealed class OrderMustHaveItems(bool isBroken) : BusinessRule
+    {
+        public override bool IsBroken() => isBroken;
+        public override string DefaultMessage => "An order must have at least one item.";
+    }
+
+    private sealed class CustomKeyRule : BusinessRule
+    {
+        public override bool IsBroken() => true;
+        public override string DefaultMessage => "x";
+        public override string MessageKey => "custom_key";
+    }
+
+    private sealed class WithArgsRule(int min) : BusinessRule
+    {
+        public override bool IsBroken() => true;
+        public override string DefaultMessage => "must be >= {0}";
+        public override object[] MessageArgs => new object[] { min };
+    }
+
+    [Fact]
+    public void IsBroken_ShouldReturnSubclassImplementation()
+    {
+        Assert.True(new OrderMustHaveItems(true).IsBroken());
+        Assert.False(new OrderMustHaveItems(false).IsBroken());
+    }
+
+    [Fact]
+    public void MessageKey_ShouldDefaultToTypeName()
+    {
+        var rule = new OrderMustHaveItems(true);
+        Assert.Equal(nameof(OrderMustHaveItems), rule.MessageKey);
+    }
+
+    [Fact]
+    public void MessageKey_ShouldRespectOverride()
+    {
+        Assert.Equal("custom_key", new CustomKeyRule().MessageKey);
+    }
+
+    [Fact]
+    public void MessageArgs_ShouldDefaultToNull()
+    {
+        Assert.Null(new OrderMustHaveItems(true).MessageArgs);
+    }
+
+    [Fact]
+    public void MessageArgs_ShouldRespectOverride()
+    {
+        Assert.Equal(new object[] { 5 }, new WithArgsRule(5).MessageArgs);
+    }
+}


### PR DESCRIPTION
This pull request introduces OrionGuard v6.4.0, featuring major enhancements to business rule ergonomics, ASP.NET Core integration, and outbox processing for distributed systems. It also adds new abstractions, configuration options, and migration documentation to improve usability and robustness, especially in multi-instance deployments. Additionally, new solution and test project entries are included, and package versions are updated.

**Key changes:**

### Business Rule Ergonomics and ASP.NET Core Integration

* Introduced `BusinessRule` and `AsyncBusinessRule` base classes, simplifying the implementation of business rules with default `MessageKey` behavior. Added static helpers `Guard.AgainstBrokenRule` and `Guard.AgainstBrokenRuleAsync` for rule checking, with `Entity.CheckRule`/`CheckRuleAsync` delegating to these helpers.
* Enhanced ASP.NET Core exception handling: `OrionGuardExceptionHandler` now returns a 422 `ValidationProblemDetails` for `BusinessRuleValidationException` (was 500), with a new configurable `BusinessRuleStatusCode` option (default 422) for legacy clients. Added a `Create(BusinessRuleValidationException)` overload in `OrionGuardProblemDetailsFactory` for structured error responses. [[1]](diffhunk://#diff-e8d2e38b13794d4af9eef3df976603a105e7c94312bba1fbe9fa5b1389983dd5R10) [[2]](diffhunk://#diff-e8d2e38b13794d4af9eef3df976603a105e7c94312bba1fbe9fa5b1389983dd5R83-R119) [[3]](diffhunk://#diff-1f4276a3f8f7d2dcbc1540616f11354d146fd9d1a44d106ba67f7ceffe5d7938R1-R2) [[4]](diffhunk://#diff-1f4276a3f8f7d2dcbc1540616f11354d146fd9d1a44d106ba67f7ceffe5d7938R28-R34) [[5]](diffhunk://#diff-2385ab5f186aaf0e4e3db82d0d3e8f695bb44e4f24ec7b5a5dde62b04733c590R1-R4) [[6]](diffhunk://#diff-2385ab5f186aaf0e4e3db82d0d3e8f695bb44e4f24ec7b5a5dde62b04733c590R18-R21) [[7]](diffhunk://#diff-2385ab5f186aaf0e4e3db82d0d3e8f695bb44e4f24ec7b5a5dde62b04733c590R60-R80)

### Outbox Production-Hardening

* Added distributed locking via `IDistributedLock`/`IDistributedLockHandle` abstractions. Default implementation uses a new `OrionGuard_OutboxLocks` table (multi-provider support). Includes a no-op `NullDistributedLock` for single-instance scenarios. Introduced `OutboxTypeMapRegistry` for logical name to type mapping, and `OutboxArchivalHostedService` for periodic cleanup. New configuration options for outbox locking and archival. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R52) [[2]](diffhunk://#diff-775e3fa86e0729efd8d2aa1a1db459ec77ca936bc5ac7e4b9ad3d889a2e4ceb9R8)
* Provided migration documentation for the new `OrionGuard_OutboxLocks` table, including EF Core and raw SQL DDL for major databases.

### Solution and Package Updates

* Added `Moongazing.OrionGuard.AspNetCore.Tests` project to the solution and updated solution configuration accordingly. [[1]](diffhunk://#diff-7c7002d33a6380b29508a7b5b085cbd619b0d3e5fa071f7a90595c95f34f76f8R54-R55) [[2]](diffhunk://#diff-7c7002d33a6380b29508a7b5b085cbd619b0d3e5fa071f7a90595c95f34f76f8R270-R281) [[3]](diffhunk://#diff-7c7002d33a6380b29508a7b5b085cbd619b0d3e5fa071f7a90595c95f34f76f8R304)
* Bumped package versions to 6.4.0 for `OrionGuard.AspNetCore` and `OrionGuard.Blazor`. [[1]](diffhunk://#diff-27f46d2f0b58b91b44e88efedd4faea2acb5a8f8688758bf9cb7174571aac8bbL11-R11) [[2]](diffhunk://#diff-34bfc6e76e2a9153837c402ba9df913a71210b264d3552ed554906e94960b00bL11-R11)

### Documentation and Benchmarks

* Updated `CHANGELOG.md` with all new features, migration steps, and roadmap. Added a benchmarks section to `README.md` with performance data for core operations. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R52) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R425-R493)

---

These updates provide improved developer ergonomics, more robust distributed processing, and better ASP.NET Core integration, with clear migration paths and documentation.