### PR TITLE
Release v6.5.8: outbox dashboard cursor pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to OrionGuard will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.5.8] - 2026-06-10
+
+### Added
+
+#### Outbox dashboard cursor-based pagination
+
+The v6.5.4-6.5.7 `/failed` endpoint used offset pagination (`?page=N&size=M`). Offset pagination grows expensive on large failed-message tables (each page does an OFFSET scan of every preceding row) and is unstable when new rows arrive mid-paging (the same row can appear on consecutive pages, or be skipped entirely). v6.5.8 adds a cursor variant that uses keyset pagination: the next page's WHERE predicate seeks past the last-seen `(sortKey, Id)` pair so the database does an index seek instead of an OFFSET scan.
+
+- **`GET /_orion/outbox/failed/cursor?cursor=<token>&size=N&sort=<axis>`**: paginated endpoint that returns up to `size` rows past the cursor's last position, plus the `nextCursor` for the page after. The first call sends no cursor; subsequent calls send the `nextCursor` from the previous response.
+- **`OutboxFailedCursor`** opaque token: base64Url-encoded `(LastOccurredOnUtcTicks, LastId, LastRetryCount, Sort)`. Internal-only - clients treat it as opaque. The sort axis is encoded INTO the cursor so a caller cannot switch sort mid-paging and get duplicate / skipped rows.
+- **One-extra-row peek**: the endpoint fetches `size + 1` rows; if the peek row exists, slice it off and emit a `nextCursor` based on the LAST returned row (not the peek). Detects "is there another page" without a separate COUNT round-trip.
+- **Invalid / garbage cursors** fall back to the no-cursor path (start of results) rather than 400. Matches the dashboard's existing forgiving query-string behaviour (invalid `sort` also falls back rather than failing the request).
+- **Stable tiebreaker**: every sort axis appends `Id` as a secondary key so rows with identical `OccurredOnUtc` / `RetryCount` stay in deterministic order across pages.
+
+### Tests
+
+5 new facts: cursor pages through 25 rows in chunks of 10 with no duplicates / no skips, `hasNextPage=true` + `nextCursor` set when more rows remain, `hasNextPage=false` + `nextCursor=null` on last page, invalid cursor falls back to beginning, cursor locks sort axis (switched `?sort=` on a follow-up call is ignored). 30 dashboard facts total.
+
+### Migration from v6.5.7
+
+Source-compatible. The existing `/failed` offset endpoint continues to work; the cursor endpoint is an additive new route. Operator UIs that page through large tables should switch to the cursor variant:
+
+```
+GET /_orion/outbox/failed/cursor?size=50&sort=MostRetries
+-> { items: [...], nextCursor: "AAAB...", hasNextPage: true, ... }
+GET /_orion/outbox/failed/cursor?cursor=AAAB...&size=50
+-> next page
+```
+
 ## [6.5.7] - 2026-06-10
 
 ### Added

--- a/src/Moongazing.OrionGuard.AspNetCore/Moongazing.OrionGuard.AspNetCore.csproj
+++ b/src/Moongazing.OrionGuard.AspNetCore/Moongazing.OrionGuard.AspNetCore.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.AspNetCore</PackageId>
-    <Version>6.5.7</Version>
+    <Version>6.5.8</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>ASP.NET Core integration for OrionGuard validation library. Provides middleware, Minimal API endpoint filters, MVC action filters, and RFC 9457 ProblemDetails support.</Description>
     <PackageTags>guard;validation;aspnetcore;middleware;minimal-api;problemdetails</PackageTags>

--- a/src/Moongazing.OrionGuard.Blazor/Moongazing.OrionGuard.Blazor.csproj
+++ b/src/Moongazing.OrionGuard.Blazor/Moongazing.OrionGuard.Blazor.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Blazor</PackageId>
-    <Version>6.5.7</Version>
+    <Version>6.5.8</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Blazor integration for OrionGuard validation library. Provides EditForm validation, custom validation components, and data annotations interop.</Description>
     <PackageTags>guard;validation;blazor;editform;component;wasm;server</PackageTags>

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Moongazing.OrionGuard.EntityFrameworkCore.csproj
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Moongazing.OrionGuard.EntityFrameworkCore.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.EntityFrameworkCore</PackageId>
-    <Version>6.5.7</Version>
+    <Version>6.5.8</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>EF Core integration for OrionGuard. Provides a SaveChanges interceptor that dispatches domain events from AggregateRoot&lt;TId&gt; instances after commit (Inline mode) or via a transactional outbox (Outbox mode) consumed by a hosted background worker. Includes W3C trace context propagation across the outbox boundary.</Description>
     <PackageTags>guard;validation;ddd;domain-events;outbox;entity-framework-core;efcore;aggregate-root</PackageTags>

