### PR TITLE
Release v6.5.1: push-dispatch contract (IOutboxWakeSignal)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,43 @@ All notable changes to OrionGuard will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.5.1] - 2026-06-04
+
+### Added
+
+#### Push-based dispatch contract (`Moongazing.OrionGuard.EntityFrameworkCore`)
+
+The push-based outbox dispatcher promised in v6.5.0 lands as a contract + in-process implementation in v6.5.1. The concrete cross-process backends (Postgres `LISTEN/NOTIFY` and SQL Server Service Broker) ship as separate add-on packages in v6.5.2 and v6.5.3 respectively. The dispatcher loop now honours the new contract; consumers who do not opt in see identical v6.5.0 behaviour because the default implementation is polling-only.
+
+- **`IOutboxWakeSignal`** abstraction in `Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Push`. Two methods: `WaitForNextTickAsync(pollingInterval, ct)` (upper-bounded wait the dispatcher uses between batches) and `SignalAsync(ct)` (called by enqueue paths or push backends to wake the dispatcher immediately).
+- **`NullOutboxWakeSignal`** - default registration. Polling-only; behaviour byte-for-byte identical to v6.5.0.
+- **`ChannelOutboxWakeSignal`** - in-process bounded `Channel<bool>` implementation. Useful for unit tests and for single-process deployments where the `SaveChangesInterceptor` can publish a wake directly. Signals coalesce: repeated `SignalAsync` calls while one wait is pending all complete a single wake.
+- **`OutboxDispatcherHostedService` constructor** gains an optional `IOutboxWakeSignal` parameter (defaults to `NullOutboxWakeSignal` when null). Polling-interval upper-bound is always honoured, so a misbehaving signal cannot stall dispatch indefinitely.
+- **DI default** in `AddOrionGuardEfCore(...)` registers `NullOutboxWakeSignal` via `TryAddSingleton<IOutboxWakeSignal, NullOutboxWakeSignal>()`. Consumers replace it before `AddOrionGuardEfCore` to opt in (`services.AddSingleton<IOutboxWakeSignal, ChannelOutboxWakeSignal>()`).
+
+### Deferred from v6.5.1
+
+The concrete push backends will land as add-on packages so consumers can adopt one without dragging the others into their dependency graph:
+
+- **`Moongazing.OrionGuard.Outbox.PostgresNotify`** package (Postgres `LISTEN/NOTIFY`-backed `IOutboxWakeSignal`) -> v6.5.2.
+- **`Moongazing.OrionGuard.Outbox.SqlServerBroker`** package (SQL Server Service Broker-backed `IOutboxWakeSignal`) -> v6.5.3.
+
+The outbox dead-letter UI from the original v6.5.0 plan stays at v6.5.4.
+
+`docs/ROADMAP.md` reflects the new targets.
+
+### Migration from v6.5.0
+
+Source-compatible. No DI registration change is required. Consumers that opt into the new contract:
+
+```csharp
+// Single-process - in-process push so SaveChangesInterceptor can wake the dispatcher.
+services.AddSingleton<IOutboxWakeSignal, ChannelOutboxWakeSignal>();
+services.AddOrionGuardEfCore<AppDbContext>(o => o.UseOutbox());
+```
+
+The dispatcher continues to acquire the distributed lock before each batch, so multi-instance correctness is unchanged.
+
 ## [6.5.0] - 2026-06-01
 
 ### Added

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -87,22 +87,30 @@ Theme: *let OrionGuard quietly hand off the workloads its siblings now do better
   already added OrionGuard for validation get distributed locking via one extra
   `UseOrionLockRedis(...)` call on the EF Core options.
 
-### v6.5.1 — Push-Based Outbox Dispatch *(planned, Q3 2026)*
+### v6.5.1 — Push-Dispatch Contract *(shipped 2026-06-04)*
 
-Theme: *cut tail-latency on outbox dispatch from "polling interval" to "milliseconds".*
+Ships the push-dispatch contract + in-process implementation. Concrete cross-process backends move to follow-up patches so this minor stays small and reviewable.
 
-- **Push-based outbox dispatcher.** Replaces the v6.4 polling loop with a `PostgresLISTEN` /
-  `SqlServerBrokerNotification` push backend on the EF Core providers that support it.
-  Falls back to polling cleanly. Deferred from v6.5.0 to keep the v6.5.0 release scoped to
-  the Locks.Redis bridge.
+- **`IOutboxWakeSignal`** abstraction in `Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Push`.
+- **`NullOutboxWakeSignal`** - polling-only default (byte-for-byte v6.5.0 behaviour).
+- **`ChannelOutboxWakeSignal`** - in-process `Channel<bool>` implementation for single-process deployments and unit tests.
+- Dispatcher honours the signal as the polling-loop wait, with the configured polling interval as an upper bound on wake latency.
 
