### PR TITLE
Release v6.5.7: dashboard sort + richer pagination metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable changes to OrionGuard will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.5.7] - 2026-06-10
+
+### Added
+
+#### Dashboard sort + richer pagination metadata
+
+The v6.5.4 `/failed` listing only supported `OccurredOnUtc` ascending and returned `{page, size, total, items}`. v6.5.7 adds an explicit sort axis and the navigation metadata operators expect for paged tables.
+
+- **`OutboxFailedListingSort`** enum: `OldestFirst` (default), `NewestFirst`, `MostRetries`. Query string: `?sort=newestfirst` (case-insensitive enum name match).
+- **`OutboxDashboardOptions.DefaultSort`** controls the default when the consumer omits the query string. Default `OldestFirst` so operators triage the longest-failing rows first.
+- **Response shape extended** with `totalPages`, `hasNextPage`, `hasPreviousPage`, and `sort` (the resolved enum name). Existing `page` / `size` / `total` / `items` fields unchanged; consumers depending on the v6.5.4-6.5.6 shape continue to parse cleanly.
+- **`MostRetries`** order falls back to `OccurredOnUtc` ascending as a stable tiebreaker so rows with the same retry count stay in deterministic order.
+
+### Tests
+
+4 new facts: pagination metadata returned (total/totalPages/hasNextPage/hasPreviousPage), `NewestFirst` orders descending by `OccurredOnUtc`, `MostRetries` orders descending by `RetryCount`, invalid sort falls back to default. 24 dashboard facts total.
+
+`ConfigureWarnings(w => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning))` added to the in-memory test fixture - additional fixtures pushed the EF Core internal-service-provider count past the framework's 20-instance warning threshold.
+
+### Migration from v6.5.6
+
+Source-compatible. Existing query strings without `?sort=...` use the configured `DefaultSort`.
+
+```csharp
+app.MapOutboxDashboard<AppDbContext>(o =>
+{
+    o.DefaultSort = OutboxFailedListingSort.MostRetries; // triage most-retried first by default
+});
+```
+
 ## [6.5.6] - 2026-06-10
 
 ### Added

--- a/src/Moongazing.OrionGuard.AspNetCore/Moongazing.OrionGuard.AspNetCore.csproj
+++ b/src/Moongazing.OrionGuard.AspNetCore/Moongazing.OrionGuard.AspNetCore.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.AspNetCore</PackageId>
-    <Version>6.5.6</Version>
+    <Version>6.5.7</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>ASP.NET Core integration for OrionGuard validation library. Provides middleware, Minimal API endpoint filters, MVC action filters, and RFC 9457 ProblemDetails support.</Description>
     <PackageTags>guard;validation;aspnetcore;middleware;minimal-api;problemdetails</PackageTags>

--- a/src/Moongazing.OrionGuard.Blazor/Moongazing.OrionGuard.Blazor.csproj
+++ b/src/Moongazing.OrionGuard.Blazor/Moongazing.OrionGuard.Blazor.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Blazor</PackageId>
-    <Version>6.5.6</Version>
+    <Version>6.5.7</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Blazor integration for OrionGuard validation library. Provides EditForm validation, custom validation components, and data annotations interop.</Description>
     <PackageTags>guard;validation;blazor;editform;component;wasm;server</PackageTags>

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Moongazing.OrionGuard.EntityFrameworkCore.csproj
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Moongazing.OrionGuard.EntityFrameworkCore.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.EntityFrameworkCore</PackageId>
-    <Version>6.5.6</Version>
+    <Version>6.5.7</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>EF Core integration for OrionGuard. Provides a SaveChanges interceptor that dispatches domain events from AggregateRoot&lt;TId&gt; instances after commit (Inline mode) or via a transactional outbox (Outbox mode) consumed by a hosted background worker. Includes W3C trace context propagation across the outbox boundary.</Description>
     <PackageTags>guard;validation;ddd;domain-events;outbox;entity-framework-core;efcore;aggregate-root</PackageTags>

