### PR TITLE
Release v6.5.6: IOutboxArchiver strategy hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable changes to OrionGuard will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.5.6] - 2026-06-10
+
+### Added
+
+#### `IOutboxArchiver` strategy hook
+
+Outbox archival worker (pre-existing) gains a pluggable strategy hook so consumers can swap the default delete-on-retention behaviour for compliance-friendly archive-table copies without forking the hosted service.
+
+- **`IOutboxArchiver`** interface: `Task<int> ArchiveAsync(DbContext, DateTime cutoff, OutboxArchivalOptions, CancellationToken)`. Implementations honour `OutboxArchivalOptions.PreserveDeadLetters` and `BatchSize`; return value is the row count for the hosted service's logging / metrics.
+- **`DeleteOutboxArchiver`**: the default. Same `ExecuteDeleteAsync` semantics as the pre-v6.5.6 inline code; ordering by `ProcessedOnUtc` so the oldest rows leave first. Honours `PreserveDeadLetters`.
+- **`CopyToTableOutboxArchiver<TArchiveRow>`** (generic): COPIES eligible rows into a consumer-owned archive table, then deletes the originals in the SAME transaction so no row is lost across the boundary. Consumer supplies a `Func<OutboxMessage, TArchiveRow>` projection. Useful for retention regimes that must keep the dispatched-event trail past the live-table window.
+- **`OutboxArchivalHostedService`** ctor gains an optional `IOutboxArchiver?` parameter (position 5, after the existing `ILogger?`). Null defaults to `DeleteOutboxArchiver` so existing wiring keeps working without changes. `ArchiveBatchAsync` now delegates to the archiver instead of executing the delete inline.
+
+### Tests
+
+2 new facts cover the strategy hook: `CopyToTableOutboxArchiver` copies rows to a separate table AND deletes originals; a custom no-op archiver is honoured (default delete path is bypassed). 9 archival facts total.
+
+### Migration from v6.5.5
+
+Source-compatible. Existing `new OutboxArchivalHostedService(opts, scopeFactory, distributedLock, logger)` calls keep the delete-on-retention behaviour. Opt into copy-to-table archival:
+
+```csharp
+services.AddSingleton<IOutboxArchiver>(_ => new CopyToTableOutboxArchiver<OutboxArchiveRow>(m => new OutboxArchiveRow
+{
+    Id = m.Id,
+    EventType = m.EventType,
+    Payload = m.Payload,
+    OccurredOnUtc = m.OccurredOnUtc,
+    ArchivedOnUtc = DateTime.UtcNow,
+}));
+```
+
 ## [6.5.5] - 2026-06-10
 
 ### Added

--- a/src/Moongazing.OrionGuard.AspNetCore/Moongazing.OrionGuard.AspNetCore.csproj
+++ b/src/Moongazing.OrionGuard.AspNetCore/Moongazing.OrionGuard.AspNetCore.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.AspNetCore</PackageId>
-    <Version>6.5.5</Version>
+    <Version>6.5.6</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>ASP.NET Core integration for OrionGuard validation library. Provides middleware, Minimal API endpoint filters, MVC action filters, and RFC 9457 ProblemDetails support.</Description>
     <PackageTags>guard;validation;aspnetcore;middleware;minimal-api;problemdetails</PackageTags>

