### PR TITLE
Release v6.5.5: outbox operator mutation surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,44 @@ All notable changes to OrionGuard will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.5.5] - 2026-06-10
+
+### Added
+
+#### Outbox dashboard mutation surface
+
+Completes the operator workflow started in v6.5.4. The read surface listed failed / dead-lettered messages; v6.5.5 lets operators actually act on them.
+
+- **`POST /_orion/outbox/{id:guid}/replay`** finds the row, clears `RetryCount`, clears `Error`, clears `ProcessedOnUtc` (in case the dispatcher had already dead-lettered it), commits via `SaveChangesAsync`, and returns `200 OK` with `{ id, action: "replay" }`. Unknown id -> `404 Not Found`.
+- **`POST /_orion/outbox/{id:guid}/discard`** stamps `ProcessedOnUtc = UtcNow` so the dispatcher loop skips the row on its next pass; `Error` and `RetryCount` stay intact so future operators see the history. Idempotent: a row that already has `ProcessedOnUtc` set returns `200 OK` with `{ id, action: "discard", note: "already processed" }` and the audit hook does NOT fire again. Unknown id -> `404 Not Found`.
+- **`OutboxDashboardOptions.OnMutation`** optional `Func<OutboxMutationEvent, Task>` audit hook fires after a successful replay / discard. The dashboard itself never writes audit rows so consumers stay in control of storage shape and retention. `OutboxMutationEvent` carries `Action`, `OutboxMessageId`, `HttpContext`, and `OccurredAtUtc` so consumers stamp `User.Identity.Name`, claims, IP, etc. Throwing from the hook does NOT roll back the database commit.
+- **`OutboxDashboardOptions.EnableMutations`** (default `true`) - set `false` for strictly read-only mounts. When false the `POST` endpoints are not registered at all (return `404`) while the existing `/failed` listing stays available.
+
+### Tests
+
+5 new endpoint tests (replay path, discard path, replay 404, discard 404, discard idempotency) + 3 mutation-hook tests (fires on replay, does NOT fire on 404, does NOT fire on already-processed discard) + 2 read-only-mode tests (POST returns 404 when disabled, GET still works). 18 facts total in the dashboard test suite.
+
+### Migration from v6.5.4
+
+Source-compatible. Existing dashboard registrations get `replay` and `discard` automatically; opt out with `o.EnableMutations = false`.
+
+```csharp
+app.MapOutboxDashboard<AppDbContext>(o =>
+{
+    o.OnMutation = async evt =>
+    {
+        await auditWriter.WriteAsync(new
+        {
+            evt.Action,
+            evt.OutboxMessageId,
+            User = evt.HttpContext.User.Identity?.Name,
+            Ip = evt.HttpContext.Connection.RemoteIpAddress?.ToString(),
+            evt.OccurredAtUtc,
+        });
+    };
+});
+```
+
 ## [6.5.4] - 2026-06-09
 
 ### Added

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -108,9 +108,12 @@ Ships the push-dispatch contract + in-process implementation. Concrete cross-pro
 
 - **`Moongazing.OrionGuard.Outbox.Dashboard` add-on shipped.** `MapOutboxDashboard<TDbContext>` registers an authorized read-only endpoint group; `GET /_orion/outbox/failed?page=N&size=M` returns paginated failed-message metadata (payload deliberately excluded). Authorization required by default; pagination clamped to a configurable `MaxPageSize`; error text truncated to `ErrorTruncationLength`.
 
-### v6.5.5 — Outbox Operator Mutation Surface *(planned)*
+### v6.5.5 — Outbox Operator Mutation Surface *(shipped 2026-06-10)*
 
-- **Replay / discard actions on the dashboard endpoint group.** Authenticated mutations to retry a single poisoned message (resets `RetryCount` + clears `Error`) or discard it. Audit log entries to track who-did-what. Deferred from v6.5.4 so the read surface ships first and the mutation surface gets a focused review.
+- `POST /_orion/outbox/{id:guid}/replay` clears `RetryCount`, `Error`, and `ProcessedOnUtc` so the next dispatcher pass re-attempts the row. 404 for unknown ids.
+- `POST /_orion/outbox/{id:guid}/discard` stamps `ProcessedOnUtc = UtcNow` so the dispatcher skips the row; idempotent for already-processed rows.
+- `OutboxDashboardOptions.OnMutation` audit hook (consumer-controlled storage shape; the dashboard never writes audit rows).
+- `OutboxDashboardOptions.EnableMutations` (default `true`) - false leaves the dashboard strictly read-only.
 
 ### v6.6.0 — Migration & Contract-First *(planned, Q4 2026)*
 

