### PR TITLE
Release v6.5.9: off-box archival via IOutboxArchiveSink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to OrionGuard will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.5.9] - 2026-06-10
+
+### Added
+
+#### `IOutboxArchiveSink` + `BlobOutboxArchiver` for off-box archival
+
+Extends the v6.5.6 `IOutboxArchiver` strategy hook. v6.5.6 introduced the `CopyToTableOutboxArchiver` archive-table pattern; v6.5.9 ships the off-box version: rows leave the database entirely after archival, landing in a consumer-supplied blob sink (S3, Azure Blob, GCS, local filesystem).
+
+- `IOutboxArchiveSink` abstraction with a single `WriteAsync(string keyHint, ReadOnlyMemory<byte> payload, ct)` call.
+- `BlobOutboxArchiver` orchestrates SELECT eligible rows -> serialise to newline-delimited JSON (`.jsonl`) -> `sink.WriteAsync` -> `ExecuteDelete` with re-checked eligibility (matches v6.5.6 safety).
+- `LocalFileOutboxArchiveSink` reference implementation writes `.jsonl` files to a local directory.
+- Sink failure aborts the sweep WITHOUT deleting; rows stay on the live table for the next tick.
+
+### Tests
+
+6 new facts; 30 dashboard + 15 archival facts total.
+
+### Migration from v6.5.8
+
+Source-compatible.
+
 ## [6.5.8] - 2026-06-10
 
 ### Added

--- a/src/Moongazing.OrionGuard.AspNetCore/Moongazing.OrionGuard.AspNetCore.csproj
+++ b/src/Moongazing.OrionGuard.AspNetCore/Moongazing.OrionGuard.AspNetCore.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.AspNetCore</PackageId>
-    <Version>6.5.8</Version>
+    <Version>6.5.9</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>ASP.NET Core integration for OrionGuard validation library. Provides middleware, Minimal API endpoint filters, MVC action filters, and RFC 9457 ProblemDetails support.</Description>
     <PackageTags>guard;validation;aspnetcore;middleware;minimal-api;problemdetails</PackageTags>

--- a/src/Moongazing.OrionGuard.Blazor/Moongazing.OrionGuard.Blazor.csproj
+++ b/src/Moongazing.OrionGuard.Blazor/Moongazing.OrionGuard.Blazor.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Blazor</PackageId>
-    <Version>6.5.8</Version>
+    <Version>6.5.9</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Blazor integration for OrionGuard validation library. Provides EditForm validation, custom validation components, and data annotations interop.</Description>
     <PackageTags>guard;validation;blazor;editform;component;wasm;server</PackageTags>

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Moongazing.OrionGuard.EntityFrameworkCore.csproj
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Moongazing.OrionGuard.EntityFrameworkCore.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.EntityFrameworkCore</PackageId>
-    <Version>6.5.8</Version>
+    <Version>6.5.9</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>EF Core integration for OrionGuard. Provides a SaveChanges interceptor that dispatches domain events from AggregateRoot&lt;TId&gt; instances after commit (Inline mode) or via a transactional outbox (Outbox mode) consumed by a hosted background worker. Includes W3C trace context propagation across the outbox boundary.</Description>
     <PackageTags>guard;validation;ddd;domain-events;outbox;entity-framework-core;efcore;aggregate-root</PackageTags>

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Archival/BlobOutboxArchiver.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Archival/BlobOutboxArchiver.cs
@@ -70,7 +70,12 @@ public sealed class BlobOutboxArchiver : IOutboxArchiver
         // Serialise to JSON Lines before the sink call so a serialisation failure also
         // aborts the sweep without partial state.
         var payload = SerializeJsonLines(rows);