--- a/src/Moongazing.OrionGuard.Blazor/Moongazing.OrionGuard.Blazor.csproj
+++ b/src/Moongazing.OrionGuard.Blazor/Moongazing.OrionGuard.Blazor.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Blazor</PackageId>
-    <Version>6.5.5</Version>
+    <Version>6.5.6</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Blazor integration for OrionGuard validation library. Provides EditForm validation, custom validation components, and data annotations interop.</Description>
     <PackageTags>guard;validation;blazor;editform;component;wasm;server</PackageTags>

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Moongazing.OrionGuard.EntityFrameworkCore.csproj
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Moongazing.OrionGuard.EntityFrameworkCore.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.EntityFrameworkCore</PackageId>
-    <Version>6.5.5</Version>
+    <Version>6.5.6</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>EF Core integration for OrionGuard. Provides a SaveChanges interceptor that dispatches domain events from AggregateRoot&lt;TId&gt; instances after commit (Inline mode) or via a transactional outbox (Outbox mode) consumed by a hosted background worker. Includes W3C trace context propagation across the outbox boundary.</Description>
     <PackageTags>guard;validation;ddd;domain-events;outbox;entity-framework-core;efcore;aggregate-root</PackageTags>

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Archival/CopyToTableOutboxArchiver.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Archival/CopyToTableOutboxArchiver.cs
@@ -1,0 +1,81 @@
+namespace Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Archival;
+
+using Microsoft.EntityFrameworkCore;
+
+/// <summary>
+/// <see cref="IOutboxArchiver"/> that COPIES rows past the retention cutoff into a
+/// consumer-supplied archive table, then deletes the originals in the SAME transaction so
+/// no row is lost across the boundary. Useful for compliance regimes that require retaining
+/// the audit trail of dispatched events past the live-table retention window.
+/// </summary>
+/// <typeparam name="TArchiveRow">
+/// Consumer-owned entity that maps to the archive table. The mapping function passed to
+/// the constructor projects a live <see cref="OutboxMessage"/> into a
+/// <typeparamref name="TArchiveRow"/>.
+/// </typeparam>
+public sealed class CopyToTableOutboxArchiver<TArchiveRow> : IOutboxArchiver
+    where TArchiveRow : class
+{
+    private readonly Func<OutboxMessage, TArchiveRow> map;
+
+    /// <summary>Construct with the projection function applied to each row before delete.</summary>
+    public CopyToTableOutboxArchiver(Func<OutboxMessage, TArchiveRow> map)
+    {
+        ArgumentNullException.ThrowIfNull(map);
+        this.map = map;
+    }
+
+    /// <inheritdoc />
+    public async Task<int> ArchiveAsync(
+        DbContext dbContext,
+        DateTime cutoff,
+        OutboxArchivalOptions options,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(dbContext);
+        ArgumentNullException.ThrowIfNull(options);
+
+        var query = dbContext.Set<OutboxMessage>()
+            .Where(m => m.ProcessedOnUtc != null && m.ProcessedOnUtc < cutoff);
+
+        if (options.PreserveDeadLetters)
+        {
+            query = query.Where(m => m.Error == null);
+        }
+
+        // Snapshot the eligible rows BEFORE we mutate the table. AsNoTracking keeps the
+        // change-tracker clean; the Take honours the batch size so we do not OOM a
+        // long-running consumer.
+        var live = await query
+            .OrderBy(m => m.ProcessedOnUtc)
+            .Take(options.BatchSize)
+            .AsNoTracking()
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        if (live.Count == 0)
+        {
+            return 0;
+        }
+
+        // Copy + delete in ONE transaction. The archive insert and the live delete must
+        // commit atomically or we risk losing rows (delete without insert) or duplicating
+        // them (insert without delete).
+        await using var tx = await dbContext.Database
+            .BeginTransactionAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var archiveRows = live.Select(map).ToList();
+        await dbContext.Set<TArchiveRow>().AddRangeAsync(archiveRows, cancellationToken).ConfigureAwait(false);
+        await dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        var ids = live.Select(m => m.Id).ToList();
+        var deleted = await dbContext.Set<OutboxMessage>()
+            .Where(m => ids.Contains(m.Id))
+            .ExecuteDeleteAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        await tx.CommitAsync(cancellationToken).ConfigureAwait(false);
+        return deleted;
+    }
+}

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Archival/CopyToTableOutboxArchiver.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Archival/CopyToTableOutboxArchiver.cs
@@ -69,9 +69,18 @@ public sealed class CopyToTableOutboxArchiver<TArchiveRow> : IOutboxArchiver
         await dbContext.Set<TArchiveRow>().AddRangeAsync(archiveRows, cancellationToken).ConfigureAwait(false);
         await dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