--- a/src/Moongazing.OrionGuard.AspNetCore/Moongazing.OrionGuard.AspNetCore.csproj
+++ b/src/Moongazing.OrionGuard.AspNetCore/Moongazing.OrionGuard.AspNetCore.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.AspNetCore</PackageId>
-    <Version>6.5.4</Version>
+    <Version>6.5.5</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>ASP.NET Core integration for OrionGuard validation library. Provides middleware, Minimal API endpoint filters, MVC action filters, and RFC 9457 ProblemDetails support.</Description>
     <PackageTags>guard;validation;aspnetcore;middleware;minimal-api;problemdetails</PackageTags>

--- a/src/Moongazing.OrionGuard.Blazor/Moongazing.OrionGuard.Blazor.csproj
+++ b/src/Moongazing.OrionGuard.Blazor/Moongazing.OrionGuard.Blazor.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Blazor</PackageId>
-    <Version>6.5.4</Version>
+    <Version>6.5.5</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Blazor integration for OrionGuard validation library. Provides EditForm validation, custom validation components, and data annotations interop.</Description>
     <PackageTags>guard;validation;blazor;editform;component;wasm;server</PackageTags>

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Moongazing.OrionGuard.EntityFrameworkCore.csproj
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Moongazing.OrionGuard.EntityFrameworkCore.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.EntityFrameworkCore</PackageId>
-    <Version>6.5.4</Version>
+    <Version>6.5.5</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>EF Core integration for OrionGuard. Provides a SaveChanges interceptor that dispatches domain events from AggregateRoot&lt;TId&gt; instances after commit (Inline mode) or via a transactional outbox (Outbox mode) consumed by a hosted background worker. Includes W3C trace context propagation across the outbox boundary.</Description>
     <PackageTags>guard;validation;ddd;domain-events;outbox;entity-framework-core;efcore;aggregate-root</PackageTags>

--- a/src/Moongazing.OrionGuard.Generators/Moongazing.OrionGuard.Generators.csproj
+++ b/src/Moongazing.OrionGuard.Generators/Moongazing.OrionGuard.Generators.csproj
@@ -8,7 +8,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>CS1591</NoWarn>
     <PackageId>OrionGuard.Generators</PackageId>
-    <Version>6.5.4</Version>
+    <Version>6.5.5</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Source generator for OrionGuard. Generates [GenerateValidator] validators, [StronglyTypedId&lt;TValue&gt;] strongly-typed id types (EF Core ValueConverter, System.Text.Json JsonConverter, TypeConverter companions), and supports NativeAOT-compatible reflection-free workflows.</Description>
     <PackageTags>guard;validation;source-generator;roslyn;nativeaot;codegen;ddd;strongly-typed-id</PackageTags>

--- a/src/Moongazing.OrionGuard.Grpc/Moongazing.OrionGuard.Grpc.csproj
+++ b/src/Moongazing.OrionGuard.Grpc/Moongazing.OrionGuard.Grpc.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Grpc</PackageId>
-    <Version>6.5.4</Version>
+    <Version>6.5.5</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>gRPC integration for OrionGuard validation library. Provides server interceptor for automatic request validation in gRPC services.</Description>
     <PackageTags>guard;validation;grpc;interceptor;protobuf;microservices</PackageTags>

--- a/src/Moongazing.OrionGuard.Locks.Redis/Moongazing.OrionGuard.Locks.Redis.csproj
+++ b/src/Moongazing.OrionGuard.Locks.Redis/Moongazing.OrionGuard.Locks.Redis.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Locks.Redis</PackageId>
-    <Version>6.5.4</Version>
+    <Version>6.5.5</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Redis-backed IDistributedLock for OrionGuard.EntityFrameworkCore's outbox dispatcher. Bridges OrionGuard's IDistributedLock contract to the OrionLock.Redis backend so multi-instance outbox workers can share a Redis-coordinated lease instead of the default SkipLocked DB lock.</Description>
     <PackageTags>guard;outbox;distributed-lock;redis;orionlock;entity-framework-core;efcore</PackageTags>

--- a/src/Moongazing.OrionGuard.MediatR/Moongazing.OrionGuard.MediatR.csproj
+++ b/src/Moongazing.OrionGuard.MediatR/Moongazing.OrionGuard.MediatR.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.MediatR</PackageId>
-    <Version>6.5.4</Version>
+    <Version>6.5.5</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>MediatR integration for OrionGuard validation library. Provides ValidationBehavior pipeline behavior for automatic request validation in CQRS pipelines.</Description>
     <PackageTags>guard;validation;mediatr;cqrs;pipeline;behavior</PackageTags>