--- a/src/Moongazing.OrionGuard.Generators/Moongazing.OrionGuard.Generators.csproj
+++ b/src/Moongazing.OrionGuard.Generators/Moongazing.OrionGuard.Generators.csproj
@@ -8,7 +8,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>CS1591</NoWarn>
     <PackageId>OrionGuard.Generators</PackageId>
-    <Version>6.5.6</Version>
+    <Version>6.5.7</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Source generator for OrionGuard. Generates [GenerateValidator] validators, [StronglyTypedId&lt;TValue&gt;] strongly-typed id types (EF Core ValueConverter, System.Text.Json JsonConverter, TypeConverter companions), and supports NativeAOT-compatible reflection-free workflows.</Description>
     <PackageTags>guard;validation;source-generator;roslyn;nativeaot;codegen;ddd;strongly-typed-id</PackageTags>

--- a/src/Moongazing.OrionGuard.Grpc/Moongazing.OrionGuard.Grpc.csproj
+++ b/src/Moongazing.OrionGuard.Grpc/Moongazing.OrionGuard.Grpc.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Grpc</PackageId>
-    <Version>6.5.6</Version>
+    <Version>6.5.7</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>gRPC integration for OrionGuard validation library. Provides server interceptor for automatic request validation in gRPC services.</Description>
     <PackageTags>guard;validation;grpc;interceptor;protobuf;microservices</PackageTags>

--- a/src/Moongazing.OrionGuard.Locks.Redis/Moongazing.OrionGuard.Locks.Redis.csproj
+++ b/src/Moongazing.OrionGuard.Locks.Redis/Moongazing.OrionGuard.Locks.Redis.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Locks.Redis</PackageId>
-    <Version>6.5.6</Version>
+    <Version>6.5.7</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Redis-backed IDistributedLock for OrionGuard.EntityFrameworkCore's outbox dispatcher. Bridges OrionGuard's IDistributedLock contract to the OrionLock.Redis backend so multi-instance outbox workers can share a Redis-coordinated lease instead of the default SkipLocked DB lock.</Description>
     <PackageTags>guard;outbox;distributed-lock;redis;orionlock;entity-framework-core;efcore</PackageTags>

--- a/src/Moongazing.OrionGuard.MediatR/Moongazing.OrionGuard.MediatR.csproj
+++ b/src/Moongazing.OrionGuard.MediatR/Moongazing.OrionGuard.MediatR.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.MediatR</PackageId>
-    <Version>6.5.6</Version>
+    <Version>6.5.7</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>MediatR integration for OrionGuard validation library. Provides ValidationBehavior pipeline behavior for automatic request validation in CQRS pipelines.</Description>
     <PackageTags>guard;validation;mediatr;cqrs;pipeline;behavior</PackageTags>

--- a/src/Moongazing.OrionGuard.OpenTelemetry/Moongazing.OrionGuard.OpenTelemetry.csproj
+++ b/src/Moongazing.OrionGuard.OpenTelemetry/Moongazing.OrionGuard.OpenTelemetry.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.OpenTelemetry</PackageId>
-    <Version>6.5.6</Version>
+    <Version>6.5.7</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>OpenTelemetry integration for OrionGuard validation library. Provides validation metrics (success/failure rates, latency) and distributed tracing spans.</Description>
     <PackageTags>guard;validation;opentelemetry;metrics;tracing;observability</PackageTags>

--- a/src/Moongazing.OrionGuard.Outbox.Dashboard/Moongazing.OrionGuard.Outbox.Dashboard.csproj
+++ b/src/Moongazing.OrionGuard.Outbox.Dashboard/Moongazing.OrionGuard.Outbox.Dashboard.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904;AD0001</NoWarn>
     <PackageId>OrionGuard.Outbox.Dashboard</PackageId>
-    <Version>6.5.6</Version>
+    <Version>6.5.7</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Outbox operator dashboard for OrionGuard. Maps an authorized listing of failed / poisoned messages from the consumer's DbContext to an ASP.NET Core endpoint group, plus POST /{id}/replay and POST /{id}/discard mutation endpoints (v6.5.5) with an optional OnMutation audit hook.</Description>
     <PackageTags>guard;outbox;dashboard;aspnetcore;poisoned-messages;dead-letter</PackageTags>