+        // Re-check eligibility against the live state before deleting. Between the SELECT
+        // above and this DELETE, another caller may have flipped the row state back to
+        // unprocessed (the v6.5.5 dashboard replay endpoint clears ProcessedOnUtc for
+        // failed rows). Without the predicate the delete would still remove the row by id
+        // and the replay would silently lose its intent.
         var ids = live.Select(m => m.Id).ToList();
+        var preserveDeadLetters = options.PreserveDeadLetters;
         var deleted = await dbContext.Set<OutboxMessage>()
-            .Where(m => ids.Contains(m.Id))
+            .Where(m => ids.Contains(m.Id)
+                     && m.ProcessedOnUtc != null
+                     && m.ProcessedOnUtc < cutoff
+                     && (!preserveDeadLetters || m.Error == null))
             .ExecuteDeleteAsync(cancellationToken)
             .ConfigureAwait(false);
 

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Archival/DeleteOutboxArchiver.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Archival/DeleteOutboxArchiver.cs
@@ -1,0 +1,37 @@
+namespace Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Archival;
+
+using Microsoft.EntityFrameworkCore;
+
+/// <summary>
+/// Default <see cref="IOutboxArchiver"/>: deletes rows past the retention cutoff via
+/// <see cref="EntityFrameworkQueryableExtensions.ExecuteDeleteAsync{TSource}(IQueryable{TSource}, CancellationToken)"/>.
+/// Honours <see cref="OutboxArchivalOptions.PreserveDeadLetters"/>; orders by
+/// <see cref="OutboxMessage.ProcessedOnUtc"/> so the oldest rows leave first.
+/// </summary>
+public sealed class DeleteOutboxArchiver : IOutboxArchiver
+{
+    /// <inheritdoc />
+    public async Task<int> ArchiveAsync(
+        DbContext dbContext,
+        DateTime cutoff,
+        OutboxArchivalOptions options,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(dbContext);
+        ArgumentNullException.ThrowIfNull(options);
+
+        var query = dbContext.Set<OutboxMessage>()
+            .Where(m => m.ProcessedOnUtc != null && m.ProcessedOnUtc < cutoff);
+
+        if (options.PreserveDeadLetters)
+        {
+            query = query.Where(m => m.Error == null);
+        }
+
+        return await query
+            .OrderBy(m => m.ProcessedOnUtc)
+            .Take(options.BatchSize)
+            .ExecuteDeleteAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+}

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Archival/IOutboxArchiver.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Archival/IOutboxArchiver.cs
@@ -1,0 +1,30 @@
+namespace Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Archival;
+
+using Microsoft.EntityFrameworkCore;
+
+/// <summary>
+/// Pluggable archival strategy invoked by <see cref="OutboxArchivalHostedService"/> once
+/// per batch. Default <see cref="DeleteOutboxArchiver"/> deletes rows past the retention
+/// cutoff; consumers wire a custom strategy (copy to archive table, push to object storage,
+/// etc.) by registering their own <see cref="IOutboxArchiver"/> before
+/// <c>opts.UseOutboxArchival(...)</c>.
+/// </summary>
+public interface IOutboxArchiver
+{
+    /// <summary>
+    /// Archive at most <see cref="OutboxArchivalOptions.BatchSize"/> processed rows whose
+    /// <see cref="OutboxMessage.ProcessedOnUtc"/> is older than <paramref name="cutoff"/>.
+    /// The implementation MUST honour <see cref="OutboxArchivalOptions.PreserveDeadLetters"/>
+    /// when filtering rows. Returns the number of rows archived this batch (used by the
+    /// hosted service for logging / metrics).
+    /// </summary>
+    /// <param name="dbContext">The consumer's <see cref="DbContext"/>; resolved fresh per batch.</param>
+    /// <param name="cutoff">UTC instant before which rows are eligible for archival.</param>
+    /// <param name="options">Snapshot of the archival options for this batch.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<int> ArchiveAsync(
+        DbContext dbContext,
+        DateTime cutoff,
+        OutboxArchivalOptions options,
+        CancellationToken cancellationToken);
+}

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Archival/OutboxArchivalHostedService.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Archival/OutboxArchivalHostedService.cs
@@ -38,14 +38,29 @@ public sealed class OutboxArchivalHostedService : BackgroundService
         OutboxArchivalOptions options,
         IServiceScopeFactory scopeFactory,
         IDistributedLock distributedLock,