--- a/src/Moongazing.OrionGuard.OpenTelemetry/Moongazing.OrionGuard.OpenTelemetry.csproj
+++ b/src/Moongazing.OrionGuard.OpenTelemetry/Moongazing.OrionGuard.OpenTelemetry.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.OpenTelemetry</PackageId>
-    <Version>6.5.4</Version>
+    <Version>6.5.5</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>OpenTelemetry integration for OrionGuard validation library. Provides validation metrics (success/failure rates, latency) and distributed tracing spans.</Description>
     <PackageTags>guard;validation;opentelemetry;metrics;tracing;observability</PackageTags>

--- a/src/Moongazing.OrionGuard.Outbox.Dashboard/Moongazing.OrionGuard.Outbox.Dashboard.csproj
+++ b/src/Moongazing.OrionGuard.Outbox.Dashboard/Moongazing.OrionGuard.Outbox.Dashboard.csproj
@@ -8,9 +8,9 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904;AD0001</NoWarn>
     <PackageId>OrionGuard.Outbox.Dashboard</PackageId>
-    <Version>6.5.4</Version>
+    <Version>6.5.5</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
-    <Description>Read-only outbox operator dashboard for OrionGuard. Maps an authorized listing of failed / poisoned messages from the consumer's DbContext to an ASP.NET Core endpoint group. Replay and discard actions stage to v6.5.5.</Description>
+    <Description>Outbox operator dashboard for OrionGuard. Maps an authorized listing of failed / poisoned messages from the consumer's DbContext to an ASP.NET Core endpoint group, plus POST /{id}/replay and POST /{id}/discard mutation endpoints (v6.5.5) with an optional OnMutation audit hook.</Description>
     <PackageTags>guard;outbox;dashboard;aspnetcore;poisoned-messages;dead-letter</PackageTags>
     <PackageReadmeFile>docs/README.md</PackageReadmeFile>
     <PackageIcon>docs/logo.png</PackageIcon>

--- a/src/Moongazing.OrionGuard.Outbox.Dashboard/OutboxDashboardEndpointRouteBuilderExtensions.cs
+++ b/src/Moongazing.OrionGuard.Outbox.Dashboard/OutboxDashboardEndpointRouteBuilderExtensions.cs
@@ -116,6 +116,20 @@ public static class OutboxDashboardEndpointRouteBuilderExtensions
                     {
                         return Results.NotFound();
                     }
+                    // Reject replay for cleanly-processed rows (Error null AND already
+                    // processed). Without this guard a caller could clear ProcessedOnUtc
+                    // on a successful event, causing the dispatcher to re-dispatch it as
+                    // if the original handler never ran. Failed + dead-lettered rows
+                    // (Error != null) remain replayable - that's the whole point.
+                    if (row.ProcessedOnUtc is not null && row.Error is null)
+                    {
+                        return Results.Conflict(new
+                        {
+                            id,
+                            error = "already-processed-success",
+                            message = "Row was dispatched successfully and has no error; replay would re-deliver a clean event.",
+                        });
+                    }
                     row.RetryCount = 0;
                     row.Error = null;
                     row.ProcessedOnUtc = null;

--- a/src/Moongazing.OrionGuard.Outbox.Dashboard/OutboxDashboardEndpointRouteBuilderExtensions.cs
+++ b/src/Moongazing.OrionGuard.Outbox.Dashboard/OutboxDashboardEndpointRouteBuilderExtensions.cs
@@ -101,6 +101,72 @@ public static class OutboxDashboardEndpointRouteBuilderExtensions
             });
         });
 