--- a/src/Moongazing.OrionGuard.Outbox.Dashboard/OutboxDashboardEndpointRouteBuilderExtensions.cs
+++ b/src/Moongazing.OrionGuard.Outbox.Dashboard/OutboxDashboardEndpointRouteBuilderExtensions.cs
@@ -58,26 +58,35 @@ public static class OutboxDashboardEndpointRouteBuilderExtensions
         }
         // else: intentionally fall through so the host's FallbackPolicy applies.
 
-        group.MapGet("/failed", async (TDbContext db, HttpContext http, int? page, int? size) =>
+        group.MapGet("/failed", async (TDbContext db, HttpContext http, int? page, int? size, string? sort) =>
         {
             var pageNumber = page is null or < 1 ? 1 : page.Value;
             var pageSize = ResolvePageSize(size, options);
             var skip = (pageNumber - 1) * pageSize;
             var threshold = options.FailedRetryThreshold;
             var truncation = options.ErrorTruncationLength;
+            var sortOrder = ResolveSort(sort, options.DefaultSort);
 
             // Include BOTH still-failing rows (Error set, not yet processed) AND rows that
             // the dispatcher dead-lettered (it stamps ProcessedOnUtc once RetryCount >=
             // MaxRetries while preserving Error/RetryCount for operator inspection). Filtering
             // on Error != null AND RetryCount >= threshold covers both states without
             // double-counting successfully-dispatched rows (those have Error == null).
-            var query = db.Set<OutboxMessage>()
+            var baseQuery = db.Set<OutboxMessage>()
                 .AsNoTracking()
-                .Where(m => m.RetryCount >= threshold && m.Error != null)
-                .OrderBy(m => m.OccurredOnUtc);
+                .Where(m => m.RetryCount >= threshold && m.Error != null);
 
-            var total = await query.CountAsync(http.RequestAborted).ConfigureAwait(false);
-            var rows = await query
+            IQueryable<OutboxMessage> ordered = sortOrder switch
+            {
+                OutboxFailedListingSort.NewestFirst => baseQuery.OrderByDescending(m => m.OccurredOnUtc),
+                OutboxFailedListingSort.MostRetries => baseQuery
+                    .OrderByDescending(m => m.RetryCount)
+                    .ThenBy(m => m.OccurredOnUtc),
+                _ => baseQuery.OrderBy(m => m.OccurredOnUtc),
+            };
+
+            var total = await baseQuery.CountAsync(http.RequestAborted).ConfigureAwait(false);
+            var rows = await ordered
                 .Skip(skip)
                 .Take(pageSize)
                 .Select(m => new OutboxFailedMessageRow(
@@ -92,11 +101,16 @@ public static class OutboxDashboardEndpointRouteBuilderExtensions
                 .ToListAsync(http.RequestAborted)
                 .ConfigureAwait(false);
 
+            var totalPages = (int)Math.Ceiling((double)total / pageSize);
             return Results.Ok(new
             {
                 page = pageNumber,
                 size = pageSize,
                 total,
+                totalPages,
+                hasNextPage = pageNumber < totalPages,
+                hasPreviousPage = pageNumber > 1,
+                sort = sortOrder.ToString(),
                 items = rows,
             });
         });
@@ -188,6 +202,17 @@ public static class OutboxDashboardEndpointRouteBuilderExtensions
     {
         var size = requested is null or < 1 ? options.DefaultPageSize : requested.Value;
         return size > options.MaxPageSize ? options.MaxPageSize : size;
+    }
+
+    private static OutboxFailedListingSort ResolveSort(string? requested, OutboxFailedListingSort fallback)
+    {
+        if (string.IsNullOrWhiteSpace(requested))
+        {
+            return fallback;
+        }
+        return Enum.TryParse<OutboxFailedListingSort>(requested, ignoreCase: true, out var parsed)
+            ? parsed
+            : fallback;
     }
 
     private static void ValidateOptions(OutboxDashboardOptions options)

--- a/src/Moongazing.OrionGuard.Outbox.Dashboard/OutboxDashboardEndpointRouteBuilderExtensions.cs
+++ b/src/Moongazing.OrionGuard.Outbox.Dashboard/OutboxDashboardEndpointRouteBuilderExtensions.cs
@@ -210,7 +210,12 @@ public static class OutboxDashboardEndpointRouteBuilderExtensions
         {
             return fallback;
         }
+        // Enum.TryParse with ignoreCase=true also accepts numeric strings ("99") and
+        // returns Success when the value can be cast to the enum's underlying type. That
+        // would let a misconfigured caller smuggle an undefined sort through the response.
+        // Pair the parse with Enum.IsDefined so only declared names succeed.
         return Enum.TryParse<OutboxFailedListingSort>(requested, ignoreCase: true, out var parsed)
+               && Enum.IsDefined(typeof(OutboxFailedListingSort), parsed)
             ? parsed
             : fallback;
     }

--- a/src/Moongazing.OrionGuard.Outbox.Dashboard/OutboxDashboardOptions.cs
+++ b/src/Moongazing.OrionGuard.Outbox.Dashboard/OutboxDashboardOptions.cs
@@ -73,4 +73,28 @@ public sealed class OutboxDashboardOptions
     /// audit failure.
     /// </summary>
     public Func<OutboxMutationEvent, Task>? OnMutation { get; set; }
+
+    /// <summary>
+    /// Default sort applied to the failed-listing when the consumer omits the
+    /// <c>sort</c> query string. Default <see cref="OutboxFailedListingSort.OldestFirst"/>;
+    /// most operators want to triage the longest-failing rows first.
+    /// </summary>
+    public OutboxFailedListingSort DefaultSort { get; set; } = OutboxFailedListingSort.OldestFirst;
+}
+
+/// <summary>
+/// Sort options accepted by the failed-listing endpoint's <c>sort</c> query string. The
+/// query string value matches the enum name case-insensitively (e.g. <c>?sort=newestfirst</c>
+/// or <c>?sort=mostretries</c>).
+/// </summary>
+public enum OutboxFailedListingSort
+{
+    /// <summary>Order by <see cref="EntityFrameworkCore.Outbox.OutboxMessage.OccurredOnUtc"/> ascending - the dispatcher's natural FIFO order.</summary>
+    OldestFirst = 0,
+
+    /// <summary>Order by <see cref="EntityFrameworkCore.Outbox.OutboxMessage.OccurredOnUtc"/> descending - newest events first.</summary>
+    NewestFirst = 1,
+
+    /// <summary>Order by <see cref="EntityFrameworkCore.Outbox.OutboxMessage.RetryCount"/> descending - the most-retried rows first.</summary>
+    MostRetries = 2,
 }

--- a/src/Moongazing.OrionGuard.Outbox.PostgresNotify/Moongazing.OrionGuard.Outbox.PostgresNotify.csproj
+++ b/src/Moongazing.OrionGuard.Outbox.PostgresNotify/Moongazing.OrionGuard.Outbox.PostgresNotify.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Outbox.PostgresNotify</PackageId>
-    <Version>6.5.6</Version>
+    <Version>6.5.7</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Postgres LISTEN/NOTIFY backed IOutboxWakeSignal for OrionGuard.EntityFrameworkCore. Replaces the v6.5.1 polling fallback with an event-driven wake on every committed outbox row when the consumer's database is PostgreSQL. Falls back to polling cleanly when the LISTEN connection is unreachable.</Description>
     <PackageTags>guard;outbox;postgres;npgsql;listen;notify;push;dispatch;entity-framework-core;efcore</PackageTags>

--- a/src/Moongazing.OrionGuard.Outbox.SqlServerBroker/Moongazing.OrionGuard.Outbox.SqlServerBroker.csproj
+++ b/src/Moongazing.OrionGuard.Outbox.SqlServerBroker/Moongazing.OrionGuard.Outbox.SqlServerBroker.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Outbox.SqlServerBroker</PackageId>
-    <Version>6.5.6</Version>
+    <Version>6.5.7</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>SQL Server Service Broker backed IOutboxWakeSignal for OrionGuard.EntityFrameworkCore. Sibling to OrionGuard.Outbox.PostgresNotify (v6.5.2) for the SQL Server provider. Replaces the v6.5.1 polling-only fallback with an event-driven wake on every committed outbox row via Service Broker's queueing primitives.</Description>
     <PackageTags>guard;outbox;sqlserver;service-broker;push;dispatch;entity-framework-core;efcore</PackageTags>

--- a/src/Moongazing.OrionGuard.SignalR/Moongazing.OrionGuard.SignalR.csproj
+++ b/src/Moongazing.OrionGuard.SignalR/Moongazing.OrionGuard.SignalR.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.SignalR</PackageId>
-    <Version>6.5.6</Version>
+    <Version>6.5.7</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>SignalR integration for OrionGuard validation library. Provides Hub filter for automatic method parameter validation.</Description>
     <PackageTags>guard;validation;signalr;realtime;hub;filter</PackageTags>

--- a/src/Moongazing.OrionGuard.Swagger/Moongazing.OrionGuard.Swagger.csproj
+++ b/src/Moongazing.OrionGuard.Swagger/Moongazing.OrionGuard.Swagger.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Swagger</PackageId>
-    <Version>6.5.6</Version>
+    <Version>6.5.7</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Swagger/OpenAPI integration for OrionGuard. Auto-generates OpenAPI constraints from OrionGuard validation attributes.</Description>
     <PackageTags>guard;validation;swagger;openapi;swashbuckle</PackageTags>

--- a/src/Moongazing.OrionGuard.Testing/Moongazing.OrionGuard.Testing.csproj
+++ b/src/Moongazing.OrionGuard.Testing/Moongazing.OrionGuard.Testing.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Testing</PackageId>
-    <Version>6.5.6</Version>
+    <Version>6.5.7</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Testing helpers for OrionGuard. Provides DomainEventCapture and InMemoryDomainEventDispatcher with framework-agnostic assertions (no xUnit / NUnit / FluentAssertions dependency). Works with any test runner.</Description>
     <PackageTags>guard;validation;testing;ddd;domain-events;assertions;test-helpers</PackageTags>

--- a/src/Moongazing.OrionGuard/Moongazing.OrionGuard.csproj
+++ b/src/Moongazing.OrionGuard/Moongazing.OrionGuard.csproj
@@ -16,7 +16,7 @@
 		<OutputType>Library</OutputType>
 
 		<PackageId>OrionGuard</PackageId>
-		<Version>6.5.6</Version>
+		<Version>6.5.7</Version>
 		<Authors>Tunahan Ali Ozturk</Authors>
 		<Company>Tunahan Ali Ozturk</Company>
 		<GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/tests/Moongazing.OrionGuard.Outbox.Dashboard.Tests/OutboxDashboardEndpointTests.cs
+++ b/tests/Moongazing.OrionGuard.Outbox.Dashboard.Tests/OutboxDashboardEndpointTests.cs
@@ -29,7 +29,7 @@ public sealed class OutboxDashboardEndpointTests : IAsyncLifetime
                 builder.ConfigureServices(s =>
                 {
                     s.AddRouting();
-                    s.AddDbContext<TestDbContext>(opts => opts.UseInMemoryDatabase(dbName, inMemoryRoot));
+                    s.AddDbContext<TestDbContext>(opts => opts.UseInMemoryDatabase(dbName, inMemoryRoot).ConfigureWarnings(w => w.Ignore(Microsoft.EntityFrameworkCore.Diagnostics.CoreEventId.ManyServiceProvidersCreatedWarning)));
                 });
                 builder.Configure(app =>
                 {
@@ -159,6 +159,72 @@ public sealed class OutboxDashboardEndpointTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task Failed_endpoint_returns_pagination_metadata()
+    {
+        await SeedAsync(Enumerable.Range(0, 25).Select(_ => Row(retryCount: 3)));
+
+        var body = await client.GetFromJsonAsync<JsonElement>("/_orion/outbox/failed?page=2&size=10");
+
+        Assert.Equal(25, body.GetProperty("total").GetInt32());
+        Assert.Equal(3, body.GetProperty("totalPages").GetInt32());
+        Assert.True(body.GetProperty("hasNextPage").GetBoolean());
+        Assert.True(body.GetProperty("hasPreviousPage").GetBoolean());
+    }
+
+    [Fact]
+    public async Task Failed_endpoint_sort_NewestFirst_orders_descending_by_OccurredOnUtc()
+    {
+        var anchor = DateTime.UtcNow;
+        await SeedAsync(new[]
+        {
+            new OutboxMessage { EventType = "T", Payload = "{}", OccurredOnUtc = anchor.AddMinutes(-30), RetryCount = 3, Error = "boom1" },
+            new OutboxMessage { EventType = "T", Payload = "{}", OccurredOnUtc = anchor.AddMinutes(-10), RetryCount = 3, Error = "boom2" },
+            new OutboxMessage { EventType = "T", Payload = "{}", OccurredOnUtc = anchor.AddMinutes(-20), RetryCount = 3, Error = "boom3" },
+        });
+
+        var body = await client.GetFromJsonAsync<JsonElement>("/_orion/outbox/failed?sort=NewestFirst");
+
+        var items = body.GetProperty("items");
+        Assert.Equal(3, items.GetArrayLength());
+        for (var i = 0; i < items.GetArrayLength() - 1; i++)
+        {
+            var current = items[i].GetProperty("occurredOnUtc").GetDateTime();
+            var next = items[i + 1].GetProperty("occurredOnUtc").GetDateTime();
+            Assert.True(current >= next, "rows must be in descending OccurredOnUtc order");
+        }
+        Assert.Equal("NewestFirst", body.GetProperty("sort").GetString());
+    }
+
+    [Fact]
+    public async Task Failed_endpoint_sort_MostRetries_orders_descending_by_RetryCount()
+    {
+        await SeedAsync(new[]
+        {
+            new OutboxMessage { EventType = "T", Payload = "{}", OccurredOnUtc = DateTime.UtcNow, RetryCount = 5, Error = "x" },
+            new OutboxMessage { EventType = "T", Payload = "{}", OccurredOnUtc = DateTime.UtcNow, RetryCount = 9, Error = "x" },
+            new OutboxMessage { EventType = "T", Payload = "{}", OccurredOnUtc = DateTime.UtcNow, RetryCount = 3, Error = "x" },
+        });
+
+        var body = await client.GetFromJsonAsync<JsonElement>("/_orion/outbox/failed?sort=MostRetries");
+
+        var items = body.GetProperty("items");
+        Assert.Equal(9, items[0].GetProperty("retryCount").GetInt32());
+        Assert.Equal(5, items[1].GetProperty("retryCount").GetInt32());
+        Assert.Equal(3, items[2].GetProperty("retryCount").GetInt32());
+    }
+
+    [Fact]
+    public async Task Failed_endpoint_invalid_sort_falls_back_to_default()
+    {
+        await SeedAsync(new[] { Row(retryCount: 3) });
+
+        var body = await client.GetFromJsonAsync<JsonElement>("/_orion/outbox/failed?sort=garbage");
+
+        // Default is OldestFirst; the response echoes the resolved sort regardless.
+        Assert.Equal("OldestFirst", body.GetProperty("sort").GetString());
+    }
+
+    [Fact]
     public async Task Replay_endpoint_clears_retry_count_and_error()
     {
         var failing = Row(retryCount: 5);
@@ -271,7 +337,7 @@ public sealed class OutboxDashboardMutationHookTests : IAsyncLifetime
                 builder.ConfigureServices(s =>
                 {
                     s.AddRouting();
-                    s.AddDbContext<MutHookCtx>(opts => opts.UseInMemoryDatabase(dbName, inMemoryRoot));
+                    s.AddDbContext<MutHookCtx>(opts => opts.UseInMemoryDatabase(dbName, inMemoryRoot).ConfigureWarnings(w => w.Ignore(Microsoft.EntityFrameworkCore.Diagnostics.CoreEventId.ManyServiceProvidersCreatedWarning)));
                 });
                 builder.Configure(app =>
                 {
@@ -398,7 +464,7 @@ public sealed class OutboxDashboardReadOnlyModeTests : IAsyncLifetime
                 builder.ConfigureServices(s =>
                 {
                     s.AddRouting();
-                    s.AddDbContext<ReadOnlyCtx>(opts => opts.UseInMemoryDatabase(dbName, inMemoryRoot));
+                    s.AddDbContext<ReadOnlyCtx>(opts => opts.UseInMemoryDatabase(dbName, inMemoryRoot).ConfigureWarnings(w => w.Ignore(Microsoft.EntityFrameworkCore.Diagnostics.CoreEventId.ManyServiceProvidersCreatedWarning)));
                 });
                 builder.Configure(app =>
                 {
@@ -459,7 +525,7 @@ public sealed class OutboxDashboardConfigurationTests
                 builder.ConfigureServices(s =>
                 {
                     s.AddRouting();
-                    s.AddDbContext<DummyDbContext>(opts => opts.UseInMemoryDatabase("opts-test"));
+                    s.AddDbContext<DummyDbContext>(opts => opts.UseInMemoryDatabase("opts-test").ConfigureWarnings(w => w.Ignore(Microsoft.EntityFrameworkCore.Diagnostics.CoreEventId.ManyServiceProvidersCreatedWarning)));
                 });
                 builder.Configure(app =>
                 {
@@ -488,7 +554,7 @@ public sealed class OutboxDashboardConfigurationTests
                 builder.ConfigureServices(s =>
                 {
                     s.AddRouting();
-                    s.AddDbContext<DummyDbContext>(opts => opts.UseInMemoryDatabase("opts-" + Guid.NewGuid()));
+                    s.AddDbContext<DummyDbContext>(opts => opts.UseInMemoryDatabase("opts-" + Guid.NewGuid()).ConfigureWarnings(w => w.Ignore(Microsoft.EntityFrameworkCore.Diagnostics.CoreEventId.ManyServiceProvidersCreatedWarning)));
                 });
                 builder.Configure(app =>
                 {

--- a/tests/Moongazing.OrionGuard.Outbox.Dashboard.Tests/OutboxDashboardEndpointTests.cs
+++ b/tests/Moongazing.OrionGuard.Outbox.Dashboard.Tests/OutboxDashboardEndpointTests.cs
@@ -214,6 +214,19 @@ public sealed class OutboxDashboardEndpointTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task Failed_endpoint_numeric_sort_outside_enum_range_falls_back_to_default()
+    {
+        await SeedAsync(new[] { Row(retryCount: 3) });
+
+        // ?sort=99 must NOT be accepted by Enum.TryParse + Enum.IsDefined - the response
+        // would otherwise echo "99" as the sort axis even though the rows came out in the
+        // default order.
+        var body = await client.GetFromJsonAsync<JsonElement>("/_orion/outbox/failed?sort=99");
+
+        Assert.Equal("OldestFirst", body.GetProperty("sort").GetString());
+    }
+
+    [Fact]
     public async Task Failed_endpoint_invalid_sort_falls_back_to_default()
     {
         await SeedAsync(new[] { Row(retryCount: 3) });


### PR DESCRIPTION
## OrionGuard v6.5.7 - Dashboard sort + richer pagination metadata

### Shipped

- `OutboxFailedListingSort` enum (OldestFirst / NewestFirst / MostRetries) + `?sort=` query string.
- `OutboxDashboardOptions.DefaultSort`.
- Response shape adds `totalPages`, `hasNextPage`, `hasPreviousPage`, `sort`. Existing fields unchanged.
- 24 facts (4 new + 20 existing).

### Migration

Source-compatible.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added sorting options to the outbox dashboard failed listing: OldestFirst, NewestFirst, MostRetries.
  * `/failed` endpoint returns enhanced pagination metadata (`totalPages`, `hasNextPage`, `hasPreviousPage`) and echoes the resolved sort name.
  * Configurable default sort order via DefaultSort setting.

* **Tests**
  * Added coverage for pagination, sorting (including fallback for invalid sort), and MostRetries ordering behavior.

* **Chores**
  * Version bumped to 6.5.7 across packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->