-        ILogger<OutboxArchivalHostedService>? logger = null,
-        IOutboxArchiver? archiver = null)
+        ILogger<OutboxArchivalHostedService>? logger,
+        IOutboxArchiver? archiver)
     {
         this.options = options ?? throw new ArgumentNullException(nameof(options));
         this.scopeFactory = scopeFactory ?? throw new ArgumentNullException(nameof(scopeFactory));
         this.distributedLock = distributedLock ?? throw new ArgumentNullException(nameof(distributedLock));
         this.archiver = archiver ?? new DeleteOutboxArchiver();
         this.logger = logger;
+    }
+
+    /// <summary>
+    /// Source-compatible 4-arg constructor matching the pre-v6.5.6 ABI. Existing
+    /// applications compiled against v6.5.5 directly instantiate this signature; the v6.5.6
+    /// 5-arg ctor would otherwise be a binary break that surfaces as MissingMethodException
+    /// at runtime. Defaults the archiver to <see cref="DeleteOutboxArchiver"/>.
+    /// </summary>
+    public OutboxArchivalHostedService(
+        OutboxArchivalOptions options,
+        IServiceScopeFactory scopeFactory,
+        IDistributedLock distributedLock,
+        ILogger<OutboxArchivalHostedService>? logger = null)
+        : this(options, scopeFactory, distributedLock, logger, archiver: null)
+    {
     }
 
     /// <summary>Archives one batch of processed rows older than the retention cutoff. Public for tests.</summary>

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Archival/OutboxArchivalHostedService.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Archival/OutboxArchivalHostedService.cs
@@ -17,6 +17,7 @@ public sealed class OutboxArchivalHostedService : BackgroundService
     private readonly OutboxArchivalOptions options;
     private readonly IServiceScopeFactory scopeFactory;
     private readonly IDistributedLock distributedLock;
+    private readonly IOutboxArchiver archiver;
     private readonly ILogger<OutboxArchivalHostedService>? logger;
 
     /// <summary>Initializes a new archival worker.</summary>
@@ -26,53 +27,45 @@ public sealed class OutboxArchivalHostedService : BackgroundService
     /// Distributed lock used to coordinate archival across instances. Use
     /// <see cref="NullDistributedLock"/> for single-instance deployments.
     /// </param>
+    /// <param name="archiver">
+    /// Pluggable archival strategy. When <see langword="null"/>, defaults to
+    /// <see cref="DeleteOutboxArchiver"/> (drop-in equivalent to the pre-v6.5.6 behaviour).
+    /// Consumers register <see cref="CopyToTableOutboxArchiver{TArchiveRow}"/> or their own
+    /// implementation for copy-to-archive-table / push-to-object-storage flows.
+    /// </param>
     /// <param name="logger">Optional logger.</param>
-    /// <exception cref="ArgumentNullException">
-    /// Thrown when <paramref name="options"/>, <paramref name="scopeFactory"/>, or
-    /// <paramref name="distributedLock"/> is <see langword="null"/>.
-    /// </exception>
     public OutboxArchivalHostedService(
         OutboxArchivalOptions options,
         IServiceScopeFactory scopeFactory,
         IDistributedLock distributedLock,
-        ILogger<OutboxArchivalHostedService>? logger = null)
+        ILogger<OutboxArchivalHostedService>? logger = null,
+        IOutboxArchiver? archiver = null)
     {
         this.options = options ?? throw new ArgumentNullException(nameof(options));
         this.scopeFactory = scopeFactory ?? throw new ArgumentNullException(nameof(scopeFactory));
         this.distributedLock = distributedLock ?? throw new ArgumentNullException(nameof(distributedLock));
+        this.archiver = archiver ?? new DeleteOutboxArchiver();
         this.logger = logger;
     }
 