+        if (options.EnableMutations)
+        {
+            // Replay: clear RetryCount + Error so the next dispatcher pass re-attempts the
+            // row. ProcessedOnUtc stays null (or is cleared if the dispatcher already
+            // dead-lettered). Returns 200 on success, 404 if the id is unknown.
+            group.MapPost("/{id:guid}/replay",
+                async (TDbContext db, HttpContext http, Guid id) =>
+                {
+                    var row = await db.Set<OutboxMessage>()
+                        .FirstOrDefaultAsync(m => m.Id == id, http.RequestAborted)
+                        .ConfigureAwait(false);
+                    if (row is null)
+                    {
+                        return Results.NotFound();
+                    }
+                    row.RetryCount = 0;
+                    row.Error = null;
+                    row.ProcessedOnUtc = null;
+                    await db.SaveChangesAsync(http.RequestAborted).ConfigureAwait(false);
+
+                    if (options.OnMutation is { } hook)
+                    {
+                        await hook(new OutboxMutationEvent(
+                            Action: "replay",
+                            OutboxMessageId: id,
+                            HttpContext: http,
+                            OccurredAtUtc: DateTime.UtcNow)).ConfigureAwait(false);
+                    }
+                    return Results.Ok(new { id, action = "replay" });
+                });
+
+            // Discard: mark the row processed without re-dispatch. ProcessedOnUtc is set so
+            // the dispatcher loop skips it; Error/RetryCount stay intact so future operators
+            // can still see what failed. Returns 200 on success, 404 if the id is unknown.
+            group.MapPost("/{id:guid}/discard",
+                async (TDbContext db, HttpContext http, Guid id) =>
+                {
+                    var row = await db.Set<OutboxMessage>()
+                        .FirstOrDefaultAsync(m => m.Id == id, http.RequestAborted)
+                        .ConfigureAwait(false);
+                    if (row is null)
+                    {
+                        return Results.NotFound();
+                    }
+                    if (row.ProcessedOnUtc is not null)
+                    {
+                        // Already processed (either by successful dispatch or a prior discard).
+                        // Idempotent: report 200 without re-stamping so audit hooks don't fire
+                        // again.
+                        return Results.Ok(new { id, action = "discard", note = "already processed" });
+                    }
+                    row.ProcessedOnUtc = DateTime.UtcNow;
+                    await db.SaveChangesAsync(http.RequestAborted).ConfigureAwait(false);
+
+                    if (options.OnMutation is { } hook)
+                    {
+                        await hook(new OutboxMutationEvent(
+                            Action: "discard",
+                            OutboxMessageId: id,
+                            HttpContext: http,
+                            OccurredAtUtc: DateTime.UtcNow)).ConfigureAwait(false);
+                    }
+                    return Results.Ok(new { id, action = "discard" });
+                });
+        }
+
         return group;
     }
 

--- a/src/Moongazing.OrionGuard.Outbox.Dashboard/OutboxDashboardOptions.cs
+++ b/src/Moongazing.OrionGuard.Outbox.Dashboard/OutboxDashboardOptions.cs
@@ -57,4 +57,20 @@ public sealed class OutboxDashboardOptions
     /// keep response sizes bounded.
     /// </summary>
     public int ErrorTruncationLength { get; set; } = 1024;
+
+    /// <summary>
+    /// Enable the v6.5.5 mutation endpoints (<c>POST /{id}/replay</c> and
+    /// <c>POST /{id}/discard</c>). Default <see langword="true"/>. Set false when the
+    /// dashboard should remain strictly read-only (e.g., audit-only mounts).
+    /// </summary>
+    public bool EnableMutations { get; set; } = true;
+
+    /// <summary>
+    /// Optional audit hook invoked after every successful replay / discard. The dashboard
+    /// itself never writes audit rows so consumers stay in control of storage shape and
+    /// retention. Throwing from the hook does NOT roll back the mutation; the database
+    /// commit already happened. Wrap in try/catch if you want the endpoint to fail fast on
+    /// audit failure.
+    /// </summary>
+    public Func<OutboxMutationEvent, Task>? OnMutation { get; set; }
 }

--- a/src/Moongazing.OrionGuard.Outbox.Dashboard/OutboxMutationEvent.cs
+++ b/src/Moongazing.OrionGuard.Outbox.Dashboard/OutboxMutationEvent.cs
@@ -1,0 +1,18 @@
+namespace Moongazing.OrionGuard.Outbox.Dashboard;
+
+using Microsoft.AspNetCore.Http;
+
+/// <summary>
+/// Audit hook payload raised by the dashboard's replay / discard endpoints. Surface the
+/// who-did-what context to the consumer's audit pipeline; the dashboard itself never
+/// writes audit rows so consumers can pick any storage shape.
+/// </summary>
+/// <param name="Action">Either <c>"replay"</c> or <c>"discard"</c>.</param>
+/// <param name="OutboxMessageId">Stable id of the row that was mutated.</param>
+/// <param name="HttpContext">Inbound request context (route, user, IP) so consumers can stamp <c>User.Identity.Name</c> or claim-based identifiers.</param>
+/// <param name="OccurredAtUtc">Server clock at the moment the mutation was applied.</param>
+public sealed record OutboxMutationEvent(
+    string Action,
+    Guid OutboxMessageId,
+    HttpContext HttpContext,
+    DateTime OccurredAtUtc);