-### v6.5.2 — Outbox Operator Surface *(planned, Q4 2026)*
+### v6.5.2 — Postgres Push Backend *(planned)*
+
+- **`Moongazing.OrionGuard.Outbox.PostgresNotify`** add-on package. `IOutboxWakeSignal` backed by PostgreSQL `LISTEN/NOTIFY` with auto-reconnect and a polling fallback.
+
+### v6.5.3 — SQL Server Push Backend *(planned)*
+
+- **`Moongazing.OrionGuard.Outbox.SqlServerBroker`** add-on package. `IOutboxWakeSignal` backed by SQL Server Service Broker with the same fallback contract.
+
+### v6.5.4 — Outbox Operator Surface *(planned)*
 
 Theme: *make poisoned messages a first-class operator concern, not a manual SQL chore.*
 
 - **Outbox dead-letter UI surface.** A read-only `MapOutboxDashboard` endpoint listing
   failed/poisoned messages with replay / discard actions. Authorization-required by default.
-  Deferred from v6.5.0 in service of the same focus discipline.
+  Originally deferred from v6.5.0; staged after the push-dispatch trio so the dashboard can surface push-vs-polling state honestly.
 
 ### v6.6.0 — Migration & Contract-First *(planned, Q4 2026)*
 

--- a/src/Moongazing.OrionGuard.AspNetCore/Moongazing.OrionGuard.AspNetCore.csproj
+++ b/src/Moongazing.OrionGuard.AspNetCore/Moongazing.OrionGuard.AspNetCore.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.AspNetCore</PackageId>
-    <Version>6.5.0</Version>
+    <Version>6.5.1</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>ASP.NET Core integration for OrionGuard validation library. Provides middleware, Minimal API endpoint filters, MVC action filters, and RFC 9457 ProblemDetails support.</Description>
     <PackageTags>guard;validation;aspnetcore;middleware;minimal-api;problemdetails</PackageTags>

--- a/src/Moongazing.OrionGuard.Blazor/Moongazing.OrionGuard.Blazor.csproj
+++ b/src/Moongazing.OrionGuard.Blazor/Moongazing.OrionGuard.Blazor.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Blazor</PackageId>
-    <Version>6.5.0</Version>
+    <Version>6.5.1</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Blazor integration for OrionGuard validation library. Provides EditForm validation, custom validation components, and data annotations interop.</Description>
     <PackageTags>guard;validation;blazor;editform;component;wasm;server</PackageTags>

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/DomainEventSaveChangesInterceptor.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/DomainEventSaveChangesInterceptor.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Moongazing.OrionGuard.Domain.Events;
 using Moongazing.OrionGuard.Domain.Primitives;
 using Moongazing.OrionGuard.EntityFrameworkCore.Outbox;
+using Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Push;
 using Moongazing.OrionGuard.EntityFrameworkCore.Outbox.TypeMap;
 
 namespace Moongazing.OrionGuard.EntityFrameworkCore;
@@ -101,6 +102,14 @@ public sealed class DomainEventSaveChangesInterceptor : SaveChangesInterceptor
         var options = serviceProvider.GetRequiredService<OrionGuardEfCoreOptions>();
         if (options.Strategy != DomainEventDispatchStrategy.Inline)
         {
+            // Outbox mode: fire the optional push-dispatch wake so a ChannelOutboxWakeSignal
+            // or other push backend can wake the dispatcher mid-poll instead of waiting for
+            // the polling interval. The default NullOutboxWakeSignal makes this a no-op.
+            var wakeSignal = serviceProvider.GetService<IOutboxWakeSignal>();
+            if (wakeSignal is not null)
+            {
+                await wakeSignal.SignalAsync(cancellationToken).ConfigureAwait(false);
+            }
             return await base.SavedChangesAsync(eventData, result, cancellationToken).ConfigureAwait(false);
         }
 

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/DomainEventSaveChangesInterceptor.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/DomainEventSaveChangesInterceptor.cs
@@ -105,10 +105,15 @@ public sealed class DomainEventSaveChangesInterceptor : SaveChangesInterceptor
             // Outbox mode: fire the optional push-dispatch wake so a ChannelOutboxWakeSignal
             // or other push backend can wake the dispatcher mid-poll instead of waiting for
             // the polling interval. The default NullOutboxWakeSignal makes this a no-op.
+            //
+            // Use CancellationToken.None: the rows are already committed by the time we get
+            // here, so a request-level cancellation MUST NOT skip the wake. Skipping would
+            // leave the dispatcher waiting up to PollingInterval before noticing the new rows,
+            // which is exactly what the push-dispatch contract exists to prevent.
             var wakeSignal = serviceProvider.GetService<IOutboxWakeSignal>();
             if (wakeSignal is not null)
             {
-                await wakeSignal.SignalAsync(cancellationToken).ConfigureAwait(false);
+                await wakeSignal.SignalAsync(CancellationToken.None).ConfigureAwait(false);
             }
             return await base.SavedChangesAsync(eventData, result, cancellationToken).ConfigureAwait(false);
         }

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Moongazing.OrionGuard.EntityFrameworkCore.csproj
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Moongazing.OrionGuard.EntityFrameworkCore.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.EntityFrameworkCore</PackageId>
-    <Version>6.5.0</Version>
+    <Version>6.5.1</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>EF Core integration for OrionGuard. Provides a SaveChanges interceptor that dispatches domain events from AggregateRoot&lt;TId&gt; instances after commit (Inline mode) or via a transactional outbox (Outbox mode) consumed by a hosted background worker. Includes W3C trace context propagation across the outbox boundary.</Description>
     <PackageTags>guard;validation;ddd;domain-events;outbox;entity-framework-core;efcore;aggregate-root</PackageTags>

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/OutboxDispatcherHostedService.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/OutboxDispatcherHostedService.cs
@@ -66,16 +66,16 @@ public sealed class OutboxDispatcherHostedService : BackgroundService
         IDistributedLock? distributedLock = null,
         OutboxTypeMapRegistry? typeMap = null,
         OutboxTypeMapOptions? typeMapOptions = null,