--- a/src/Moongazing.OrionGuard.Generators/Moongazing.OrionGuard.Generators.csproj
+++ b/src/Moongazing.OrionGuard.Generators/Moongazing.OrionGuard.Generators.csproj
@@ -8,7 +8,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>CS1591</NoWarn>
     <PackageId>OrionGuard.Generators</PackageId>
-    <Version>6.5.7</Version>
+    <Version>6.5.8</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Source generator for OrionGuard. Generates [GenerateValidator] validators, [StronglyTypedId&lt;TValue&gt;] strongly-typed id types (EF Core ValueConverter, System.Text.Json JsonConverter, TypeConverter companions), and supports NativeAOT-compatible reflection-free workflows.</Description>
     <PackageTags>guard;validation;source-generator;roslyn;nativeaot;codegen;ddd;strongly-typed-id</PackageTags>

--- a/src/Moongazing.OrionGuard.Grpc/Moongazing.OrionGuard.Grpc.csproj
+++ b/src/Moongazing.OrionGuard.Grpc/Moongazing.OrionGuard.Grpc.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Grpc</PackageId>
-    <Version>6.5.7</Version>
+    <Version>6.5.8</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>gRPC integration for OrionGuard validation library. Provides server interceptor for automatic request validation in gRPC services.</Description>
     <PackageTags>guard;validation;grpc;interceptor;protobuf;microservices</PackageTags>

--- a/src/Moongazing.OrionGuard.Locks.Redis/Moongazing.OrionGuard.Locks.Redis.csproj
+++ b/src/Moongazing.OrionGuard.Locks.Redis/Moongazing.OrionGuard.Locks.Redis.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Locks.Redis</PackageId>
-    <Version>6.5.7</Version>
+    <Version>6.5.8</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Redis-backed IDistributedLock for OrionGuard.EntityFrameworkCore's outbox dispatcher. Bridges OrionGuard's IDistributedLock contract to the OrionLock.Redis backend so multi-instance outbox workers can share a Redis-coordinated lease instead of the default SkipLocked DB lock.</Description>
     <PackageTags>guard;outbox;distributed-lock;redis;orionlock;entity-framework-core;efcore</PackageTags>

--- a/src/Moongazing.OrionGuard.MediatR/Moongazing.OrionGuard.MediatR.csproj
+++ b/src/Moongazing.OrionGuard.MediatR/Moongazing.OrionGuard.MediatR.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.MediatR</PackageId>
-    <Version>6.5.7</Version>
+    <Version>6.5.8</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>MediatR integration for OrionGuard validation library. Provides ValidationBehavior pipeline behavior for automatic request validation in CQRS pipelines.</Description>
     <PackageTags>guard;validation;mediatr;cqrs;pipeline;behavior</PackageTags>

--- a/src/Moongazing.OrionGuard.OpenTelemetry/Moongazing.OrionGuard.OpenTelemetry.csproj
+++ b/src/Moongazing.OrionGuard.OpenTelemetry/Moongazing.OrionGuard.OpenTelemetry.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.OpenTelemetry</PackageId>
-    <Version>6.5.7</Version>
+    <Version>6.5.8</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>OpenTelemetry integration for OrionGuard validation library. Provides validation metrics (success/failure rates, latency) and distributed tracing spans.</Description>
     <PackageTags>guard;validation;opentelemetry;metrics;tracing;observability</PackageTags>

--- a/src/Moongazing.OrionGuard.Outbox.Dashboard/Moongazing.OrionGuard.Outbox.Dashboard.csproj
+++ b/src/Moongazing.OrionGuard.Outbox.Dashboard/Moongazing.OrionGuard.Outbox.Dashboard.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904;AD0001</NoWarn>
     <PackageId>OrionGuard.Outbox.Dashboard</PackageId>
