### PR TITLE
Cross-link OrionVault in family list

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,7 @@ OrionGuard is one of a set of standalone .NET libraries:
 - [OrionKey](https://github.com/tunahanaliozturk/OrionKey) - source-generated strongly-typed IDs.
 - [OrionLock](https://github.com/tunahanaliozturk/OrionLock) - distributed locking.
 - [OrionPatch](https://github.com/tunahanaliozturk/OrionPatch) - transactional outbox for EF Core (enqueue inside SaveChanges, dispatch at-least-once through a pluggable sink).
+- [OrionVault](https://github.com/tunahanaliozturk/OrionVault) - column-level transparent data encryption at rest for EF Core.
 
 ---
 


### PR DESCRIPTION
Adds OrionVault to the Orion family list following its v0.1.0 release on NuGet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README to include OrionVault in the Orion family product listings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tunahanaliozturk/OrionGuard/pull/15?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->