-        IOutboxWakeSignal? wakeSignal = null,
-        ILogger<OutboxDispatcherHostedService>? logger = null)
+        ILogger<OutboxDispatcherHostedService>? logger = null,
+        IOutboxWakeSignal? wakeSignal = null)
     {
         this.options = options ?? throw new ArgumentNullException(nameof(options));
         this.scopeFactory = scopeFactory ?? throw new ArgumentNullException(nameof(scopeFactory));
         this.distributedLock = distributedLock ?? new NullDistributedLock();
         this.typeMap = typeMap ?? new OutboxTypeMapRegistry();
         this.typeMapOptions = typeMapOptions ?? new OutboxTypeMapOptions();
-        this.wakeSignal = wakeSignal ?? new NullOutboxWakeSignal();
         this.logger = logger;
+        this.wakeSignal = wakeSignal ?? new NullOutboxWakeSignal();
     }
 
     /// <inheritdoc />

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/OutboxDispatcherHostedService.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/OutboxDispatcherHostedService.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Moongazing.OrionGuard.Domain.Events;
 using Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Locking;
+using Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Push;
 using Moongazing.OrionGuard.EntityFrameworkCore.Outbox.TypeMap;
 
 namespace Moongazing.OrionGuard.EntityFrameworkCore.Outbox;
@@ -33,6 +34,7 @@ public sealed class OutboxDispatcherHostedService : BackgroundService
     private readonly IDistributedLock distributedLock;
     private readonly OutboxTypeMapRegistry typeMap;
     private readonly OutboxTypeMapOptions typeMapOptions;
+    private readonly IOutboxWakeSignal wakeSignal;
     private readonly ILogger<OutboxDispatcherHostedService>? logger;
 
     /// <summary>Initializes a new worker.</summary>
@@ -51,6 +53,11 @@ public sealed class OutboxDispatcherHostedService : BackgroundService
     /// Controls the AQN fallback behaviour when the registry has no mapping. When <see langword="null"/>,
     /// defaults preserve v6.3 source compatibility (AQN fallback enabled).
     /// </param>
+    /// <param name="wakeSignal">
+    /// Optional push-based wake signal used to wake the dispatcher mid-poll when new rows arrive.
+    /// When <see langword="null"/>, defaults to <see cref="NullOutboxWakeSignal"/> (polling-only,
+    /// behaviour identical to v6.4 / v6.5.0).
+    /// </param>
     /// <param name="logger">Optional logger used to surface startup and per-row diagnostic messages.</param>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="options"/> or <paramref name="scopeFactory"/> is <see langword="null"/>.</exception>
     public OutboxDispatcherHostedService(
@@ -59,6 +66,7 @@ public sealed class OutboxDispatcherHostedService : BackgroundService
         IDistributedLock? distributedLock = null,
         OutboxTypeMapRegistry? typeMap = null,
         OutboxTypeMapOptions? typeMapOptions = null,
+        IOutboxWakeSignal? wakeSignal = null,
         ILogger<OutboxDispatcherHostedService>? logger = null)
     {
         this.options = options ?? throw new ArgumentNullException(nameof(options));
@@ -66,6 +74,7 @@ public sealed class OutboxDispatcherHostedService : BackgroundService
         this.distributedLock = distributedLock ?? new NullDistributedLock();
         this.typeMap = typeMap ?? new OutboxTypeMapRegistry();
         this.typeMapOptions = typeMapOptions ?? new OutboxTypeMapOptions();
+        this.wakeSignal = wakeSignal ?? new NullOutboxWakeSignal();
         this.logger = logger;
     }
 
@@ -92,7 +101,7 @@ public sealed class OutboxDispatcherHostedService : BackgroundService
                 if (handle is null)
                 {
                     // Why: another instance holds the lease. Sleep and retry — do not dispatch.
-                    await Task.Delay(options.PollingInterval, stoppingToken).ConfigureAwait(false);
+                    await wakeSignal.WaitForNextTickAsync(options.PollingInterval, stoppingToken).ConfigureAwait(false);
                     continue;
                 }
 