-    <Version>6.5.7</Version>
+    <Version>6.5.8</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Outbox operator dashboard for OrionGuard. Maps an authorized listing of failed / poisoned messages from the consumer's DbContext to an ASP.NET Core endpoint group, plus POST /{id}/replay and POST /{id}/discard mutation endpoints (v6.5.5) with an optional OnMutation audit hook.</Description>
     <PackageTags>guard;outbox;dashboard;aspnetcore;poisoned-messages;dead-letter</PackageTags>

--- a/src/Moongazing.OrionGuard.Outbox.Dashboard/OutboxDashboardEndpointRouteBuilderExtensions.cs
+++ b/src/Moongazing.OrionGuard.Outbox.Dashboard/OutboxDashboardEndpointRouteBuilderExtensions.cs
@@ -115,6 +115,102 @@ public static class OutboxDashboardEndpointRouteBuilderExtensions
             });
         });
 
+        group.MapGet("/failed/cursor", async (TDbContext db, HttpContext http, string? cursor, int? size, string? sort) =>
+        {
+            var pageSize = ResolvePageSize(size, options);
+            var threshold = options.FailedRetryThreshold;
+            var truncation = options.ErrorTruncationLength;
+
+            // Sort axis is taken from the cursor when present (a switched sort mid-paging
+            // would otherwise emit duplicate / skipped rows). If no cursor is supplied,
+            // fall through to the query-string / default like the offset endpoint.
+            OutboxFailedCursor.TryDecode(cursor, out var decoded);
+            var sortOrder = cursor is not null && OutboxFailedCursor.TryDecode(cursor, out var fromCursor)
+                ? fromCursor.Sort
+                : ResolveSort(sort, options.DefaultSort);
+
+            var baseQuery = db.Set<OutboxMessage>()
+                .AsNoTracking()
+                .Where(m => m.RetryCount >= threshold && m.Error != null);
+
+            // Apply cursor predicate to the WHERE so the database does a keyset seek
+            // instead of an OFFSET scan. Each branch repeats the secondary key (Id) as a
+            // stable tiebreaker so rows with identical sort values do not slip through.
+            if (cursor is not null && OutboxFailedCursor.TryDecode(cursor, out var c))
+            {
+                var lastOccurred = new DateTime(c.LastOccurredOnUtcTicks, DateTimeKind.Utc);
+                var lastId = c.LastId;
+                var lastRetries = c.LastRetryCount;
+                baseQuery = sortOrder switch
+                {
+                    OutboxFailedListingSort.NewestFirst => baseQuery.Where(m =>
+                        m.OccurredOnUtc < lastOccurred
+                        || (m.OccurredOnUtc == lastOccurred && m.Id.CompareTo(lastId) > 0)),
+                    OutboxFailedListingSort.MostRetries => baseQuery.Where(m =>
+                        m.RetryCount < lastRetries
+                        || (m.RetryCount == lastRetries && m.OccurredOnUtc > lastOccurred)
+                        || (m.RetryCount == lastRetries && m.OccurredOnUtc == lastOccurred && m.Id.CompareTo(lastId) > 0)),
+                    _ => baseQuery.Where(m =>
+                        m.OccurredOnUtc > lastOccurred
+                        || (m.OccurredOnUtc == lastOccurred && m.Id.CompareTo(lastId) > 0)),
+                };
+            }
+
+            IQueryable<OutboxMessage> ordered = sortOrder switch
+            {
+                OutboxFailedListingSort.NewestFirst => baseQuery
+                    .OrderByDescending(m => m.OccurredOnUtc).ThenBy(m => m.Id),
+                OutboxFailedListingSort.MostRetries => baseQuery
+                    .OrderByDescending(m => m.RetryCount)
+                    .ThenBy(m => m.OccurredOnUtc)
+                    .ThenBy(m => m.Id),
+                _ => baseQuery.OrderBy(m => m.OccurredOnUtc).ThenBy(m => m.Id),
+            };
+
+            // Take one extra row to detect whether another page exists without an extra
+            // round-trip; the response slices off the peek before serialisation.
+            var page = await ordered
+                .Take(pageSize + 1)
+                .Select(m => new OutboxFailedMessageRow(
+                    m.Id,
+                    m.EventType,
+                    m.OccurredOnUtc,
+                    m.RetryCount,
+                    m.Error == null
+                        ? null
+                        : m.Error.Length <= truncation ? m.Error : m.Error.Substring(0, truncation),
+                    m.CorrelationId))
+                .ToListAsync(http.RequestAborted)
+                .ConfigureAwait(false);
+
+            string? nextCursor = null;
+            if (page.Count > pageSize)
+            {
+                // Peeked one ahead - slice it off and base the next cursor on the LAST
+                // returned row (not the peek row), which is the one the client will see
+                // as their "last" position.
+                page.RemoveAt(page.Count - 1);
+                if (page.Count > 0)
+                {
+                    var last = page[^1];
+                    nextCursor = new OutboxFailedCursor(
+                        last.OccurredOnUtc.Ticks,
+                        last.Id,
+                        last.RetryCount,
+                        sortOrder).Encode();
+                }
+            }
+
+            return Results.Ok(new
+            {
+                size = pageSize,
+                sort = sortOrder.ToString(),
+                items = page,
+                nextCursor,
+                hasNextPage = nextCursor is not null,
+            });
+        });
+
         if (options.EnableMutations)
         {
             // Replay: clear RetryCount + Error so the next dispatcher pass re-attempts the

--- a/src/Moongazing.OrionGuard.Outbox.Dashboard/OutboxFailedCursor.cs
+++ b/src/Moongazing.OrionGuard.Outbox.Dashboard/OutboxFailedCursor.cs
@@ -73,11 +73,16 @@ internal readonly record struct OutboxFailedCursor(
             return false;
         }
         if (!long.TryParse(parts[0], NumberStyles.Integer, CultureInfo.InvariantCulture, out var ticks)
+            || ticks < DateTime.MinValue.Ticks
+            || ticks > DateTime.MaxValue.Ticks
             || !Guid.TryParseExact(parts[1], "N", out var id)
             || !int.TryParse(parts[2], NumberStyles.Integer, CultureInfo.InvariantCulture, out var retries)
             || !int.TryParse(parts[3], NumberStyles.Integer, CultureInfo.InvariantCulture, out var sortRaw)
             || !Enum.IsDefined(typeof(OutboxFailedListingSort), sortRaw))
         {
+            // Reject out-of-range ticks here so the endpoint's `new DateTime(ticks, Utc)`
+            // cannot throw ArgumentOutOfRangeException - a malformed cursor MUST fall
+            // back to the start of results, not surface as a 500.
             return false;
         }
         cursor = new OutboxFailedCursor(ticks, id, retries, (OutboxFailedListingSort)sortRaw);

--- a/src/Moongazing.OrionGuard.Outbox.Dashboard/OutboxFailedCursor.cs
+++ b/src/Moongazing.OrionGuard.Outbox.Dashboard/OutboxFailedCursor.cs
@@ -1,0 +1,86 @@
+namespace Moongazing.OrionGuard.Outbox.Dashboard;
+
+using System.Buffers.Text;
+using System.Globalization;
+using System.Text;
+
+/// <summary>
+/// Opaque cursor token used by the v6.5.8 cursor-pagination endpoint
+/// (<c>GET /_orion/outbox/failed/cursor</c>). The cursor encodes the last row's sort key
+/// + id + retry count + axis so the next page predicate is a deterministic
+/// <c>WHERE (sortKey, id) &gt; (lastSortKey, lastId)</c> instead of the offset-pagination
+/// <c>OFFSET</c> that grows expensive on large failed-message tables.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Wire format: <c>base64Url(LastOccurredOnUtc.Ticks | LastId | LastRetryCount | Sort)</c>
+/// joined with <c>'|'</c> separators. The encoding is opaque to clients - a future
+/// schema change can rev the format without affecting the public API.
+/// </para>
+/// <para>
+/// The cursor is NOT cryptographically signed; consumers MUST treat it as a soft hint
+/// for paging and re-validate any business rules on the rows the page returns. The token
+/// is bound to the sort axis it was issued under; a caller that switches sort mid-paging
+/// effectively restarts from page one.
+/// </para>
+/// </remarks>
+internal readonly record struct OutboxFailedCursor(
+    long LastOccurredOnUtcTicks,
+    Guid LastId,
+    int LastRetryCount,
+    OutboxFailedListingSort Sort)
+{
+    public string Encode()
+    {
+        var raw = string.Join('|',
+            LastOccurredOnUtcTicks.ToString(CultureInfo.InvariantCulture),
+            LastId.ToString("N"),
+            LastRetryCount.ToString(CultureInfo.InvariantCulture),
+            ((int)Sort).ToString(CultureInfo.InvariantCulture));
+        return Convert.ToBase64String(Encoding.UTF8.GetBytes(raw))
+            // base64url - replace + / with - _ and strip padding so the cursor fits a
+            // URL query string without escaping.
+            .Replace('+', '-')
+            .Replace('/', '_')
+            .TrimEnd('=');
+    }
+
+    public static bool TryDecode(string? raw, out OutboxFailedCursor cursor)
+    {
+        cursor = default;
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            return false;
+        }
+        var padded = raw.Replace('-', '+').Replace('_', '/');
+        switch (padded.Length % 4)
+        {
+            case 2: padded += "=="; break;
+            case 3: padded += "="; break;
+        }
+        byte[] bytes;
+        try
+        {
+            bytes = Convert.FromBase64String(padded);
+        }
+        catch (FormatException)
+        {
+            return false;
+        }
+        var parts = Encoding.UTF8.GetString(bytes).Split('|');
+        if (parts.Length != 4)
+        {
+            return false;
+        }
+        if (!long.TryParse(parts[0], NumberStyles.Integer, CultureInfo.InvariantCulture, out var ticks)
+            || !Guid.TryParseExact(parts[1], "N", out var id)
+            || !int.TryParse(parts[2], NumberStyles.Integer, CultureInfo.InvariantCulture, out var retries)
+            || !int.TryParse(parts[3], NumberStyles.Integer, CultureInfo.InvariantCulture, out var sortRaw)
+            || !Enum.IsDefined(typeof(OutboxFailedListingSort), sortRaw))
+        {
+            return false;
+        }
+        cursor = new OutboxFailedCursor(ticks, id, retries, (OutboxFailedListingSort)sortRaw);
+        return true;
+    }
+}

