### PR TITLE
Cross-link OrionPatch in family list

### DIFF
--- a/README.md
+++ b/README.md
@@ -541,6 +541,17 @@ workload demand is what moves items up the list.
 
 ---
 
+## More from the Orion family
+
+OrionGuard is one of a set of standalone .NET libraries:
+
+- [OrionAudit](https://github.com/tunahanaliozturk/OrionAudit) - automatic EF Core change-audit trail.
+- [OrionKey](https://github.com/tunahanaliozturk/OrionKey) - source-generated strongly-typed IDs.
+- [OrionLock](https://github.com/tunahanaliozturk/OrionLock) - distributed locking.
+- [OrionPatch](https://github.com/tunahanaliozturk/OrionPatch) - transactional outbox for EF Core (enqueue inside SaveChanges, dispatch at-least-once through a pluggable sink).
+
+---
+
 ## Contributing
 
 Contributions are welcome! Please read our [Contributing Guide](CONTRIBUTING.md) before submitting a pull request.


### PR DESCRIPTION
Adds OrionPatch to the More from the Orion family section of the README, alongside OrionAudit, OrionKey, and OrionLock. OrionPatch v0.1.0 shipped today.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced README with a new "More from the Orion family" section highlighting related standalone .NET libraries available in the Orion ecosystem, including OrionAudit, OrionKey, OrionLock, and OrionPatch. The section is positioned before the Contributing guidelines.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tunahanaliozturk/OrionGuard/pull/14?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->