@@ -111,7 +120,7 @@ public sealed class OutboxDispatcherHostedService : BackgroundService
 
             try
             {
-                await Task.Delay(options.PollingInterval, stoppingToken).ConfigureAwait(false);
+                await wakeSignal.WaitForNextTickAsync(options.PollingInterval, stoppingToken).ConfigureAwait(false);
             }
             catch (OperationCanceledException)
             {

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Push/ChannelOutboxWakeSignal.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Push/ChannelOutboxWakeSignal.cs
@@ -1,0 +1,46 @@
+namespace Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Push;
+
+using System.Threading.Channels;
+
+/// <summary>
+/// In-process <see cref="IOutboxWakeSignal"/> backed by a bounded
+/// <see cref="System.Threading.Channels.Channel{T}"/>. Useful for unit tests and for the
+/// "enqueue inside the same process as the dispatcher" pattern, where the
+/// <c>SaveChangesInterceptor</c> can publish a wake signal directly. Distributed (cross-process)
+/// push backends ship in v6.5.2 (Postgres LISTEN/NOTIFY) and v6.5.3 (SQL Server Service Broker).
+/// </summary>
+/// <remarks>
+/// Wake signals coalesce: repeated calls to <see cref="SignalAsync"/> while the dispatcher
+/// is in <see cref="WaitForNextTickAsync"/> all unblock the same single wait. A signal that
+/// arrives while the dispatcher is mid-batch is buffered and consumed by the next wait.
+/// </remarks>
+public sealed class ChannelOutboxWakeSignal : IOutboxWakeSignal
+{
+    private readonly Channel<bool> channel = Channel.CreateBounded<bool>(
+        new BoundedChannelOptions(capacity: 1) { FullMode = BoundedChannelFullMode.DropWrite });
+
+    /// <inheritdoc />
+    public async Task WaitForNextTickAsync(TimeSpan pollingInterval, CancellationToken cancellationToken)
+    {
+        using var pollingCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        pollingCts.CancelAfter(pollingInterval);
+
+        try
+        {
+            await channel.Reader.ReadAsync(pollingCts.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (pollingCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+        {
+            // Polling interval elapsed without a signal — return normally so the dispatcher
+            // runs a polling tick.
+        }
+    }
+
+    /// <inheritdoc />
+    public ValueTask SignalAsync(CancellationToken cancellationToken)
+    {
+        // DropWrite policy: if a signal is already pending, this call is a no-op.
+        _ = channel.Writer.TryWrite(true);
+        return ValueTask.CompletedTask;
+    }
+}

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Push/IOutboxWakeSignal.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Push/IOutboxWakeSignal.cs
@@ -1,0 +1,33 @@
+namespace Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Push;
+
+/// <summary>
+/// Optional push-based wake-up contract for the outbox dispatcher. Concrete implementations
+/// (Postgres LISTEN/NOTIFY, SQL Server Service Broker, Redis PubSub, etc.) replace the default
+/// polling-only wait with an event-driven wake so newly enqueued rows are dispatched without
+/// waiting for the next polling tick.
+/// </summary>
+/// <remarks>
+/// The default registration is <see cref="NullOutboxWakeSignal"/>, which preserves the v6.4 /
+/// v6.5.0 polling-only behaviour. Consumers opt in to push-based dispatch by registering a
+/// concrete <see cref="IOutboxWakeSignal"/> in DI. The dispatcher always honours the polling
+/// interval as an upper bound on wake latency, so a misbehaving signal (missed NOTIFY,
+/// dropped connection) cannot stall dispatch indefinitely.
+/// </remarks>
+public interface IOutboxWakeSignal
+{
+    /// <summary>
+    /// Wait until either <paramref name="pollingInterval"/> elapses or a wake signal arrives,
+    /// whichever happens first. Returns when work may be available.
+    /// </summary>
+    /// <param name="pollingInterval">Upper bound on the wait. Acts as the polling-fallback period.</param>
+    /// <param name="cancellationToken">Cancellation token observed during the wait.</param>
+    Task WaitForNextTickAsync(TimeSpan pollingInterval, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Signal that new outbox rows are available. Should wake any pending
+    /// <see cref="WaitForNextTickAsync"/> call. Called by enqueue paths and by concrete push
+    /// backends (a Postgres LISTEN handler, for instance).
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    ValueTask SignalAsync(CancellationToken cancellationToken);
+}

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Push/NullOutboxWakeSignal.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Push/NullOutboxWakeSignal.cs
@@ -1,0 +1,17 @@
+namespace Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Push;
+
+/// <summary>
+/// Default <see cref="IOutboxWakeSignal"/> registration. Polling-only: <see cref="WaitForNextTickAsync"/>
+/// simply awaits the supplied polling interval, and <see cref="SignalAsync"/> is a no-op.
+/// Behaviour is byte-for-byte identical to the v6.4 / v6.5.0 dispatcher loop, so consumers
+/// who do not opt into push-based dispatch see no functional change.
+/// </summary>
+public sealed class NullOutboxWakeSignal : IOutboxWakeSignal
+{
+    /// <inheritdoc />
+    public Task WaitForNextTickAsync(TimeSpan pollingInterval, CancellationToken cancellationToken) =>
+        Task.Delay(pollingInterval, cancellationToken);
+
+    /// <inheritdoc />
+    public ValueTask SignalAsync(CancellationToken cancellationToken) => ValueTask.CompletedTask;
+}

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/ServiceCollectionExtensions.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/ServiceCollectionExtensions.cs
@@ -64,8 +64,8 @@ public static class ServiceCollectionExtensions
                 sp.GetRequiredService<IDistributedLock>(),
                 sp.GetRequiredService<OutboxTypeMapRegistry>(),
                 sp.GetRequiredService<OutboxTypeMapOptions>(),
-                sp.GetRequiredService<IOutboxWakeSignal>(),
-                sp.GetService<ILogger<OutboxDispatcherHostedService>>()));
+                sp.GetService<ILogger<OutboxDispatcherHostedService>>(),
+                sp.GetRequiredService<IOutboxWakeSignal>()));
         }
 
         // Apply fluent customizations (UseDistributedLock / UseOutboxTypeMap / UseOutboxArchival)

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/ServiceCollectionExtensions.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/ServiceCollectionExtensions.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Moongazing.OrionGuard.EntityFrameworkCore.Outbox;
 using Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Locking;