--- a/src/Moongazing.OrionGuard.Outbox.PostgresNotify/Moongazing.OrionGuard.Outbox.PostgresNotify.csproj
+++ b/src/Moongazing.OrionGuard.Outbox.PostgresNotify/Moongazing.OrionGuard.Outbox.PostgresNotify.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Outbox.PostgresNotify</PackageId>
-    <Version>6.5.7</Version>
+    <Version>6.5.8</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Postgres LISTEN/NOTIFY backed IOutboxWakeSignal for OrionGuard.EntityFrameworkCore. Replaces the v6.5.1 polling fallback with an event-driven wake on every committed outbox row when the consumer's database is PostgreSQL. Falls back to polling cleanly when the LISTEN connection is unreachable.</Description>
     <PackageTags>guard;outbox;postgres;npgsql;listen;notify;push;dispatch;entity-framework-core;efcore</PackageTags>

--- a/src/Moongazing.OrionGuard.Outbox.SqlServerBroker/Moongazing.OrionGuard.Outbox.SqlServerBroker.csproj
+++ b/src/Moongazing.OrionGuard.Outbox.SqlServerBroker/Moongazing.OrionGuard.Outbox.SqlServerBroker.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Outbox.SqlServerBroker</PackageId>
-    <Version>6.5.7</Version>
+    <Version>6.5.8</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>SQL Server Service Broker backed IOutboxWakeSignal for OrionGuard.EntityFrameworkCore. Sibling to OrionGuard.Outbox.PostgresNotify (v6.5.2) for the SQL Server provider. Replaces the v6.5.1 polling-only fallback with an event-driven wake on every committed outbox row via Service Broker's queueing primitives.</Description>
     <PackageTags>guard;outbox;sqlserver;service-broker;push;dispatch;entity-framework-core;efcore</PackageTags>