-    /// <summary>Deletes one batch of processed rows older than the retention cutoff. Public for tests.</summary>
+    /// <summary>Archives one batch of processed rows older than the retention cutoff. Public for tests.</summary>
     /// <param name="cancellationToken">Token used to observe cancellation requests.</param>
-    /// <returns>The number of rows deleted in this batch.</returns>
+    /// <returns>The number of rows archived in this batch.</returns>
     public async Task<int> ArchiveBatchAsync(CancellationToken cancellationToken)
     {
         var cutoff = DateTime.UtcNow - options.RetentionPeriod;
         await using var scope = scopeFactory.CreateAsyncScope();
         var ctx = scope.ServiceProvider.GetRequiredService<DbContext>();
 
-        var query = ctx.Set<OutboxMessage>()
-            .Where(m => m.ProcessedOnUtc != null && m.ProcessedOnUtc < cutoff);
+        var archived = await archiver.ArchiveAsync(ctx, cutoff, options, cancellationToken).ConfigureAwait(false);
 
-        if (options.PreserveDeadLetters)
-        {
-            query = query.Where(m => m.Error == null);
-        }
-
-        var deleted = await query
-            .OrderBy(m => m.ProcessedOnUtc)
-            .Take(options.BatchSize)
-            .ExecuteDeleteAsync(cancellationToken)
-            .ConfigureAwait(false);
-
-        if (deleted > 0)
+        if (archived > 0)
         {
             logger?.LogInformation(
-                "Outbox archival deleted {Count} rows older than {Cutoff:O}.", deleted, cutoff);
+                "Outbox archival processed {Count} rows older than {Cutoff:O}.", archived, cutoff);
         }
 
-        return deleted;
+        return archived;
     }
 
     /// <inheritdoc />

--- a/src/Moongazing.OrionGuard.Generators/Moongazing.OrionGuard.Generators.csproj
+++ b/src/Moongazing.OrionGuard.Generators/Moongazing.OrionGuard.Generators.csproj
@@ -8,7 +8,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>CS1591</NoWarn>
     <PackageId>OrionGuard.Generators</PackageId>
-    <Version>6.5.5</Version>
+    <Version>6.5.6</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Source generator for OrionGuard. Generates [GenerateValidator] validators, [StronglyTypedId&lt;TValue&gt;] strongly-typed id types (EF Core ValueConverter, System.Text.Json JsonConverter, TypeConverter companions), and supports NativeAOT-compatible reflection-free workflows.</Description>
     <PackageTags>guard;validation;source-generator;roslyn;nativeaot;codegen;ddd;strongly-typed-id</PackageTags>

--- a/src/Moongazing.OrionGuard.Grpc/Moongazing.OrionGuard.Grpc.csproj
+++ b/src/Moongazing.OrionGuard.Grpc/Moongazing.OrionGuard.Grpc.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Grpc</PackageId>
-    <Version>6.5.5</Version>
+    <Version>6.5.6</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>gRPC integration for OrionGuard validation library. Provides server interceptor for automatic request validation in gRPC services.</Description>
     <PackageTags>guard;validation;grpc;interceptor;protobuf;microservices</PackageTags>

--- a/src/Moongazing.OrionGuard.Locks.Redis/Moongazing.OrionGuard.Locks.Redis.csproj
+++ b/src/Moongazing.OrionGuard.Locks.Redis/Moongazing.OrionGuard.Locks.Redis.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Locks.Redis</PackageId>
-    <Version>6.5.5</Version>
+    <Version>6.5.6</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Redis-backed IDistributedLock for OrionGuard.EntityFrameworkCore's outbox dispatcher. Bridges OrionGuard's IDistributedLock contract to the OrionLock.Redis backend so multi-instance outbox workers can share a Redis-coordinated lease instead of the default SkipLocked DB lock.</Description>
     <PackageTags>guard;outbox;distributed-lock;redis;orionlock;entity-framework-core;efcore</PackageTags>