+using Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Push;
 using Moongazing.OrionGuard.EntityFrameworkCore.Outbox.TypeMap;
 
 namespace Moongazing.OrionGuard.EntityFrameworkCore;
@@ -55,6 +56,7 @@ public static class ServiceCollectionExtensions
             services.TryAddSingleton<IDistributedLock, SkipLockedDistributedLock>();
             services.TryAddSingleton(new OutboxTypeMapRegistry());
             services.TryAddSingleton(new OutboxTypeMapOptions());
+            services.TryAddSingleton<IOutboxWakeSignal, NullOutboxWakeSignal>();
 
             services.AddHostedService(sp => new OutboxDispatcherHostedService(
                 sp.GetRequiredService<OutboxOptions>(),
@@ -62,6 +64,7 @@ public static class ServiceCollectionExtensions
                 sp.GetRequiredService<IDistributedLock>(),
                 sp.GetRequiredService<OutboxTypeMapRegistry>(),
                 sp.GetRequiredService<OutboxTypeMapOptions>(),
+                sp.GetRequiredService<IOutboxWakeSignal>(),
                 sp.GetService<ILogger<OutboxDispatcherHostedService>>()));
         }
 

--- a/src/Moongazing.OrionGuard.Generators/Moongazing.OrionGuard.Generators.csproj
+++ b/src/Moongazing.OrionGuard.Generators/Moongazing.OrionGuard.Generators.csproj
@@ -8,7 +8,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>CS1591</NoWarn>
     <PackageId>OrionGuard.Generators</PackageId>
-    <Version>6.5.0</Version>
+    <Version>6.5.1</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Source generator for OrionGuard. Generates [GenerateValidator] validators, [StronglyTypedId&lt;TValue&gt;] strongly-typed id types (EF Core ValueConverter, System.Text.Json JsonConverter, TypeConverter companions), and supports NativeAOT-compatible reflection-free workflows.</Description>
     <PackageTags>guard;validation;source-generator;roslyn;nativeaot;codegen;ddd;strongly-typed-id</PackageTags>

--- a/src/Moongazing.OrionGuard.Grpc/Moongazing.OrionGuard.Grpc.csproj
+++ b/src/Moongazing.OrionGuard.Grpc/Moongazing.OrionGuard.Grpc.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Grpc</PackageId>
-    <Version>6.5.0</Version>
+    <Version>6.5.1</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>gRPC integration for OrionGuard validation library. Provides server interceptor for automatic request validation in gRPC services.</Description>
     <PackageTags>guard;validation;grpc;interceptor;protobuf;microservices</PackageTags>

--- a/src/Moongazing.OrionGuard.Locks.Redis/Moongazing.OrionGuard.Locks.Redis.csproj
+++ b/src/Moongazing.OrionGuard.Locks.Redis/Moongazing.OrionGuard.Locks.Redis.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Locks.Redis</PackageId>
-    <Version>6.5.0</Version>
+    <Version>6.5.1</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Redis-backed IDistributedLock for OrionGuard.EntityFrameworkCore's outbox dispatcher. Bridges OrionGuard's IDistributedLock contract to the OrionLock.Redis backend so multi-instance outbox workers can share a Redis-coordinated lease instead of the default SkipLocked DB lock.</Description>
     <PackageTags>guard;outbox;distributed-lock;redis;orionlock;entity-framework-core;efcore</PackageTags>

--- a/src/Moongazing.OrionGuard.MediatR/Moongazing.OrionGuard.MediatR.csproj
+++ b/src/Moongazing.OrionGuard.MediatR/Moongazing.OrionGuard.MediatR.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.MediatR</PackageId>
-    <Version>6.5.0</Version>
+    <Version>6.5.1</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>MediatR integration for OrionGuard validation library. Provides ValidationBehavior pipeline behavior for automatic request validation in CQRS pipelines.</Description>
     <PackageTags>guard;validation;mediatr;cqrs;pipeline;behavior</PackageTags>

