### PR TITLE
docs(readme): link the public ROADMAP

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 ---
 
 > **v6.0.0 is here!** 9 ecosystem packages, 14-language localization, Dynamic Rule Engine, source generators, ASP.NET Core / MediatR / Blazor / gRPC / SignalR integration, and much more.
-> [See what's new in this release.](CHANGELOG.md)
+> [See what's new in this release.](CHANGELOG.md) · [What's coming next (12-month roadmap)](docs/ROADMAP.md)
 
 ---
 
@@ -526,6 +526,18 @@ public class MyExceptionFactory : IExceptionFactory
 services.AddOrionGuardExceptionFactory<MyExceptionFactory>();
 // Or globally: ExceptionFactoryProvider.Configure(new MyExceptionFactory());
 ```
+
+---
+
+## Roadmap
+
+OrionGuard publishes a public, twelve-month forward roadmap covering the next minor releases
+through **v7.0.0 (Q2 2027)**. See [docs/ROADMAP.md](docs/ROADMAP.md) for the next-12-months
+view (v6.5.0 family integration, v6.6.0 migration tooling, v6.7.0 production excellence,
+v7.0.0 API freeze) plus the deep tier backlog of every item under consideration.
+
+If something on the roadmap matters to you, open an issue with the `roadmap` label. Real
+workload demand is what moves items up the list.
 
 ---
 


### PR DESCRIPTION
Surfaces the public 12-month roadmap from the README so people do not have to hunt for it.

- **Top banner** now links `docs/ROADMAP.md` next to the existing v6.0.0 changelog link.
- **New 'Roadmap' section** near the end summarising the v6.5.0..v7.0.0 milestones (family integration, migration tooling, production excellence, API freeze) and pointing at `docs/ROADMAP.md` for the deep tier backlog.

Same intent as the parallel README updates landed this week across the Orion family.