--- a/src/Moongazing.OrionGuard.MediatR/Moongazing.OrionGuard.MediatR.csproj
+++ b/src/Moongazing.OrionGuard.MediatR/Moongazing.OrionGuard.MediatR.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.MediatR</PackageId>
-    <Version>6.5.5</Version>
+    <Version>6.5.6</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>MediatR integration for OrionGuard validation library. Provides ValidationBehavior pipeline behavior for automatic request validation in CQRS pipelines.</Description>
     <PackageTags>guard;validation;mediatr;cqrs;pipeline;behavior</PackageTags>

--- a/src/Moongazing.OrionGuard.OpenTelemetry/Moongazing.OrionGuard.OpenTelemetry.csproj
+++ b/src/Moongazing.OrionGuard.OpenTelemetry/Moongazing.OrionGuard.OpenTelemetry.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.OpenTelemetry</PackageId>
-    <Version>6.5.5</Version>
+    <Version>6.5.6</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>OpenTelemetry integration for OrionGuard validation library. Provides validation metrics (success/failure rates, latency) and distributed tracing spans.</Description>
     <PackageTags>guard;validation;opentelemetry;metrics;tracing;observability</PackageTags>

--- a/src/Moongazing.OrionGuard.Outbox.Dashboard/Moongazing.OrionGuard.Outbox.Dashboard.csproj
+++ b/src/Moongazing.OrionGuard.Outbox.Dashboard/Moongazing.OrionGuard.Outbox.Dashboard.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904;AD0001</NoWarn>
     <PackageId>OrionGuard.Outbox.Dashboard</PackageId>
-    <Version>6.5.5</Version>
+    <Version>6.5.6</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Outbox operator dashboard for OrionGuard. Maps an authorized listing of failed / poisoned messages from the consumer's DbContext to an ASP.NET Core endpoint group, plus POST /{id}/replay and POST /{id}/discard mutation endpoints (v6.5.5) with an optional OnMutation audit hook.</Description>
     <PackageTags>guard;outbox;dashboard;aspnetcore;poisoned-messages;dead-letter</PackageTags>

--- a/src/Moongazing.OrionGuard.Outbox.PostgresNotify/Moongazing.OrionGuard.Outbox.PostgresNotify.csproj
+++ b/src/Moongazing.OrionGuard.Outbox.PostgresNotify/Moongazing.OrionGuard.Outbox.PostgresNotify.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Outbox.PostgresNotify</PackageId>
-    <Version>6.5.5</Version>
+    <Version>6.5.6</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Postgres LISTEN/NOTIFY backed IOutboxWakeSignal for OrionGuard.EntityFrameworkCore. Replaces the v6.5.1 polling fallback with an event-driven wake on every committed outbox row when the consumer's database is PostgreSQL. Falls back to polling cleanly when the LISTEN connection is unreachable.</Description>
     <PackageTags>guard;outbox;postgres;npgsql;listen;notify;push;dispatch;entity-framework-core;efcore</PackageTags>

--- a/src/Moongazing.OrionGuard.Outbox.SqlServerBroker/Moongazing.OrionGuard.Outbox.SqlServerBroker.csproj
+++ b/src/Moongazing.OrionGuard.Outbox.SqlServerBroker/Moongazing.OrionGuard.Outbox.SqlServerBroker.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Outbox.SqlServerBroker</PackageId>
-    <Version>6.5.5</Version>
+    <Version>6.5.6</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>SQL Server Service Broker backed IOutboxWakeSignal for OrionGuard.EntityFrameworkCore. Sibling to OrionGuard.Outbox.PostgresNotify (v6.5.2) for the SQL Server provider. Replaces the v6.5.1 polling-only fallback with an event-driven wake on every committed outbox row via Service Broker's queueing primitives.</Description>
     <PackageTags>guard;outbox;sqlserver;service-broker;push;dispatch;entity-framework-core;efcore</PackageTags>