--- a/src/Moongazing.OrionGuard.OpenTelemetry/Moongazing.OrionGuard.OpenTelemetry.csproj
+++ b/src/Moongazing.OrionGuard.OpenTelemetry/Moongazing.OrionGuard.OpenTelemetry.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.OpenTelemetry</PackageId>
-    <Version>6.5.0</Version>
+    <Version>6.5.1</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>OpenTelemetry integration for OrionGuard validation library. Provides validation metrics (success/failure rates, latency) and distributed tracing spans.</Description>
     <PackageTags>guard;validation;opentelemetry;metrics;tracing;observability</PackageTags>

--- a/src/Moongazing.OrionGuard.SignalR/Moongazing.OrionGuard.SignalR.csproj
+++ b/src/Moongazing.OrionGuard.SignalR/Moongazing.OrionGuard.SignalR.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.SignalR</PackageId>
-    <Version>6.5.0</Version>
+    <Version>6.5.1</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>SignalR integration for OrionGuard validation library. Provides Hub filter for automatic method parameter validation.</Description>
     <PackageTags>guard;validation;signalr;realtime;hub;filter</PackageTags>

--- a/src/Moongazing.OrionGuard.Swagger/Moongazing.OrionGuard.Swagger.csproj
+++ b/src/Moongazing.OrionGuard.Swagger/Moongazing.OrionGuard.Swagger.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Swagger</PackageId>
-    <Version>6.5.0</Version>
+    <Version>6.5.1</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Swagger/OpenAPI integration for OrionGuard. Auto-generates OpenAPI constraints from OrionGuard validation attributes.</Description>
     <PackageTags>guard;validation;swagger;openapi;swashbuckle</PackageTags>

--- a/src/Moongazing.OrionGuard.Testing/Moongazing.OrionGuard.Testing.csproj
+++ b/src/Moongazing.OrionGuard.Testing/Moongazing.OrionGuard.Testing.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Testing</PackageId>
-    <Version>6.5.0</Version>
+    <Version>6.5.1</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Testing helpers for OrionGuard. Provides DomainEventCapture and InMemoryDomainEventDispatcher with framework-agnostic assertions (no xUnit / NUnit / FluentAssertions dependency). Works with any test runner.</Description>
     <PackageTags>guard;validation;testing;ddd;domain-events;assertions;test-helpers</PackageTags>

--- a/src/Moongazing.OrionGuard/Moongazing.OrionGuard.csproj
+++ b/src/Moongazing.OrionGuard/Moongazing.OrionGuard.csproj
@@ -35,13 +35,23 @@
 		<PackageProjectUrl>https://github.com/tunahanaliozturk/OrionGuard</PackageProjectUrl>
 		<PackageTags>guard;validation;fluent;exceptions;.NET;input-validation;guard-clauses;defensive-programming;security;localization;format-validation;nativeaot;source-generator;aspnetcore;mediatr</PackageTags>
 		<PackageReleaseNotes>
+v6.5.1 - Push-Dispatch Contract
+
+NEW: IOutboxWakeSignal abstraction in Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Push. Lets consumers swap the dispatcher's between-batch wait from polling to push without touching the rest of the dispatch loop. Two methods: WaitForNextTickAsync(pollingInterval, ct) and SignalAsync(ct).
+
+NEW: NullOutboxWakeSignal default - polling-only, byte-for-byte v6.5.0 behaviour. ChannelOutboxWakeSignal in-process Channel-backed implementation for single-process deployments and unit tests; repeated SignalAsync calls coalesce into one wake.
+
+CHANGED: DomainEventSaveChangesInterceptor fires SignalAsync on the registered IOutboxWakeSignal after every SaveChanges that runs in Outbox mode, so an opted-in consumer sees mid-poll wakes automatically. Polling interval still upper-bounds wake latency.
+
+CHANGED: OutboxDispatcherHostedService gains an optional 8th IOutboxWakeSignal parameter; positional callers using the previous 6-argument constructor with logger last continue to compile.
+
+DEFERRED: Moongazing.OrionGuard.Outbox.PostgresNotify add-on (Postgres LISTEN/NOTIFY) -> v6.5.2. Moongazing.OrionGuard.Outbox.SqlServerBroker (SQL Server Service Broker) -> v6.5.3. Outbox dead-letter UI -> v6.5.4.
+
+MIGRATION: Source-compatible. No DI changes are required to stay on polling. Opt in to in-process push by registering ChannelOutboxWakeSignal as IOutboxWakeSignal before AddOrionGuardEfCore.
+
 v6.5.0 - Family Integration
 