--- a/src/Moongazing.OrionGuard.SignalR/Moongazing.OrionGuard.SignalR.csproj
+++ b/src/Moongazing.OrionGuard.SignalR/Moongazing.OrionGuard.SignalR.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.SignalR</PackageId>
-    <Version>6.5.7</Version>
+    <Version>6.5.8</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>SignalR integration for OrionGuard validation library. Provides Hub filter for automatic method parameter validation.</Description>
     <PackageTags>guard;validation;signalr;realtime;hub;filter</PackageTags>

--- a/src/Moongazing.OrionGuard.Swagger/Moongazing.OrionGuard.Swagger.csproj
+++ b/src/Moongazing.OrionGuard.Swagger/Moongazing.OrionGuard.Swagger.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Swagger</PackageId>
-    <Version>6.5.7</Version>
+    <Version>6.5.8</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Swagger/OpenAPI integration for OrionGuard. Auto-generates OpenAPI constraints from OrionGuard validation attributes.</Description>
     <PackageTags>guard;validation;swagger;openapi;swashbuckle</PackageTags>

--- a/src/Moongazing.OrionGuard.Testing/Moongazing.OrionGuard.Testing.csproj
+++ b/src/Moongazing.OrionGuard.Testing/Moongazing.OrionGuard.Testing.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Testing</PackageId>
-    <Version>6.5.7</Version>
+    <Version>6.5.8</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Testing helpers for OrionGuard. Provides DomainEventCapture and InMemoryDomainEventDispatcher with framework-agnostic assertions (no xUnit / NUnit / FluentAssertions dependency). Works with any test runner.</Description>
     <PackageTags>guard;validation;testing;ddd;domain-events;assertions;test-helpers</PackageTags>