--- a/src/Moongazing.OrionGuard.Outbox.PostgresNotify/Moongazing.OrionGuard.Outbox.PostgresNotify.csproj
+++ b/src/Moongazing.OrionGuard.Outbox.PostgresNotify/Moongazing.OrionGuard.Outbox.PostgresNotify.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Outbox.PostgresNotify</PackageId>
-    <Version>6.5.4</Version>
+    <Version>6.5.5</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Postgres LISTEN/NOTIFY backed IOutboxWakeSignal for OrionGuard.EntityFrameworkCore. Replaces the v6.5.1 polling fallback with an event-driven wake on every committed outbox row when the consumer's database is PostgreSQL. Falls back to polling cleanly when the LISTEN connection is unreachable.</Description>
     <PackageTags>guard;outbox;postgres;npgsql;listen;notify;push;dispatch;entity-framework-core;efcore</PackageTags>

--- a/src/Moongazing.OrionGuard.Outbox.SqlServerBroker/Moongazing.OrionGuard.Outbox.SqlServerBroker.csproj
+++ b/src/Moongazing.OrionGuard.Outbox.SqlServerBroker/Moongazing.OrionGuard.Outbox.SqlServerBroker.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Outbox.SqlServerBroker</PackageId>
-    <Version>6.5.4</Version>
+    <Version>6.5.5</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>SQL Server Service Broker backed IOutboxWakeSignal for OrionGuard.EntityFrameworkCore. Sibling to OrionGuard.Outbox.PostgresNotify (v6.5.2) for the SQL Server provider. Replaces the v6.5.1 polling-only fallback with an event-driven wake on every committed outbox row via Service Broker's queueing primitives.</Description>
     <PackageTags>guard;outbox;sqlserver;service-broker;push;dispatch;entity-framework-core;efcore</PackageTags>

--- a/src/Moongazing.OrionGuard.SignalR/Moongazing.OrionGuard.SignalR.csproj
+++ b/src/Moongazing.OrionGuard.SignalR/Moongazing.OrionGuard.SignalR.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.SignalR</PackageId>
-    <Version>6.5.4</Version>
+    <Version>6.5.5</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>SignalR integration for OrionGuard validation library. Provides Hub filter for automatic method parameter validation.</Description>
     <PackageTags>guard;validation;signalr;realtime;hub;filter</PackageTags>

--- a/src/Moongazing.OrionGuard.Swagger/Moongazing.OrionGuard.Swagger.csproj
+++ b/src/Moongazing.OrionGuard.Swagger/Moongazing.OrionGuard.Swagger.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Swagger</PackageId>
-    <Version>6.5.4</Version>
+    <Version>6.5.5</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Swagger/OpenAPI integration for OrionGuard. Auto-generates OpenAPI constraints from OrionGuard validation attributes.</Description>
     <PackageTags>guard;validation;swagger;openapi;swashbuckle</PackageTags>

--- a/src/Moongazing.OrionGuard.Testing/Moongazing.OrionGuard.Testing.csproj
+++ b/src/Moongazing.OrionGuard.Testing/Moongazing.OrionGuard.Testing.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Testing</PackageId>
-    <Version>6.5.4</Version>
+    <Version>6.5.5</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Testing helpers for OrionGuard. Provides DomainEventCapture and InMemoryDomainEventDispatcher with framework-agnostic assertions (no xUnit / NUnit / FluentAssertions dependency). Works with any test runner.</Description>
     <PackageTags>guard;validation;testing;ddd;domain-events;assertions;test-helpers</PackageTags>

--- a/src/Moongazing.OrionGuard/Moongazing.OrionGuard.csproj
+++ b/src/Moongazing.OrionGuard/Moongazing.OrionGuard.csproj
@@ -16,7 +16,7 @@
 		<OutputType>Library</OutputType>
 
 		<PackageId>OrionGuard</PackageId>
-		<Version>6.5.4</Version>
+		<Version>6.5.5</Version>
 		<Authors>Tunahan Ali Ozturk</Authors>
 		<Company>Tunahan Ali Ozturk</Company>
 		<GeneratePackageOnBuild>false</GeneratePackageOnBuild>
@@ -35,6 +35,17 @@
 		<PackageProjectUrl>https://github.com/tunahanaliozturk/OrionGuard</PackageProjectUrl>
 		<PackageTags>guard;validation;fluent;exceptions;.NET;input-validation;guard-clauses;defensive-programming;security;localization;format-validation;nativeaot;source-generator;aspnetcore;mediatr</PackageTags>
 		<PackageReleaseNotes>