-NEW PACKAGE: Moongazing.OrionGuard.Locks.Redis - bridges OrionGuard's IDistributedLock primitive (introduced in v6.4.0 for the outbox dispatcher) to the standalone OrionLock.Redis backend. Two DI entry points: UseOrionLockRedis(connectionString, configure) and UseOrionLockRedis(configure). Multi-instance outbox workers can now use Redis instead of the default DB-backed SkipLockedDistributedLock.
-
-DEFERRED from v6.5.0: Push-based outbox dispatcher moved to v6.5.1 (PostgresLISTEN + ServiceBroker push backends with polling fallback). Outbox dead-letter UI moved to v6.5.2 (MapOutboxDashboard read-only endpoint with replay and discard actions).
-
-MIGRATION: No breaking changes. Default DB-backed lock continues to work. Opt in to Redis by adding Moongazing.OrionGuard.Locks.Redis and calling .UseOrionLockRedis(...) on OrionGuardEfCoreOptions.
+NEW PACKAGE: Moongazing.OrionGuard.Locks.Redis - bridges OrionGuard's IDistributedLock primitive to the standalone OrionLock.Redis backend.
 
 Full changelog: https://github.com/tunahanaliozturk/OrionGuard/blob/master/CHANGELOG.md
 

--- a/src/Moongazing.OrionGuard/Moongazing.OrionGuard.csproj
+++ b/src/Moongazing.OrionGuard/Moongazing.OrionGuard.csproj
@@ -16,7 +16,7 @@
 		<OutputType>Library</OutputType>
 
 		<PackageId>OrionGuard</PackageId>
-		<Version>6.5.0</Version>
+		<Version>6.5.1</Version>
 		<Authors>Tunahan Ali Ozturk</Authors>
 		<Company>Tunahan Ali Ozturk</Company>
 		<GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/Push/OutboxWakeSignalTests.cs
+++ b/tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/Push/OutboxWakeSignalTests.cs
@@ -66,13 +66,16 @@ public sealed class OutboxWakeSignalTests
     {
         IOutboxWakeSignal signal = new ChannelOutboxWakeSignal();
 
+        // Start the stopwatch before the wait begins so we measure the FULL wait duration,
+        // not just the post-signal portion. Without this, a near-zero measurement is possible
+        // if waitTask happens to complete before the stopwatch starts.
+        var sw = Stopwatch.StartNew();
         var waitTask = signal.WaitForNextTickAsync(TimeSpan.FromSeconds(30), CancellationToken.None);
 
         // Signal after a short delay. The wait should complete well before 30s.
         await Task.Delay(100);
         await signal.SignalAsync(CancellationToken.None);
 
-        var sw = Stopwatch.StartNew();
         await waitTask;
         sw.Stop();
 

--- a/tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/Push/OutboxWakeSignalTests.cs
+++ b/tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/Push/OutboxWakeSignalTests.cs
@@ -1,0 +1,112 @@
+namespace Moongazing.OrionGuard.EntityFrameworkCore.Tests.Outbox.Push;
+
+using System.Diagnostics;
+using Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Push;
+using Xunit;
+
+public sealed class OutboxWakeSignalTests
+{
+    [Fact]
+    public async Task NullSignal_waits_polling_interval_then_returns()
+    {
+        IOutboxWakeSignal signal = new NullOutboxWakeSignal();
+        var sw = Stopwatch.StartNew();
+
+        await signal.WaitForNextTickAsync(TimeSpan.FromMilliseconds(150), CancellationToken.None);
+
+        sw.Stop();
+        Assert.InRange(sw.ElapsedMilliseconds, 100, 1000);
+    }
+
+    [Fact]
+    public async Task NullSignal_signal_is_a_no_op()
+    {
+        IOutboxWakeSignal signal = new NullOutboxWakeSignal();
+
+        // Calling Signal does not throw and returns synchronously. Subsequent WaitForNextTick
+        // still observes the full polling interval (no buffered wake).
+        await signal.SignalAsync(CancellationToken.None);
+        var sw = Stopwatch.StartNew();
+        await signal.WaitForNextTickAsync(TimeSpan.FromMilliseconds(150), CancellationToken.None);
+        sw.Stop();
+
+        Assert.InRange(sw.ElapsedMilliseconds, 100, 1000);
+    }
+
+    [Fact]
+    public async Task ChannelSignal_pending_signal_wakes_immediately()
+    {
+        IOutboxWakeSignal signal = new ChannelOutboxWakeSignal();
+        await signal.SignalAsync(CancellationToken.None);
+
+        var sw = Stopwatch.StartNew();
+        await signal.WaitForNextTickAsync(TimeSpan.FromSeconds(30), CancellationToken.None);
+        sw.Stop();
+
+        // A signal already in the channel should unblock the wait in well under 100ms,
+        // never waiting for the 30s polling interval.
+        Assert.True(sw.ElapsedMilliseconds < 1000,
+            $"expected fast wake but waited {sw.ElapsedMilliseconds} ms");
+    }
+
+    [Fact]
+    public async Task ChannelSignal_falls_back_to_polling_after_interval()
+    {
+        IOutboxWakeSignal signal = new ChannelOutboxWakeSignal();
+
+        var sw = Stopwatch.StartNew();
+        await signal.WaitForNextTickAsync(TimeSpan.FromMilliseconds(200), CancellationToken.None);
+        sw.Stop();
+
+        Assert.InRange(sw.ElapsedMilliseconds, 150, 2000);
+    }
+
+    [Fact]
+    public async Task ChannelSignal_signal_arriving_mid_wait_wakes_dispatcher()
+    {
+        IOutboxWakeSignal signal = new ChannelOutboxWakeSignal();
+
+        var waitTask = signal.WaitForNextTickAsync(TimeSpan.FromSeconds(30), CancellationToken.None);
+
+        // Signal after a short delay. The wait should complete well before 30s.
+        await Task.Delay(100);
+        await signal.SignalAsync(CancellationToken.None);
+
+        var sw = Stopwatch.StartNew();
+        await waitTask;
+        sw.Stop();
+
+        Assert.True(sw.ElapsedMilliseconds < 2000,
+            $"expected fast wake but waited {sw.ElapsedMilliseconds} ms after signal");
+    }
+
+    [Fact]
+    public async Task ChannelSignal_repeated_signals_coalesce_to_one_wake()
+    {
+        IOutboxWakeSignal signal = new ChannelOutboxWakeSignal();
+
+        for (int i = 0; i < 10; i++)
+        {
+            await signal.SignalAsync(CancellationToken.None);
+        }
+
+        await signal.WaitForNextTickAsync(TimeSpan.FromSeconds(30), CancellationToken.None);
+
+        // After consuming the buffered wake, the next wait should fall back to polling.
+        var sw = Stopwatch.StartNew();
+        await signal.WaitForNextTickAsync(TimeSpan.FromMilliseconds(150), CancellationToken.None);
+        sw.Stop();
+        Assert.InRange(sw.ElapsedMilliseconds, 100, 2000);
+    }
+
+    [Fact]
+    public async Task ChannelSignal_external_cancellation_propagates()
+    {
+        IOutboxWakeSignal signal = new ChannelOutboxWakeSignal();
+        using var cts = new CancellationTokenSource();
+        cts.CancelAfter(100);
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() =>
+            signal.WaitForNextTickAsync(TimeSpan.FromSeconds(30), cts.Token));
+    }
+}