-        var keyHint = $"outbox-{nowUtc().ToString("yyyy-MM-ddTHH-mm-ssZ", System.Globalization.CultureInfo.InvariantCulture)}";
+        // Append a short id suffix so two batches that land in the same UTC second do
+        // not collide on the key hint. LocalFileOutboxArchiveSink uses CreateNew and many
+        // object-store sinks naturally use the hint as the object key; without the
+        // suffix the second batch would fail with a duplicate-key error or, worse,
+        // overwrite the first.
+        var keyHint = $"outbox-{nowUtc().ToString("yyyy-MM-ddTHH-mm-ssZ", System.Globalization.CultureInfo.InvariantCulture)}-{Guid.NewGuid():N}";
         await sink.WriteAsync(keyHint, payload, cancellationToken).ConfigureAwait(false);
 
         // Re-check eligibility against the live state before deleting; matches the

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Archival/BlobOutboxArchiver.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Archival/BlobOutboxArchiver.cs
@@ -1,0 +1,121 @@
+namespace Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Archival;
+
+using System.Buffers;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+
+/// <summary>
+/// <see cref="IOutboxArchiver"/> that ships expiring outbox rows to an external blob
+/// store (S3, Azure Blob, GCS, local filesystem) via an <see cref="IOutboxArchiveSink"/>
+/// before deleting them from the live table. Pairs with the v6.5.6
+/// <see cref="CopyToTableOutboxArchiver{TArchiveRow}"/> archive-table pattern but ships
+/// off-box: consumers wire a cloud-object-store sink and expiring rows leave the database
+/// entirely after archival.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Write order matters: the sink call runs FIRST, then the delete. A sink failure aborts
+/// the sweep (the rows stay on the live table for the next tick). The delete is gated on
+/// the same eligibility predicate the SELECT used so a concurrent replay-endpoint cannot
+/// lose its intent between the snapshot and the delete (matches the v6.5.6 copy-then-delete
+/// safety pattern).
+/// </para>
+/// <para>
+/// Payload format: newline-delimited JSON (<c>.jsonl</c>) records, one per row. Each
+/// record carries the fields the BlobOutboxArchiver decided to ship; consumers wanting a
+/// different shape register a different archiver. The default record shape is a
+/// projection over id, event type, payload, occurred/processed timestamps, retry count,
+/// error, and correlation id.
+/// </para>
+/// </remarks>
+public sealed class BlobOutboxArchiver : IOutboxArchiver
+{
+    private readonly IOutboxArchiveSink sink;
+    private readonly Func<DateTime> nowUtc;
+
+    /// <summary>Construct with a sink. The <c>nowUtc</c> hook lets tests stamp a deterministic key hint.</summary>
+    public BlobOutboxArchiver(IOutboxArchiveSink sink, Func<DateTime>? nowUtc = null)
+    {
+        ArgumentNullException.ThrowIfNull(sink);
+        this.sink = sink;
+        this.nowUtc = nowUtc ?? (() => DateTime.UtcNow);
+    }
+
+    /// <inheritdoc />
+    public async Task<int> ArchiveAsync(
+        DbContext dbContext,
+        DateTime cutoff,
+        OutboxArchivalOptions options,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(dbContext);
+        ArgumentNullException.ThrowIfNull(options);
+
+        var preserveDeadLetters = options.PreserveDeadLetters;
+        var rows = await dbContext.Set<OutboxMessage>()
+            .AsNoTracking()
+            .Where(m => m.ProcessedOnUtc != null
+                     && m.ProcessedOnUtc < cutoff
+                     && (!preserveDeadLetters || m.Error == null))
+            .OrderBy(m => m.ProcessedOnUtc)
+            .Take(options.BatchSize)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        if (rows.Count == 0)
+        {
+            return 0;
+        }
+
+        // Serialise to JSON Lines before the sink call so a serialisation failure also
+        // aborts the sweep without partial state.
+        var payload = SerializeJsonLines(rows);
+        var keyHint = $"outbox-{nowUtc().ToString("yyyy-MM-ddTHH-mm-ssZ", System.Globalization.CultureInfo.InvariantCulture)}";
+        await sink.WriteAsync(keyHint, payload, cancellationToken).ConfigureAwait(false);
+
+        // Re-check eligibility against the live state before deleting; matches the
+        // v6.5.6 CopyToTable safety pattern.
+        var ids = rows.Select(r => r.Id).ToList();
+        return await dbContext.Set<OutboxMessage>()
+            .Where(m => ids.Contains(m.Id)
+                     && m.ProcessedOnUtc != null
+                     && m.ProcessedOnUtc < cutoff
+                     && (!preserveDeadLetters || m.Error == null))
+            .ExecuteDeleteAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    private static byte[] SerializeJsonLines(IReadOnlyList<OutboxMessage> rows)
+    {
+        var buffer = new ArrayBufferWriter<byte>(initialCapacity: 4096);
+        using (var writer = new Utf8JsonWriter(buffer))
+        {
+            foreach (var row in rows)
+            {
+                writer.WriteStartObject();
+                writer.WriteString("id", row.Id);
+                writer.WriteString("eventType", row.EventType);
+                writer.WriteString("payload", row.Payload);
+                writer.WriteString("occurredOnUtc", row.OccurredOnUtc);
+                if (row.ProcessedOnUtc.HasValue)
+                {
+                    writer.WriteString("processedOnUtc", row.ProcessedOnUtc.Value);
+                }
+                writer.WriteNumber("retryCount", row.RetryCount);
+                if (row.Error is not null)
+                {
+                    writer.WriteString("error", row.Error);
+                }
+                if (row.CorrelationId is not null)
+                {
+                    writer.WriteString("correlationId", row.CorrelationId);
+                }
+                writer.WriteEndObject();
+                writer.Flush();
+                buffer.Write(System.Text.Encoding.UTF8.GetBytes(Environment.NewLine));
+                writer.Reset();
+            }
+        }
+        return buffer.WrittenSpan.ToArray();
+    }
+}

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Archival/IOutboxArchiveSink.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Archival/IOutboxArchiveSink.cs
@@ -1,0 +1,29 @@
+namespace Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Archival;
+
+/// <summary>
+/// Abstraction for the destination an archival batch lands in. Plug a consumer-owned
+/// implementation in DI (S3, Azure Blob, GCS, local filesystem) and the
+/// <see cref="BlobOutboxArchiver"/> calls <see cref="WriteAsync"/> with a freshly-built
+/// stream per batch. The sink is responsible for picking the actual storage key under
+/// the supplied key hint (e.g. prefix with a date partition, append an extension).
+/// </summary>
+/// <remarks>
+/// The contract is intentionally narrow: a single write call. Errors propagate, and the
+/// archiver treats any thrown exception as a failed batch (rows are NOT deleted; the
+/// sweep retries next tick). Implementations MUST flush all bytes before returning so
+/// the archiver can safely delete the source rows on the live table.
+/// </remarks>
+public interface IOutboxArchiveSink
+{
+    /// <summary>
+    /// Persist <paramref name="payload"/> bytes (typically newline-delimited JSON
+    /// snapshots of the archived rows) under a storage key derived from
+    /// <paramref name="keyHint"/>. Implementations may decorate the hint with timestamps,
+    /// partition prefixes, or content suffixes; the caller does NOT depend on the final
+    /// key shape.
+    /// </summary>
+    /// <param name="keyHint">Stable suggestion for the key (e.g. <c>"outbox-2026-06-10T12-00-00Z"</c>).</param>
+    /// <param name="payload">Bytes to write; ownership stays with the caller.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task WriteAsync(string keyHint, ReadOnlyMemory<byte> payload, CancellationToken cancellationToken);
+}

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Archival/LocalFileOutboxArchiveSink.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Archival/LocalFileOutboxArchiveSink.cs
@@ -1,0 +1,41 @@
+namespace Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Archival;
+
+using System.IO;
+
+/// <summary>
+/// Reference <see cref="IOutboxArchiveSink"/> that writes the archival payload to a local
+/// directory. Useful for local development / testing and as a fallback when consumers do
+/// not yet have an object-store credential pipeline. Production deployments register a
+/// consumer-owned cloud-object-store sink instead (S3, Azure Blob, GCS).
+/// </summary>
+public sealed class LocalFileOutboxArchiveSink : IOutboxArchiveSink
+{
+    private readonly string root;
+
+    /// <summary>Construct with the destination directory (created on first write if missing).</summary>
+    public LocalFileOutboxArchiveSink(string rootDirectory)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(rootDirectory);
+        root = rootDirectory;
+    }
+
+    /// <inheritdoc />
+    public async Task WriteAsync(string keyHint, ReadOnlyMemory<byte> payload, CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(keyHint);
+        Directory.CreateDirectory(root);
+        // Append the .jsonl extension because BlobOutboxArchiver emits newline-delimited
+        // JSON records by default. Consumers wiring a binary archive can subclass /
+        // wrap this sink with a different extension.
+        var path = Path.Combine(root, $"{keyHint}.jsonl");
+        await using var stream = new FileStream(
+            path,
+            FileMode.CreateNew,
+            FileAccess.Write,
+            FileShare.None,
+            bufferSize: 4096,
+            useAsync: true);
+        await stream.WriteAsync(payload, cancellationToken).ConfigureAwait(false);
+        await stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/src/Moongazing.OrionGuard.Generators/Moongazing.OrionGuard.Generators.csproj
+++ b/src/Moongazing.OrionGuard.Generators/Moongazing.OrionGuard.Generators.csproj
@@ -8,7 +8,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>CS1591</NoWarn>
     <PackageId>OrionGuard.Generators</PackageId>
-    <Version>6.5.8</Version>
+    <Version>6.5.9</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Source generator for OrionGuard. Generates [GenerateValidator] validators, [StronglyTypedId&lt;TValue&gt;] strongly-typed id types (EF Core ValueConverter, System.Text.Json JsonConverter, TypeConverter companions), and supports NativeAOT-compatible reflection-free workflows.</Description>
     <PackageTags>guard;validation;source-generator;roslyn;nativeaot;codegen;ddd;strongly-typed-id</PackageTags>

--- a/src/Moongazing.OrionGuard.Grpc/Moongazing.OrionGuard.Grpc.csproj
+++ b/src/Moongazing.OrionGuard.Grpc/Moongazing.OrionGuard.Grpc.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Grpc</PackageId>
-    <Version>6.5.8</Version>
+    <Version>6.5.9</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>gRPC integration for OrionGuard validation library. Provides server interceptor for automatic request validation in gRPC services.</Description>
     <PackageTags>guard;validation;grpc;interceptor;protobuf;microservices</PackageTags>

--- a/src/Moongazing.OrionGuard.Locks.Redis/Moongazing.OrionGuard.Locks.Redis.csproj
+++ b/src/Moongazing.OrionGuard.Locks.Redis/Moongazing.OrionGuard.Locks.Redis.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Locks.Redis</PackageId>
-    <Version>6.5.8</Version>
+    <Version>6.5.9</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Redis-backed IDistributedLock for OrionGuard.EntityFrameworkCore's outbox dispatcher. Bridges OrionGuard's IDistributedLock contract to the OrionLock.Redis backend so multi-instance outbox workers can share a Redis-coordinated lease instead of the default SkipLocked DB lock.</Description>
     <PackageTags>guard;outbox;distributed-lock;redis;orionlock;entity-framework-core;efcore</PackageTags>

--- a/src/Moongazing.OrionGuard.MediatR/Moongazing.OrionGuard.MediatR.csproj
+++ b/src/Moongazing.OrionGuard.MediatR/Moongazing.OrionGuard.MediatR.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.MediatR</PackageId>
-    <Version>6.5.8</Version>
+    <Version>6.5.9</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>MediatR integration for OrionGuard validation library. Provides ValidationBehavior pipeline behavior for automatic request validation in CQRS pipelines.</Description>
     <PackageTags>guard;validation;mediatr;cqrs;pipeline;behavior</PackageTags>

--- a/src/Moongazing.OrionGuard.OpenTelemetry/Moongazing.OrionGuard.OpenTelemetry.csproj
+++ b/src/Moongazing.OrionGuard.OpenTelemetry/Moongazing.OrionGuard.OpenTelemetry.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.OpenTelemetry</PackageId>
-    <Version>6.5.8</Version>
+    <Version>6.5.9</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>OpenTelemetry integration for OrionGuard validation library. Provides validation metrics (success/failure rates, latency) and distributed tracing spans.</Description>
     <PackageTags>guard;validation;opentelemetry;metrics;tracing;observability</PackageTags>

--- a/src/Moongazing.OrionGuard.Outbox.Dashboard/Moongazing.OrionGuard.Outbox.Dashboard.csproj
+++ b/src/Moongazing.OrionGuard.Outbox.Dashboard/Moongazing.OrionGuard.Outbox.Dashboard.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904;AD0001</NoWarn>
     <PackageId>OrionGuard.Outbox.Dashboard</PackageId>
-    <Version>6.5.8</Version>
+    <Version>6.5.9</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Outbox operator dashboard for OrionGuard. Maps an authorized listing of failed / poisoned messages from the consumer's DbContext to an ASP.NET Core endpoint group, plus POST /{id}/replay and POST /{id}/discard mutation endpoints (v6.5.5) with an optional OnMutation audit hook.</Description>
     <PackageTags>guard;outbox;dashboard;aspnetcore;poisoned-messages;dead-letter</PackageTags>

--- a/src/Moongazing.OrionGuard.Outbox.PostgresNotify/Moongazing.OrionGuard.Outbox.PostgresNotify.csproj
+++ b/src/Moongazing.OrionGuard.Outbox.PostgresNotify/Moongazing.OrionGuard.Outbox.PostgresNotify.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Outbox.PostgresNotify</PackageId>
-    <Version>6.5.8</Version>
+    <Version>6.5.9</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Postgres LISTEN/NOTIFY backed IOutboxWakeSignal for OrionGuard.EntityFrameworkCore. Replaces the v6.5.1 polling fallback with an event-driven wake on every committed outbox row when the consumer's database is PostgreSQL. Falls back to polling cleanly when the LISTEN connection is unreachable.</Description>
     <PackageTags>guard;outbox;postgres;npgsql;listen;notify;push;dispatch;entity-framework-core;efcore</PackageTags>

--- a/src/Moongazing.OrionGuard.Outbox.SqlServerBroker/Moongazing.OrionGuard.Outbox.SqlServerBroker.csproj
+++ b/src/Moongazing.OrionGuard.Outbox.SqlServerBroker/Moongazing.OrionGuard.Outbox.SqlServerBroker.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Outbox.SqlServerBroker</PackageId>
-    <Version>6.5.8</Version>
+    <Version>6.5.9</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>SQL Server Service Broker backed IOutboxWakeSignal for OrionGuard.EntityFrameworkCore. Sibling to OrionGuard.Outbox.PostgresNotify (v6.5.2) for the SQL Server provider. Replaces the v6.5.1 polling-only fallback with an event-driven wake on every committed outbox row via Service Broker's queueing primitives.</Description>
     <PackageTags>guard;outbox;sqlserver;service-broker;push;dispatch;entity-framework-core;efcore</PackageTags>

--- a/src/Moongazing.OrionGuard.SignalR/Moongazing.OrionGuard.SignalR.csproj
+++ b/src/Moongazing.OrionGuard.SignalR/Moongazing.OrionGuard.SignalR.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.SignalR</PackageId>
-    <Version>6.5.8</Version>
+    <Version>6.5.9</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>SignalR integration for OrionGuard validation library. Provides Hub filter for automatic method parameter validation.</Description>
     <PackageTags>guard;validation;signalr;realtime;hub;filter</PackageTags>

--- a/src/Moongazing.OrionGuard.Swagger/Moongazing.OrionGuard.Swagger.csproj
+++ b/src/Moongazing.OrionGuard.Swagger/Moongazing.OrionGuard.Swagger.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Swagger</PackageId>
-    <Version>6.5.8</Version>
+    <Version>6.5.9</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Swagger/OpenAPI integration for OrionGuard. Auto-generates OpenAPI constraints from OrionGuard validation attributes.</Description>
     <PackageTags>guard;validation;swagger;openapi;swashbuckle</PackageTags>

--- a/src/Moongazing.OrionGuard.Testing/Moongazing.OrionGuard.Testing.csproj
+++ b/src/Moongazing.OrionGuard.Testing/Moongazing.OrionGuard.Testing.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Testing</PackageId>
-    <Version>6.5.8</Version>
+    <Version>6.5.9</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Testing helpers for OrionGuard. Provides DomainEventCapture and InMemoryDomainEventDispatcher with framework-agnostic assertions (no xUnit / NUnit / FluentAssertions dependency). Works with any test runner.</Description>
     <PackageTags>guard;validation;testing;ddd;domain-events;assertions;test-helpers</PackageTags>

--- a/src/Moongazing.OrionGuard/Moongazing.OrionGuard.csproj
+++ b/src/Moongazing.OrionGuard/Moongazing.OrionGuard.csproj
@@ -16,7 +16,7 @@
 		<OutputType>Library</OutputType>
 
 		<PackageId>OrionGuard</PackageId>
-		<Version>6.5.8</Version>
+		<Version>6.5.9</Version>
 		<Authors>Tunahan Ali Ozturk</Authors>
 		<Company>Tunahan Ali Ozturk</Company>
 		<GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/Archival/BlobOutboxArchiverTests.cs
+++ b/tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/Archival/BlobOutboxArchiverTests.cs
@@ -84,7 +84,8 @@ public sealed class BlobOutboxArchiverTests
 
         Assert.Equal(2, deleted);
         var write = Assert.Single(sink.Writes);
-        Assert.Equal("outbox-2026-07-01T12-00-00Z", write.KeyHint);
+        Assert.StartsWith("outbox-2026-07-01T12-00-00Z-", write.KeyHint, StringComparison.Ordinal);
+        Assert.Equal(60, write.KeyHint.Length); // "outbox-" + 20 char iso + 1 + 32 hex
         var lines = Encoding.UTF8.GetString(write.Bytes)
             .Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
         Assert.Equal(2, lines.Length);

--- a/tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/Archival/BlobOutboxArchiverTests.cs
+++ b/tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/Archival/BlobOutboxArchiverTests.cs
@@ -1,0 +1,188 @@
+namespace Moongazing.OrionGuard.EntityFrameworkCore.Tests.Outbox.Archival;
+
+using System.Text;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Moongazing.OrionGuard.EntityFrameworkCore.Outbox;
+using Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Archival;
+using Xunit;
+
+public sealed class BlobOutboxArchiverTests
+{
+    private sealed class CapturingSink : IOutboxArchiveSink
+    {
+        public List<(string KeyHint, byte[] Bytes)> Writes { get; } = new();
+        public bool ShouldThrow { get; set; }
+        public Task WriteAsync(string keyHint, ReadOnlyMemory<byte> payload, CancellationToken ct)
+        {
+            if (ShouldThrow)
+            {
+                throw new InvalidOperationException("sink boom");
+            }
+            Writes.Add((keyHint, payload.ToArray()));
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class ArchivalDbContext : DbContext
+    {
+        public ArchivalDbContext(DbContextOptions<ArchivalDbContext> options) : base(options) { }
+        public DbSet<OutboxMessage> Outbox => Set<OutboxMessage>();
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<OutboxMessage>(b =>
+            {
+                b.ToTable("Outbox");
+                b.HasKey(m => m.Id);
+                b.Property(m => m.EventType).IsRequired();
+                b.Property(m => m.Payload).IsRequired();
+            });
+        }
+    }
+
+    private static ArchivalDbContext NewContext()
+    {
+        var options = new DbContextOptionsBuilder<ArchivalDbContext>()
+            .UseSqlite($"DataSource=blob-archiver-{Guid.NewGuid():N};Mode=Memory;Cache=Shared")
+            .Options;
+        var ctx = new ArchivalDbContext(options);
+        ctx.Database.OpenConnection();
+        ctx.Database.EnsureCreated();
+        return ctx;
+    }
+
+    private static OutboxMessage Row(DateTime processed, DateTime occurred, string? error = null) => new()
+    {
+        Id = Guid.NewGuid(),
+        EventType = "Demo.Event",
+        Payload = "{\"a\":1}",
+        OccurredOnUtc = occurred,
+        ProcessedOnUtc = processed,
+        RetryCount = error is null ? 0 : 5,
+        Error = error,
+        CorrelationId = "corr-1",
+    };
+
+    [Fact]
+    public async Task ArchiveAsync_writes_jsonl_payload_to_sink_then_deletes_eligible_rows()
+    {
+        using var db = NewContext();
+        var anchor = new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+        db.Outbox.AddRange(
+            Row(processed: anchor, occurred: anchor.AddMinutes(-10)),
+            Row(processed: anchor.AddDays(1), occurred: anchor));
+        await db.SaveChangesAsync();
+
+        var sink = new CapturingSink();
+        var fixedNow = new DateTime(2026, 7, 1, 12, 0, 0, DateTimeKind.Utc);
+        var sut = new BlobOutboxArchiver(sink, () => fixedNow);
+
+        var cutoff = anchor.AddDays(10);
+        var deleted = await sut.ArchiveAsync(db, cutoff,
+            new OutboxArchivalOptions { BatchSize = 100, PreserveDeadLetters = false },
+            CancellationToken.None);
+
+        Assert.Equal(2, deleted);
+        var write = Assert.Single(sink.Writes);
+        Assert.Equal("outbox-2026-07-01T12-00-00Z", write.KeyHint);
+        var lines = Encoding.UTF8.GetString(write.Bytes)
+            .Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+        Assert.Equal(2, lines.Length);
+        foreach (var line in lines)
+        {
+            using var doc = JsonDocument.Parse(line);
+            Assert.True(doc.RootElement.TryGetProperty("id", out _));
+            Assert.True(doc.RootElement.TryGetProperty("eventType", out _));
+        }
+        Assert.Equal(0, await db.Outbox.CountAsync());
+    }
+
+    [Fact]
+    public async Task ArchiveAsync_does_not_delete_when_sink_throws()
+    {
+        using var db = NewContext();
+        var anchor = new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+        db.Outbox.Add(Row(processed: anchor, occurred: anchor));
+        await db.SaveChangesAsync();
+
+        var sink = new CapturingSink { ShouldThrow = true };
+        var sut = new BlobOutboxArchiver(sink);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => sut.ArchiveAsync(db, anchor.AddDays(10),
+                new OutboxArchivalOptions { BatchSize = 100, PreserveDeadLetters = false },
+                CancellationToken.None));
+
+        Assert.Equal(1, await db.Outbox.CountAsync());
+    }
+
+    [Fact]
+    public async Task ArchiveAsync_preserves_dead_letters_when_option_is_set()
+    {
+        using var db = NewContext();
+        var anchor = new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+        db.Outbox.AddRange(
+            Row(processed: anchor, occurred: anchor),
+            Row(processed: anchor, occurred: anchor, error: "boom"));
+        await db.SaveChangesAsync();
+
+        var sink = new CapturingSink();
+        var sut = new BlobOutboxArchiver(sink);
+
+        var deleted = await sut.ArchiveAsync(db, anchor.AddDays(10),
+            new OutboxArchivalOptions { BatchSize = 100, PreserveDeadLetters = true },
+            CancellationToken.None);
+
+        Assert.Equal(1, deleted);
+        var remaining = await db.Outbox.SingleAsync();
+        Assert.Equal("boom", remaining.Error);
+    }
+
+    [Fact]
+    public async Task ArchiveAsync_no_op_when_no_eligible_rows()
+    {
+        using var db = NewContext();
+        db.Outbox.Add(Row(processed: DateTime.UtcNow, occurred: DateTime.UtcNow));
+        await db.SaveChangesAsync();
+
+        var sink = new CapturingSink();
+        var sut = new BlobOutboxArchiver(sink);
+
+        // Cutoff is BEFORE the row's processed time so nothing is eligible.
+        var deleted = await sut.ArchiveAsync(db, DateTime.UtcNow.AddYears(-10),
+            new OutboxArchivalOptions { BatchSize = 100 },
+            CancellationToken.None);
+
+        Assert.Equal(0, deleted);
+        Assert.Empty(sink.Writes);
+        Assert.Equal(1, await db.Outbox.CountAsync());
+    }
+
+    [Fact]
+    public void Constructor_rejects_null_sink()
+    {
+        Assert.Throws<ArgumentNullException>(() => new BlobOutboxArchiver(null!));
+    }
+
+    [Fact]
+    public async Task LocalFileOutboxArchiveSink_writes_file_with_jsonl_extension()
+    {
+        var temp = Path.Combine(Path.GetTempPath(), $"orionguard-blob-test-{Guid.NewGuid():N}");
+        try
+        {
+            var sink = new LocalFileOutboxArchiveSink(temp);
+            await sink.WriteAsync("outbox-batch-1", Encoding.UTF8.GetBytes("hello"), CancellationToken.None);
+
+            var path = Path.Combine(temp, "outbox-batch-1.jsonl");
+            Assert.True(File.Exists(path));
+            Assert.Equal("hello", await File.ReadAllTextAsync(path));
+        }
+        finally
+        {
+            if (Directory.Exists(temp))
+            {
+                Directory.Delete(temp, recursive: true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## OrionGuard v6.5.9 - Off-box archival via `IOutboxArchiveSink`

Extends the v6.5.6 `IOutboxArchiver` strategy hook.

### Shipped

- `IOutboxArchiveSink` abstraction.
- `BlobOutboxArchiver` orchestrates SELECT -> JSON Lines -> sink.WriteAsync -> ExecuteDelete with re-checked eligibility.
- `LocalFileOutboxArchiveSink` reference implementation.
- 6 new facts.

### Migration

Source-compatible.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added off-box outbox archival support with configurable storage destinations for archived messages
  * Added local file-based archival option for outbox message storage

* **Documentation**
  * Updated changelog with v6.5.9 release entry documenting archival functionality and migration guidance from v6.5.8

<!-- end of auto-generated comment: release notes by coderabbit.ai -->