--- a/src/Moongazing.OrionGuard.SignalR/Moongazing.OrionGuard.SignalR.csproj
+++ b/src/Moongazing.OrionGuard.SignalR/Moongazing.OrionGuard.SignalR.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.SignalR</PackageId>
-    <Version>6.5.5</Version>
+    <Version>6.5.6</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>SignalR integration for OrionGuard validation library. Provides Hub filter for automatic method parameter validation.</Description>
     <PackageTags>guard;validation;signalr;realtime;hub;filter</PackageTags>

--- a/src/Moongazing.OrionGuard.Swagger/Moongazing.OrionGuard.Swagger.csproj
+++ b/src/Moongazing.OrionGuard.Swagger/Moongazing.OrionGuard.Swagger.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Swagger</PackageId>
-    <Version>6.5.5</Version>
+    <Version>6.5.6</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Swagger/OpenAPI integration for OrionGuard. Auto-generates OpenAPI constraints from OrionGuard validation attributes.</Description>
     <PackageTags>guard;validation;swagger;openapi;swashbuckle</PackageTags>

--- a/src/Moongazing.OrionGuard.Testing/Moongazing.OrionGuard.Testing.csproj
+++ b/src/Moongazing.OrionGuard.Testing/Moongazing.OrionGuard.Testing.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Testing</PackageId>
-    <Version>6.5.5</Version>
+    <Version>6.5.6</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Testing helpers for OrionGuard. Provides DomainEventCapture and InMemoryDomainEventDispatcher with framework-agnostic assertions (no xUnit / NUnit / FluentAssertions dependency). Works with any test runner.</Description>
     <PackageTags>guard;validation;testing;ddd;domain-events;assertions;test-helpers</PackageTags>

--- a/src/Moongazing.OrionGuard/Moongazing.OrionGuard.csproj
+++ b/src/Moongazing.OrionGuard/Moongazing.OrionGuard.csproj
@@ -16,7 +16,7 @@
 		<OutputType>Library</OutputType>
 
 		<PackageId>OrionGuard</PackageId>
-		<Version>6.5.5</Version>
+		<Version>6.5.6</Version>
 		<Authors>Tunahan Ali Ozturk</Authors>
 		<Company>Tunahan Ali Ozturk</Company>
 		<GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/Archival/OutboxArchivalHostedServiceTests.cs
+++ b/tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/Archival/OutboxArchivalHostedServiceTests.cs
@@ -38,12 +38,29 @@ public sealed class ArchivalTestFixture : IAsyncDisposable
     }
 }
 
+public sealed class OutboxArchiveRow
+{
+    public Guid Id { get; set; }
+    public string EventType { get; set; } = default!;
+    public string Payload { get; set; } = default!;
+    public DateTime OccurredOnUtc { get; set; }
+    public DateTime ArchivedOnUtc { get; set; }
+}
+
 public sealed class ArchivalTestDbContext(DbContextOptions<ArchivalTestDbContext> options) : DbContext(options)
 {
     public DbSet<OutboxMessage> Outbox => Set<OutboxMessage>();
+    public DbSet<OutboxArchiveRow> Archive => Set<OutboxArchiveRow>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
-        => modelBuilder.ApplyConfiguration(new OutboxMessageEntityTypeConfiguration("OrionGuard_Outbox"));
+    {
+        modelBuilder.ApplyConfiguration(new OutboxMessageEntityTypeConfiguration("OrionGuard_Outbox"));
+        modelBuilder.Entity<OutboxArchiveRow>(b =>
+        {
+            b.ToTable("OrionGuard_Outbox_Archive");
+            b.HasKey(x => x.Id);
+        });
+    }
 }
 
 public class OutboxArchivalHostedServiceTests : IAsyncLifetime