### PR DESCRIPTION
## OrionGuard v6.5.1 - Push-Dispatch Contract

Delivers the push-based dispatch promise from v6.5.0 in the cleanest possible scope: the **contract** plus an in-process implementation. Concrete cross-process backends (Postgres `LISTEN/NOTIFY`, SQL Server Service Broker) move to focused add-on packages in v6.5.2 / v6.5.3, so consumers can adopt one without dragging the others into their dependency graph.

### Shipped

- **`IOutboxWakeSignal`** in `Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Push`. Two methods: `WaitForNextTickAsync(pollingInterval, ct)` and `SignalAsync(ct)`.
- **`NullOutboxWakeSignal`** - polling-only default, byte-for-byte v6.5.0 behaviour. Registered via `TryAddSingleton` so existing consumers see zero change.
- **`ChannelOutboxWakeSignal`** - in-process `Channel<bool>`-backed implementation, bounded capacity = 1 with `DropWrite` full-mode so repeated signals coalesce into a single wake.
- **`OutboxDispatcherHostedService`** ctor takes an optional `IOutboxWakeSignal` (defaults to null = `NullOutboxWakeSignal`). The dispatcher uses `WaitForNextTickAsync` instead of bare `Task.Delay` for its between-batch wait. Polling interval always upper-bounds the wait, so a misbehaving signal cannot stall dispatch indefinitely.

### Deferred from v6.5.1

- **`Moongazing.OrionGuard.Outbox.PostgresNotify`** add-on package -> v6.5.2
- **`Moongazing.OrionGuard.Outbox.SqlServerBroker`** add-on package -> v6.5.3
- **Outbox dead-letter UI** (originally v6.5.0 deferral) -> v6.5.4 (staged after push backends so the dashboard can surface push-vs-polling state honestly)

`docs/ROADMAP.md` reflects the new targets.

### Verification

- `dotnet build -c Release` - 0 errors, 33 pre-existing warnings (none introduced).
- `dotnet test --filter "FullyQualifiedName~OutboxWakeSignal"` - 7 passed, 0 failed.
- Existing EF Core outbox tests continue to pass with the new dispatcher signature.

### Migration from v6.5.0

Source-compatible. No DI changes are required to stay on polling. Opt in to in-process push with:

```csharp
services.AddSingleton<IOutboxWakeSignal, ChannelOutboxWakeSignal>();
services.AddOrionGuardEfCore<AppDbContext>(o => o.UseOutbox());
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional push-style outbox wake mechanism with an in-process channel option to reduce dispatch latency while preserving polling as the default.
  * Dispatcher can be signaled after saves so events may dispatch sooner.

* **Documentation**
  * Release notes and roadmap updated with v6.5.1 details and a migration example; future backend plan staged.

* **Chores**
  * Bumped package versions to 6.5.1 across the repo.

* **Tests**
  * Added tests covering wake-signal behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->