--- a/src/Moongazing.OrionGuard/Moongazing.OrionGuard.csproj
+++ b/src/Moongazing.OrionGuard/Moongazing.OrionGuard.csproj
@@ -16,7 +16,7 @@
 		<OutputType>Library</OutputType>
 
 		<PackageId>OrionGuard</PackageId>
-		<Version>6.5.7</Version>
+		<Version>6.5.8</Version>
 		<Authors>Tunahan Ali Ozturk</Authors>
 		<Company>Tunahan Ali Ozturk</Company>
 		<GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/tests/Moongazing.OrionGuard.Outbox.Dashboard.Tests/OutboxDashboardEndpointTests.cs
+++ b/tests/Moongazing.OrionGuard.Outbox.Dashboard.Tests/OutboxDashboardEndpointTests.cs
@@ -238,6 +238,106 @@ public sealed class OutboxDashboardEndpointTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task Cursor_endpoint_pages_through_results_using_nextCursor()
+    {
+        var anchor = new DateTime(2026, 6, 10, 12, 0, 0, DateTimeKind.Utc);
+        var rows = Enumerable.Range(0, 25)
+            .Select(i => new OutboxMessage
+            {
+                EventType = "T",
+                Payload = "{}",
+                OccurredOnUtc = anchor.AddMinutes(i),
+                RetryCount = 3,
+                Error = $"boom-{i}",
+            })
+            .ToArray();
+        await SeedAsync(rows);
+
+        var collected = new List<Guid>();
+        string? cursor = null;
+        for (var i = 0; i < 5; i++)
+        {
+            var url = cursor is null
+                ? "/_orion/outbox/failed/cursor?size=10"
+                : $"/_orion/outbox/failed/cursor?cursor={cursor}&size=10";
+            var body = await client.GetFromJsonAsync<JsonElement>(url);
+            foreach (var item in body.GetProperty("items").EnumerateArray())
+            {
+                collected.Add(item.GetProperty("id").GetGuid());
+            }
+            cursor = body.TryGetProperty("nextCursor", out var ncEl) && ncEl.ValueKind == JsonValueKind.String
+                ? ncEl.GetString()
+                : null;
+            if (cursor is null)
+            {
+                break;
+            }
+        }
+
+        Assert.Equal(25, collected.Count);
+        Assert.Equal(25, collected.Distinct().Count());
+        Assert.Null(cursor);
+    }
+
+    [Fact]
+    public async Task Cursor_endpoint_returns_hasNextPage_true_when_more_results_exist()
+    {
+        await SeedAsync(Enumerable.Range(0, 15).Select(_ => Row(retryCount: 3)));
+
+        var body = await client.GetFromJsonAsync<JsonElement>("/_orion/outbox/failed/cursor?size=5");
+
+        Assert.True(body.GetProperty("hasNextPage").GetBoolean());
+        Assert.Equal(5, body.GetProperty("items").GetArrayLength());
+        Assert.NotNull(body.GetProperty("nextCursor").GetString());
+    }
+
+    [Fact]
+    public async Task Cursor_endpoint_returns_hasNextPage_false_on_last_page()
+    {
+        await SeedAsync(Enumerable.Range(0, 5).Select(_ => Row(retryCount: 3)));
+
+        var body = await client.GetFromJsonAsync<JsonElement>("/_orion/outbox/failed/cursor?size=10");
+
+        Assert.False(body.GetProperty("hasNextPage").GetBoolean());
+        Assert.Equal(5, body.GetProperty("items").GetArrayLength());
+        Assert.Equal(JsonValueKind.Null, body.GetProperty("nextCursor").ValueKind);
+    }
+
+    [Fact]
+    public async Task Cursor_endpoint_invalid_cursor_starts_from_beginning()
+    {
+        await SeedAsync(Enumerable.Range(0, 3).Select(_ => Row(retryCount: 3)));
+
+        var body = await client.GetFromJsonAsync<JsonElement>("/_orion/outbox/failed/cursor?cursor=garbage-not-base64");
+
+        // Falls through to default (no WHERE seek), returns all 3 rows.
+        Assert.Equal(3, body.GetProperty("items").GetArrayLength());
+    }
+
+    [Fact]
+    public async Task Cursor_endpoint_locks_sort_axis_to_cursor()
+    {
+        var anchor = new DateTime(2026, 6, 10, 12, 0, 0, DateTimeKind.Utc);
+        await SeedAsync(new[]
+        {
+            new OutboxMessage { EventType = "T", Payload = "{}", OccurredOnUtc = anchor.AddMinutes(0), RetryCount = 3, Error = "x" },
+            new OutboxMessage { EventType = "T", Payload = "{}", OccurredOnUtc = anchor.AddMinutes(10), RetryCount = 9, Error = "x" },
+        });
+
+        var first = await client.GetFromJsonAsync<JsonElement>("/_orion/outbox/failed/cursor?sort=MostRetries&size=1");
+        Assert.Equal("MostRetries", first.GetProperty("sort").GetString());
+        var nextCursor = first.GetProperty("nextCursor").GetString();
+        Assert.NotNull(nextCursor);
+
+        // Even though the caller asks for OldestFirst on the second page, the cursor
+        // forces the original axis so paging stays consistent.
+        var second = await client.GetFromJsonAsync<JsonElement>(
+            $"/_orion/outbox/failed/cursor?cursor={nextCursor}&sort=OldestFirst");
+
+        Assert.Equal("MostRetries", second.GetProperty("sort").GetString());
+    }
+
+    [Fact]
     public async Task Replay_endpoint_clears_retry_count_and_error()
     {
         var failing = Row(retryCount: 5);


### PR DESCRIPTION
## OrionGuard v6.5.8 - Outbox dashboard cursor pagination

### Shipped

- `GET /_orion/outbox/failed/cursor?cursor=<token>&size=N&sort=<axis>` new endpoint with keyset pagination.
- `OutboxFailedCursor` opaque token encoding `(LastOccurredOnUtcTicks, LastId, LastRetryCount, Sort)`.
- One-extra-row peek to detect `hasNextPage` without a COUNT round-trip.
- Sort axis locked to cursor so mid-paging switches are ignored.
- 30 facts (5 new + 25 existing).

### Migration

Source-compatible. Offset `/failed` endpoint unchanged; cursor variant is additive.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Outbox Dashboard adds cursor-based pagination for failed messages via a new /failed/cursor endpoint — deterministic ordering, opaque cursor tokens, hasNextPage/nextCursor, and sort-axis locking; offset endpoint remains available.

* **Documentation**
  * Changelog updated with cursor pagination details, token format, invalid-cursor fallback, and migration notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->