+v6.5.5 - Outbox operator mutation surface
+
+NEW: POST /_orion/outbox/{id}/replay clears RetryCount + Error + ProcessedOnUtc so the next dispatcher pass re-attempts the row; returns 404 if the id is unknown.
+NEW: POST /_orion/outbox/{id}/discard stamps ProcessedOnUtc=UtcNow without re-dispatch; Error and RetryCount stay intact so later operators see the history. Idempotent for already-processed rows (returns 200 with note).
+NEW: OutboxDashboardOptions.OnMutation Func&lt;OutboxMutationEvent, Task&gt; audit hook fires after a successful replay/discard; consumers stamp User.Identity.Name and store wherever they want. Hook does NOT roll back the commit.
+NEW: OutboxDashboardOptions.EnableMutations (default true) - set false for read-only mounts; the POST endpoints are simply not registered.
+
+Full changelog: https://github.com/tunahanaliozturk/OrionGuard/blob/master/CHANGELOG.md
+
+---
+
 v6.5.4 - Outbox operator read surface
 
 NEW: Moongazing.OrionGuard.Outbox.Dashboard add-on package. MapOutboxDashboard&lt;TDbContext&gt;() registers a route group; GET /_orion/outbox/failed?page=N&amp;size=M returns paginated failed-message metadata (RetryCount &gt;= threshold AND Error != null - covers both still-failing and dispatcher-dead-lettered rows). Payload deliberately excluded from the projection; error text truncated to ErrorTruncationLength.

--- a/tests/Moongazing.OrionGuard.Outbox.Dashboard.Tests/OutboxDashboardEndpointTests.cs
+++ b/tests/Moongazing.OrionGuard.Outbox.Dashboard.Tests/OutboxDashboardEndpointTests.cs
@@ -176,6 +176,23 @@ public sealed class OutboxDashboardEndpointTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task Replay_endpoint_rejects_cleanly_processed_rows_with_409()
+    {
+        // ProcessedOnUtc set + Error null => the row dispatched successfully. Replay would
+        // re-deliver a clean event so the endpoint must refuse.
+        var successful = Row(retryCount: 1, processedOnUtc: DateTime.UtcNow, error: null);
+        await SeedAsync(new[] { successful });
+
+        var response = await client.PostAsync($"/_orion/outbox/{successful.Id}/replay", content: null);
+
+        Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
+        using var scope = host.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<TestDbContext>();
+        var fresh = await db.Set<OutboxMessage>().AsNoTracking().FirstAsync(x => x.Id == successful.Id);
+        Assert.NotNull(fresh.ProcessedOnUtc); // Must NOT have been cleared.
+    }
+
+    [Fact]
     public async Task Replay_endpoint_returns_404_for_unknown_id()
     {
         var response = await client.PostAsync($"/_orion/outbox/{Guid.NewGuid()}/replay", content: null);
@@ -301,6 +318,29 @@ public sealed class OutboxDashboardMutationHookTests : IAsyncLifetime
 
         Assert.Single(events);
         Assert.Equal("replay", events[0].Action);
+        Assert.Equal(id, events[0].OutboxMessageId);
+    }
+
+    [Fact]
+    public async Task OnMutation_fires_after_successful_discard()
+    {
+        var id = Guid.NewGuid();
+        using (var scope = host.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<MutHookCtx>();
+            db.Add(new OutboxMessage
+            {
+                Id = id, EventType = "T", Payload = "{}", OccurredOnUtc = DateTime.UtcNow,
+                RetryCount = 4, Error = "boom",
+            });
+            await db.SaveChangesAsync();
+        }
+
+        var response = await client.PostAsync($"/_orion/outbox/{id}/discard", content: null);
+        response.EnsureSuccessStatusCode();
+
+        Assert.Single(events);
+        Assert.Equal("discard", events[0].Action);
         Assert.Equal(id, events[0].OutboxMessageId);
     }
 

--- a/tests/Moongazing.OrionGuard.Outbox.Dashboard.Tests/OutboxDashboardEndpointTests.cs
+++ b/tests/Moongazing.OrionGuard.Outbox.Dashboard.Tests/OutboxDashboardEndpointTests.cs
@@ -158,6 +158,70 @@ public sealed class OutboxDashboardEndpointTests : IAsyncLifetime
         Assert.Equal(0, body.GetProperty("items").GetArrayLength());
     }
 
