### PR TITLE
Add CONTRIBUTING.md and CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,33 @@
+# Code of Conduct
+
+## Our standard
+
+We want this project to be a place where people learn something. That means we treat each other like adults who showed up to discuss code, not like Twitter opponents. Short version:
+
+- Be patient with newer contributors. Everyone was new once.
+- Critique code, not people. "This allocates per call" is fine. "Why would you write this" is not.
+- Disagree without escalating. "I think X because Y" beats "X is dumb."
+- No personal attacks, harassment, sexualised content, doxxing, or political flame wars. Save those for elsewhere on the internet.
+- If you would not say it in front of a colleague at a code review, do not say it here.
+
+## What we do
+
+If conduct in an issue, pull request, commit message, code review, or any other repo-related interaction crosses the lines above, the maintainer will:
+
+1. First time, talk to you privately. Most things resolve here.
+2. If it continues, lock the thread.
+3. If it still continues, ban the account from the repo.
+
+Egregious cases (threats, doxxing, harassment of other contributors) skip straight to a ban.
+
+## Reporting
+
+Contact the maintainer directly. Email address is in the package NuGet metadata. We will treat reports as confidential.
+
+## Scope
+
+This applies to repo interactions: issues, PRs, code reviews, commit messages, discussions. It does not extend to external venues (Twitter, blogs, conferences) unless those venues are being used to attack contributors specifically.
+
+## Attribution
+
+This document is influenced by the Contributor Covenant but is intentionally shorter. We want it to be readable, not legalistic.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,192 +1,71 @@
 # Contributing to OrionGuard
 
-First off — thank you for considering a contribution. OrionGuard is a single-maintainer project, so clear, focused contributions that carry their own tests and documentation land the fastest. This guide tells you what "good" looks like here, and what will bounce.
+Thanks for taking the time to look at this. OrionGuard is a guard-clause and fluent-validation toolkit for .NET, with ASP.NET Core endpoint-filter integration. The project is small and the bar for contributions is "does it make the package clearer, faster, or safer without expanding the public surface needlessly."
 
-## Table of contents
+## Before you open a PR
 