@@ -159,5 +176,71 @@ public class OutboxArchivalHostedServiceTests : IAsyncLifetime
 
         Assert.Equal(5, deleted);
         Assert.Equal(15, await CountAsync());
+    }
+
+    [Fact]
+    public async Task CopyToTableOutboxArchiver_ShouldCopyRowsToArchiveTableThenDelete()
+    {
+        await SeedAsync(
+            Row(DateTime.UtcNow.AddDays(-45)),
+            Row(DateTime.UtcNow.AddDays(-40)),
+            Row(DateTime.UtcNow.AddDays(-1))); // not yet past retention
+
+        var archiver = new CopyToTableOutboxArchiver<OutboxArchiveRow>(m => new OutboxArchiveRow
+        {
+            Id = m.Id,
+            EventType = m.EventType,
+            Payload = m.Payload,
+            OccurredOnUtc = m.OccurredOnUtc,
+            ArchivedOnUtc = DateTime.UtcNow,
+        });
+
+        var svc = new OutboxArchivalHostedService(
+            new OutboxArchivalOptions { RetentionPeriod = TimeSpan.FromDays(30) },
+            fixture.Services.GetRequiredService<IServiceScopeFactory>(),
+            new NullDistributedLock(),
+            NullLogger<OutboxArchivalHostedService>.Instance,
+            archiver);
+
+        var archived = await svc.ArchiveBatchAsync(CancellationToken.None);
+
+        Assert.Equal(2, archived);
+        Assert.Equal(1, await CountAsync());
+
+        using var scope = fixture.Services.CreateScope();
+        var ctx = scope.ServiceProvider.GetRequiredService<ArchivalTestDbContext>();
+        Assert.Equal(2, await ctx.Archive.CountAsync());
+    }
+
+    [Fact]
+    public async Task IOutboxArchiver_Custom_ShouldBeInvokedInsteadOfDefault()
+    {
+        // Smoke-test that the strategy hook is honoured: a no-op archiver should leave
+        // the table untouched even though the default would delete.
+        await SeedAsync(Row(DateTime.UtcNow.AddDays(-45)));
+
+        var noop = new NoopArchiver();
+        var svc = new OutboxArchivalHostedService(
+            new OutboxArchivalOptions(),
+            fixture.Services.GetRequiredService<IServiceScopeFactory>(),
+            new NullDistributedLock(),
+            NullLogger<OutboxArchivalHostedService>.Instance,
+            noop);
+
+        var archived = await svc.ArchiveBatchAsync(CancellationToken.None);
+
+        Assert.Equal(0, archived);
+        Assert.Equal(1, noop.Invocations);
+        Assert.Equal(1, await CountAsync());
+    }
+
+    private sealed class NoopArchiver : IOutboxArchiver
+    {
+        public int Invocations { get; private set; }
+        public Task<int> ArchiveAsync(DbContext _, DateTime __, OutboxArchivalOptions ___, CancellationToken ____)
+        {
+            Invocations++;
+            return Task.FromResult(0);
+        }
     }
 }


### PR DESCRIPTION
## OrionGuard v6.5.6 - `IOutboxArchiver` strategy hook

Outbox archival worker (pre-existing) gains a pluggable strategy hook so consumers can swap the default delete-on-retention behaviour for copy-to-archive-table flows without forking the hosted service.

### Shipped

- `IOutboxArchiver` interface + `DeleteOutboxArchiver` default + `CopyToTableOutboxArchiver<TArchiveRow>` generic.
- `OutboxArchivalHostedService` ctor takes optional `IOutboxArchiver?` (position 5, after existing `ILogger?`); null defaults to `DeleteOutboxArchiver`.
- 9 archival facts (7 existing + 2 new strategy-hook tests).

### Migration

Source-compatible.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pluggable outbox archival strategies: choose default deletion or copy-then-delete archival to support retention, compliance, and audit workflows.

* **Tests**
  * Added integration tests verifying copy-to-archive archival and custom archiver invocation.

* **Chores**
  * Package versions bumped to 6.5.6 and changelog updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->