+    [Fact]
+    public async Task Replay_endpoint_clears_retry_count_and_error()
+    {
+        var failing = Row(retryCount: 5);
+        await SeedAsync(new[] { failing });
+
+        var response = await client.PostAsync($"/_orion/outbox/{failing.Id}/replay", content: null);
+
+        response.EnsureSuccessStatusCode();
+        using var scope = host.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<TestDbContext>();
+        var fresh = await db.Set<OutboxMessage>().AsNoTracking().FirstAsync(x => x.Id == failing.Id);
+        Assert.Equal(0, fresh.RetryCount);
+        Assert.Null(fresh.Error);
+        Assert.Null(fresh.ProcessedOnUtc);
+    }
+
+    [Fact]
+    public async Task Replay_endpoint_returns_404_for_unknown_id()
+    {
+        var response = await client.PostAsync($"/_orion/outbox/{Guid.NewGuid()}/replay", content: null);
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Discard_endpoint_marks_row_processed_without_re_dispatch()
+    {
+        var failing = Row(retryCount: 5);
+        await SeedAsync(new[] { failing });
+
+        var response = await client.PostAsync($"/_orion/outbox/{failing.Id}/discard", content: null);
+
+        response.EnsureSuccessStatusCode();
+        using var scope = host.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<TestDbContext>();
+        var fresh = await db.Set<OutboxMessage>().AsNoTracking().FirstAsync(x => x.Id == failing.Id);
+        Assert.NotNull(fresh.ProcessedOnUtc);
+        // Error and RetryCount stay intact so future operators see the history.
+        Assert.Equal(5, fresh.RetryCount);
+        Assert.NotNull(fresh.Error);
+    }
+
+    [Fact]
+    public async Task Discard_endpoint_is_idempotent_for_already_processed_rows()
+    {
+        var processed = Row(retryCount: 3, processedOnUtc: DateTime.UtcNow);
+        await SeedAsync(new[] { processed });
+
+        var response = await client.PostAsync($"/_orion/outbox/{processed.Id}/discard", content: null);
+
+        response.EnsureSuccessStatusCode();
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Contains("already processed", body.GetProperty("note").GetString()!, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Discard_endpoint_returns_404_for_unknown_id()
+    {
+        var response = await client.PostAsync($"/_orion/outbox/{Guid.NewGuid()}/discard", content: null);
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
     private sealed class TestDbContext : DbContext
     {
         public TestDbContext(DbContextOptions<TestDbContext> options) : base(options) { }
@@ -169,6 +233,177 @@ public sealed class OutboxDashboardEndpointTests : IAsyncLifetime
                 b.HasKey(x => x.Id);
             });
         }
+    }
+}
+
+public sealed class OutboxDashboardMutationHookTests : IAsyncLifetime
+{
+    private readonly Microsoft.EntityFrameworkCore.Storage.InMemoryDatabaseRoot inMemoryRoot = new();
+    private IHost host = default!;
+    private HttpClient client = default!;
+    private List<OutboxMutationEvent> events = default!;
+
+    public async Task InitializeAsync()
+    {
+        events = new List<OutboxMutationEvent>();
+        var dbName = "mut-hook-" + Guid.NewGuid().ToString("N");
+        host = await new HostBuilder()
+            .ConfigureWebHost(builder =>
+            {
+                builder.UseTestServer();
+                builder.ConfigureServices(s =>
+                {
+                    s.AddRouting();
+                    s.AddDbContext<MutHookCtx>(opts => opts.UseInMemoryDatabase(dbName, inMemoryRoot));
+                });
+                builder.Configure(app =>
+                {
+                    app.UseRouting();
+                    app.UseEndpoints(e => e.MapOutboxDashboard<MutHookCtx>(o =>
+                    {
+                        o.AllowAnonymous = true;
+                        o.OnMutation = evt =>
+                        {
+                            events.Add(evt);
+                            return Task.CompletedTask;
+                        };
+                    }));
+                });
+            })
+            .StartAsync();
+        client = host.GetTestClient();
+    }
+
+    public async Task DisposeAsync()
+    {
+        client.Dispose();
+        await host.StopAsync();
+        host.Dispose();
+    }
+
+    [Fact]
+    public async Task OnMutation_fires_after_successful_replay()
+    {
+        var id = Guid.NewGuid();
+        using (var scope = host.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<MutHookCtx>();
+            db.Add(new OutboxMessage
+            {
+                Id = id, EventType = "T", Payload = "{}", OccurredOnUtc = DateTime.UtcNow,
+                RetryCount = 4, Error = "boom",
+            });
+            await db.SaveChangesAsync();
+        }
+
+        var response = await client.PostAsync($"/_orion/outbox/{id}/replay", content: null);
+        response.EnsureSuccessStatusCode();
+
+        Assert.Single(events);
+        Assert.Equal("replay", events[0].Action);
+        Assert.Equal(id, events[0].OutboxMessageId);
+    }
+
+    [Fact]
+    public async Task OnMutation_does_NOT_fire_when_replay_targets_unknown_id()
+    {
+        var response = await client.PostAsync($"/_orion/outbox/{Guid.NewGuid()}/replay", content: null);
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        Assert.Empty(events);
+    }
+
+    [Fact]
+    public async Task OnMutation_does_NOT_fire_when_discard_targets_already_processed_row()
+    {
+        var id = Guid.NewGuid();
+        using (var scope = host.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<MutHookCtx>();
+            db.Add(new OutboxMessage
+            {
+                Id = id, EventType = "T", Payload = "{}", OccurredOnUtc = DateTime.UtcNow,
+                RetryCount = 3, Error = "boom", ProcessedOnUtc = DateTime.UtcNow,
+            });
+            await db.SaveChangesAsync();
+        }
+
+        var response = await client.PostAsync($"/_orion/outbox/{id}/discard", content: null);
+        response.EnsureSuccessStatusCode();
+
+        Assert.Empty(events);
+    }
+
+    private sealed class MutHookCtx : DbContext
+    {
+        public MutHookCtx(DbContextOptions<MutHookCtx> options) : base(options) { }
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+            => modelBuilder.Entity<OutboxMessage>().ToTable("OutboxMessages").HasKey(x => x.Id);
+    }
+}
+
+public sealed class OutboxDashboardReadOnlyModeTests : IAsyncLifetime
+{
+    private readonly Microsoft.EntityFrameworkCore.Storage.InMemoryDatabaseRoot inMemoryRoot = new();
+    private IHost host = default!;
+    private HttpClient client = default!;
+
+    public async Task InitializeAsync()
+    {
+        var dbName = "readonly-" + Guid.NewGuid().ToString("N");
+        host = await new HostBuilder()
+            .ConfigureWebHost(builder =>
+            {
+                builder.UseTestServer();
+                builder.ConfigureServices(s =>
+                {
+                    s.AddRouting();
+                    s.AddDbContext<ReadOnlyCtx>(opts => opts.UseInMemoryDatabase(dbName, inMemoryRoot));
+                });
+                builder.Configure(app =>
+                {
+                    app.UseRouting();
+                    app.UseEndpoints(e => e.MapOutboxDashboard<ReadOnlyCtx>(o =>
+                    {
+                        o.AllowAnonymous = true;
+                        o.EnableMutations = false;
+                    }));
+                });
+            })
+            .StartAsync();
+        client = host.GetTestClient();
+    }
+
+    public async Task DisposeAsync()
+    {
+        client.Dispose();
+        await host.StopAsync();
+        host.Dispose();
+    }
+
+    [Fact]
+    public async Task EnableMutations_false_does_NOT_register_replay_or_discard_endpoints()
+    {
+        var replay = await client.PostAsync($"/_orion/outbox/{Guid.NewGuid()}/replay", content: null);
+        var discard = await client.PostAsync($"/_orion/outbox/{Guid.NewGuid()}/discard", content: null);
+
+        Assert.Equal(HttpStatusCode.NotFound, replay.StatusCode);
+        Assert.Equal(HttpStatusCode.NotFound, discard.StatusCode);
+    }
+
+    [Fact]
+    public async Task EnableMutations_false_still_serves_the_read_listing()
+    {
+        var response = await client.GetAsync("/_orion/outbox/failed");
+
+        response.EnsureSuccessStatusCode();
+    }
+
+    private sealed class ReadOnlyCtx : DbContext
+    {
+        public ReadOnlyCtx(DbContextOptions<ReadOnlyCtx> options) : base(options) { }
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+            => modelBuilder.Entity<OutboxMessage>().ToTable("OutboxMessages").HasKey(x => x.Id);
     }
 }
 