-- [Code of conduct](#code-of-conduct)
-- [Before you start](#before-you-start)
-- [Ways to contribute](#ways-to-contribute)
-- [Local development setup](#local-development-setup)
-- [Repository layout](#repository-layout)
-- [Coding standards](#coding-standards)
-- [Testing rules](#testing-rules)
-- [Documentation requirements](#documentation-requirements)
-- [Commit & PR conventions](#commit--pr-conventions)
-- [Security issues](#security-issues)
-- [Release process](#release-process)
-- [License](#license)
+For anything beyond a typo, a docs tweak, or a one-line fix, please open an issue first. Five minutes of alignment up front saves an afternoon of rework later. State:
 
-## Code of conduct
+- The use case you are trying to solve
+- What you tried that did not work
+- Whether you want to send the patch yourself or are flagging the gap
 
-Be kind, be specific, be technical. Attack ideas, not people. If a behaviour would feel out of place on a mature .NET project (e.g. dotnet/runtime), it's out of place here too.
+For typos, docs polish, comment fixes, single-line changes, please skip the issue and send a PR directly. Title it `docs: ...` or `chore: ...` so it is obvious from the queue.
 
-## Before you start
-
-1. **Search first.** Check [existing issues](https://github.com/tunahanaliozturk/OrionGuard/issues) and open pull requests. Your idea may already be in motion.
-2. **Discuss non-trivial changes in an issue before coding.** Anything touching public API, a new ecosystem package, a new localization language, or a cross-cutting refactor needs an issue with a short design sketch first. This protects your time — the maintainer may redirect the approach before you've written 500 lines.
-3. **Trivial changes can go straight to a PR.** Typos, README fixes, new test cases for existing behaviour, XML doc clarifications — no issue required.
-
-## Ways to contribute
-
-| Kind | Expectation |
-|------|-------------|
-| Bug fix | Repro test first; fix second. |
-| New guard / validator | New public API → discuss in issue first. Include XML docs, tests, localization keys if user-visible, CHANGELOG entry. |
-| Localization | Add keys to every language block in `ValidationMessages.cs` — partial translations are rejected. |
-| Source generator work | Emitter changes need at least one generator test asserting the exact emitted text shape. |
-| Performance work | Include a BenchmarkDotNet run before/after. Numbers only — no hand-waving. |
-| Documentation | Fine as a standalone PR. Keep it terse and technical. |
-| New ecosystem package | Ask first. Comes with its own README, tests, version cadence. |
-
-## Local development setup
-
-**Toolchain:**
-
-- .NET SDK 10.0 (also test against 8.0 and 9.0 if you can — solution multi-targets).
-- Git 2.30+.
-- Any editor with C# + Roslyn support (Visual Studio, Rider, VS Code + C# Dev Kit).
-
-**Clone & build:**
+## Local development
 
 ```bash
-git clone https://github.com/tunahanaliozturk/OrionGuard.git
+git clone https://github.com/tunahanaliozturk/OrionGuard
 cd OrionGuard
-dotnet build Moongazing.OrionGuard.sln -c Release
+dotnet restore
+dotnet build -c Release
+dotnet test
 ```
 
-**Run the full test suite:**
+.NET 8 SDK is required. Multi-target builds may need 9.0 / 10.0 SDKs installed; the multi-target dimension is intentional and not optional.
 
-```bash
-dotnet test Moongazing.OrionGuard.sln -c Release
-```
+Branch from `master`. Name the branch after intent: `feat/...`, `fix/...`, `docs/...`, `refactor/...`, `chore/...`, `test/...`.
 
-All tests must pass on your branch before you open a PR. The main suite has 500+ tests; expect sub-second runtime per project.
+## Pull request shape
 
-**Run the benchmarks (optional, for perf PRs):**
+- One conceptual change per PR. Refactors and behaviour changes go in separate PRs even if the diff feels small.
+- Conventional Commits style commit subject (`feat:`, `fix:`, `docs:`, etc.).
+- New behaviour comes with tests. Bug fixes come with a failing-before, passing-after test.
+- Public API additions need XML doc comments. Breaking changes need a CHANGELOG entry.
+- No `Co-Authored-By` trailers. The author of the PR is the author of the work.
 
-```bash
-dotnet run -c Release --project benchmarks/Moongazing.OrionGuard.Benchmarks -- <BenchmarkClassName>
-```
+## Coding style
 
-**Run the demo:**
+- The repo enforces analyzer warnings as errors and `AllEnabledByDefault` analysis mode. Treat warnings as bugs.
+- Match the surrounding code style. The repo does not have a separate STYLE.md; if the existing code does X, do X.
+- Names are spelled out. No `mgr`, `svc`, `ctx`. The exceptions are well-known abbreviations (`Id`, `Db`, `Url`, `Json`).
+- Comments explain why, not what. The code already says what.
 
-```bash
-dotnet run --project demo/Moongazing.OrionGuard.Demo -c Release
-```
+## Tests
 
-The demo prints every major feature. If you add a user-visible feature, wire a section into the demo too.
+- xUnit + FluentAssertions.
+- Test names are sentences with underscores: `Account_withdraw_throws_when_insufficient_funds`.
+- Integration tests that need infrastructure go in a separate test project, gated by Testcontainers or `Skip` attributes when the infrastructure is unavailable.
+- Coverage is a side effect of writing tests for behaviour, not a target in itself.
 
-## Repository layout
+## Reporting bugs
 
-```
-OrionGuard/
-├── src/
-│   ├── Moongazing.OrionGuard/                  core guard + validation library (PackageId: OrionGuard)
-│   ├── Moongazing.OrionGuard.AspNetCore/       (PackageId: OrionGuard.AspNetCore)
-│   ├── Moongazing.OrionGuard.Blazor/           (PackageId: OrionGuard.Blazor)
-│   ├── Moongazing.OrionGuard.Generators/       (PackageId: OrionGuard.Generators)
-│   ├── Moongazing.OrionGuard.Grpc/             (PackageId: OrionGuard.Grpc)
-│   ├── Moongazing.OrionGuard.MediatR/          (PackageId: OrionGuard.MediatR)
-│   ├── Moongazing.OrionGuard.OpenTelemetry/    (PackageId: OrionGuard.OpenTelemetry)
-│   ├── Moongazing.OrionGuard.SignalR/          (PackageId: OrionGuard.SignalR)
-│   └── Moongazing.OrionGuard.Swagger/          (PackageId: OrionGuard.Swagger)
-├── tests/                                      xUnit tests for core + generators
-├── benchmarks/                                 BenchmarkDotNet harness
-├── demo/                                       Console app exercising every feature
-├── docs/                                       Long-form feature guides, specs, plans
-├── CHANGELOG.md                                Keep-a-Changelog format
-└── README.md
-```
+Open an issue with:
 
-The C# namespace layout mirrors the folder layout (`Moongazing.OrionGuard.AspNetCore` etc.) — only the published NuGet PackageIds dropped the `Moongazing.` prefix starting in v6.2.0.
+- A minimal reproduction (one file, one method, ideally less than 50 lines)
+- The actual behaviour vs the expected behaviour
+- The runtime (`dotnet --info` output) and the package version
 
-## Coding standards
+If the bug has security implications, please email the maintainer privately before opening a public issue.
 
-- **Target frameworks:** core + sub-packages multi-target `net8.0;net9.0;net10.0`. The source generator project is `netstandard2.0` (Roslyn constraint). Don't break the older TFMs without discussion.
-- **Nullable reference types:** enabled project-wide. No `#nullable disable` — if the compiler complains, fix the code, not the pragma.
-- **Warnings are errors.** Core and sub-packages have `TreatWarningsAsErrors=true`. `TreatWarningsAsErrors=false` is never acceptable in a PR.
-- **XML docs on every public member.** `GenerateDocumentationFile=true` is on everywhere. Missing docs = failed build.
-- **Analyzers:** `AnalysisLevel=latest-recommended`. CA1510 (prefer `ArgumentNullException.ThrowIfNull`) is enforced — follow it, unless you're throwing an OrionGuard-specific exception type (e.g. `NullValueException`) which stays hand-rolled.
-- **File-scoped namespaces** in core and sub-packages. Block-scoped namespaces in the generator project (netstandard2.0 doesn't mind either way, but the existing style is block-scoped).
-- **One type per file.** If you need a small helper type, put it in its own file unless it's a private nested class.
-- **Formatting:** run `dotnet format` before committing. Tabs for indentation in csproj, 4-space indent in C# (Visual Studio default).
-- **No unrelated refactors in a feature PR.** Keep the diff focused.
+## Security
 
-## Testing rules
+Do not file public issues for vulnerabilities. Contact the maintainer directly. See [SECURITY.md](SECURITY.md) if present, otherwise email the address listed in the package NuGet metadata.
 
-- Every behaviour change needs a test. No exceptions for "it's obvious".
-- Tests live next to the code: core behaviour → `tests/Moongazing.OrionGuard.Tests/`; generator behaviour → `tests/Moongazing.OrionGuard.Generators.Tests/`.
-- **Test naming:** `<Method>_Should<ExpectedOutcome>_When<Condition>`. Legible at `dotnet test --filter` time.
-- **TDD-friendly but not mandatory:** write the failing test before the fix if it's practical. For generator emitter changes it's almost always practical.
-- No `Thread.Sleep` in tests. No flaky timing assertions — use ranges (`Assert.InRange`) or record real clock boundaries (`before`/`after` snapshots).
-- Generator tests assert the emitted text shape — `Assert.Contains("expected snippet", generatedSource)`. Don't snapshot-test entire emitted files; they're too brittle.
+## Conduct
 
-## Documentation requirements
-
-When you change user-visible behaviour:
-
-1. **CHANGELOG.md** — add a bullet under the appropriate Keep-a-Changelog section (`### Added` / `### Changed` / `### Fixed` / `### Deprecated`) in the unreleased block, or if there's no unreleased block yet, under the top-most released version with a short note explaining you're proposing a new minor.
-2. **README.md** — if the change surfaces a new public entry point, update the relevant example snippet.
-3. **Per-package README** (`src/<Package>/docs/README.md`) — if the change is inside a sub-package, update its README too.
-4. **XML docs** on the public API itself.
-5. **Demo** (`demo/Moongazing.OrionGuard.Demo/Program.cs`) — if the feature is user-visible and has a nice 5–10 line demonstration, add a new numbered section. Don't duplicate what's already there.
-
-## Commit & PR conventions
-
-**Commit messages** follow [Conventional Commits](https://www.conventionalcommits.org/):
-
-- `feat(guard): add AgainstPositive extension for decimal`
-- `fix(generators): skip EF Core converter when type is missing`
-- `docs(readme): document the v6.2 IParsable emission`
-- `test(domain): cover CheckRule with async rule`
-- `refactor(core): extract GuardResult builder`
-- `chore(deps): bump MediatR to 12.4.1`
-- `perf(fastguard): reduce allocations in NotNullOrEmpty`
-- `release: bump to 6.2.0`
-
-Scope (`guard`, `domain`, `generators`, `aspnetcore`, etc.) helps readers scan `git log`.
-
-**Pull requests:**
-
-- One logical change per PR. Multiple unrelated fixes → multiple PRs.
-- **PR title:** same style as a commit subject.
-- **PR body:** a short description, plus:
-  - Why (link to the issue, or explain the problem in 2-3 sentences).
-  - What (high-level summary of the change).
-  - How you tested (which test files, which commands, benchmark numbers for perf PRs).
-  - A note if the PR needs a CHANGELOG entry — usually yes.
-- **Keep the PR green.** Push fixes, don't force-push history that rewrites other reviewers' context.
-- **Squash-merge** is the default. Write the squashed commit message in the PR description so it's ready to go at merge time.
-
-## Security issues
-
-**Do not open public issues for security vulnerabilities.**
-
-Email the maintainer directly — see `FUNDING.yml` or the `<Authors>` field in the core csproj for the current contact. Include:
-
-- A minimal reproduction.
-- The affected versions.
-- Your disclosure expectations (coordinated disclosure, CVE, etc.).
-
-You'll get an acknowledgement within a few business days and a patched release within two weeks for confirmed high-severity issues.
-
-## Release process
-
-Releases are cut by the maintainer only. The flow is:
-
-1. All planned changes merged to `master`.
-2. Version bumped across all 9 csprojs in a single `release:` commit.
-3. CHANGELOG moves the unreleased block under the new version header with an ISO date.
-4. `PackageReleaseNotes` in the core csproj gains a new version block.
-5. A git tag `vX.Y.Z` is pushed; GitHub Actions publishes to NuGet.
-
-If you want to help shape the next release, open an issue describing the proposal and link to your PR (if you have one ready).
+Be kind. We follow the [Code of Conduct](CODE_OF_CONDUCT.md). Disagreement is fine; rudeness is not.
 
 ## License
 
-By contributing, you agree that your contributions will be licensed under the [MIT License](src/Moongazing.OrionGuard/docs/LICENSE.txt), the same licence the project ships under. No CLA required.
-
----
-
-Thanks again. Contributions of any size are welcome — even a single test case that covers an overlooked edge case is a real improvement.
+By submitting a pull request, you agree your contribution is licensed under the repo's [MIT License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -569,7 +569,7 @@ OrionGuard is one of a set of standalone .NET libraries:
 
 ## Contributing
 
-Contributions are welcome! Please read our [Contributing Guide](CONTRIBUTING.md) before submitting a pull request.
+Issues and pull requests welcome. Please read [CONTRIBUTING.md](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md) before opening one.
 
 ## License
 


### PR DESCRIPTION
Adds contributor guidelines and code of conduct, consistent format across the Orion family. Adds a brief Contributing section to README linking to both.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Code of Conduct with community standards and enforcement guidelines.
  * Simplified Contributing guide with streamlined workflow and updated development setup.
  * Updated README with clearer direction to contribution and conduct guidelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->