### PR DESCRIPTION
## OrionGuard v6.5.5 - Outbox operator mutation surface

Completes the operator workflow started in v6.5.4 (read surface).

### Shipped

- `POST /_orion/outbox/{id:guid}/replay` - clears `RetryCount`/`Error`/`ProcessedOnUtc`; 404 for unknown id.
- `POST /_orion/outbox/{id:guid}/discard` - stamps `ProcessedOnUtc=UtcNow`; idempotent for already-processed rows.
- `OutboxDashboardOptions.OnMutation` audit hook (consumer-controlled storage).
- `OutboxDashboardOptions.EnableMutations` (default `true`).
- 18 tests pass (5 endpoint + 3 hook + 2 read-only + 8 existing read).

### Migration

Source-compatible. Existing dashboards gain mutation endpoints automatically; opt-out is `o.EnableMutations = false`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * POST endpoints to replay or discard failed outbox messages.
  * Optional post-mutation audit hook invoked after replay/discard.
  * EnableMutations flag (default: true) to toggle registration of mutation endpoints.

* **Tests**
  * Integration tests covering replay/discard behaviors, hook invocation, idempotency, and read-only mode.

* **Chores**
  * Package version bumped to v6.5.5 across releases.

* **Documentation**
  * Release notes and roadmap updated to describe the new mutation surface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->