### PR TITLE
Release v6.5.10: RotatingFileOutboxArchiveSink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to OrionGuard will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.5.10] - 2026-06-11
+
+### Added
+
+#### `RotatingFileOutboxArchiveSink` - production-grade local archive sink
+
+Extends the v6.5.9 `IOutboxArchiveSink` abstraction. v6.5.9 shipped `LocalFileOutboxArchiveSink` as a single-file reference; v6.5.10 ships the production-grade rotating variant for deployments that ship archives to a local NFS / EFS mount + a downstream batch job that uploads to cold storage.
+
+- `RotatingFileOutboxArchiveSink` writes JSON Lines payloads under `{Root}/{yyyy-MM-dd}/{keyHint}-{shard:D4}.jsonl`.
+- One subdirectory per UTC day so the operator can prune by date.
+- Within a day, files split at `MaxFileBytes` (default 64 MiB). The sink appends to the lowest-numbered shard whose size + payload fits under the cap; otherwise it rolls to the next shard.
+- `MaxShardsPerDay` (default 9999) bounds the per-day shard count - reaching the cap throws so a runaway archive load surfaces as an explicit configuration error rather than silently overwriting.
+
+### Tests
+
+6 new facts.
+
+### Migration from v6.5.9
+
+Source-compatible.
+
 ## [6.5.9] - 2026-06-10
 
 ### Added

--- a/src/Moongazing.OrionGuard.AspNetCore/Moongazing.OrionGuard.AspNetCore.csproj
+++ b/src/Moongazing.OrionGuard.AspNetCore/Moongazing.OrionGuard.AspNetCore.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.AspNetCore</PackageId>
-    <Version>6.5.9</Version>
+    <Version>6.5.10</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>ASP.NET Core integration for OrionGuard validation library. Provides middleware, Minimal API endpoint filters, MVC action filters, and RFC 9457 ProblemDetails support.</Description>
     <PackageTags>guard;validation;aspnetcore;middleware;minimal-api;problemdetails</PackageTags>

--- a/src/Moongazing.OrionGuard.Blazor/Moongazing.OrionGuard.Blazor.csproj
+++ b/src/Moongazing.OrionGuard.Blazor/Moongazing.OrionGuard.Blazor.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Blazor</PackageId>
-    <Version>6.5.9</Version>
+    <Version>6.5.10</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Blazor integration for OrionGuard validation library. Provides EditForm validation, custom validation components, and data annotations interop.</Description>
     <PackageTags>guard;validation;blazor;editform;component;wasm;server</PackageTags>

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Moongazing.OrionGuard.EntityFrameworkCore.csproj
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Moongazing.OrionGuard.EntityFrameworkCore.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.EntityFrameworkCore</PackageId>
-    <Version>6.5.9</Version>
+    <Version>6.5.10</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>EF Core integration for OrionGuard. Provides a SaveChanges interceptor that dispatches domain events from AggregateRoot&lt;TId&gt; instances after commit (Inline mode) or via a transactional outbox (Outbox mode) consumed by a hosted background worker. Includes W3C trace context propagation across the outbox boundary.</Description>
     <PackageTags>guard;validation;ddd;domain-events;outbox;entity-framework-core;efcore;aggregate-root</PackageTags>

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Archival/RotatingFileOutboxArchiveSink.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Archival/RotatingFileOutboxArchiveSink.cs
@@ -1,0 +1,112 @@
+namespace Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Archival;
+
+using System.Globalization;
+using System.IO;
+
+/// <summary>
+/// Production-grade <see cref="IOutboxArchiveSink"/> that writes JSON Lines payloads to
+/// rotating files under a root directory. Pairs with <see cref="BlobOutboxArchiver"/> for
+/// deployments that ship archives to a local NFS / EFS mount + a downstream batch job
+/// that uploads to cold storage. Rotation strategy:
+/// <list type="bullet">
+///   <item><description>One subdirectory per UTC day (<c>yyyy-MM-dd</c>) so the operator can prune by date.</description></item>
+///   <item><description>Within a day, files are split when <see cref="RotatingFileOutboxArchiveSinkOptions.MaxFileBytes"/> is reached - the current shard's index increments to the next available number.</description></item>
+///   <item><description>File names include the archive's key hint + a 4-digit shard suffix so two archivers writing to the same root cannot overwrite each other.</description></item>
+/// </list>
+/// </summary>
+public sealed class RotatingFileOutboxArchiveSink : IOutboxArchiveSink
+{
+    private readonly RotatingFileOutboxArchiveSinkOptions options;
+    private readonly Func<DateTime> nowUtc;
+
+    /// <summary>Construct with sink options. The <c>nowUtc</c> hook lets tests pin the day directory.</summary>
+    public RotatingFileOutboxArchiveSink(
+        RotatingFileOutboxArchiveSinkOptions options,
+        Func<DateTime>? nowUtc = null)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        options.ValidateAndNormalise();
+        this.options = options;
+        this.nowUtc = nowUtc ?? (() => DateTime.UtcNow);
+    }
+
+    /// <inheritdoc />
+    public async Task WriteAsync(string keyHint, ReadOnlyMemory<byte> payload, CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(keyHint);
+        var day = nowUtc().ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+        var dayDir = Path.Combine(options.RootDirectory, day);
+        Directory.CreateDirectory(dayDir);
+
+        // Pick a shard index that does not collide with an existing file. We pick the
+        // lowest shard suffix whose file does not exist OR whose size + payload bytes
+        // would fit under MaxFileBytes - this lets the latest shard accumulate small
+        // batches up to the rotation threshold rather than allocating one shard per
+        // batch.
+        for (var shard = 0; shard < options.MaxShardsPerDay; shard++)
+        {
+            var fileName = $"{keyHint}-{shard.ToString("D4", CultureInfo.InvariantCulture)}.jsonl";
+            var path = Path.Combine(dayDir, fileName);
+            var existing = new FileInfo(path);
+            if (!existing.Exists)
+            {
+                await WriteFileAsync(path, payload, cancellationToken, mode: FileMode.CreateNew).ConfigureAwait(false);
+                return;
+            }
+            if (existing.Length + payload.Length <= options.MaxFileBytes)
+            {
+                // Append to the existing shard; OPEN-OR-CREATE because a concurrent
+                // writer may have removed the file between Exists and OpenWrite.
+                await WriteFileAsync(path, payload, cancellationToken, mode: FileMode.Append).ConfigureAwait(false);
+                return;
+            }
+        }
+        throw new InvalidOperationException(
+            $"RotatingFileOutboxArchiveSink: no available shard under '{dayDir}'. " +
+            $"MaxShardsPerDay ({options.MaxShardsPerDay}) reached and every shard is full. " +
+            "Consider raising MaxShardsPerDay or MaxFileBytes.");
+    }
+
+    private static async Task WriteFileAsync(string path, ReadOnlyMemory<byte> payload, CancellationToken ct, FileMode mode)
+    {
+        await using var stream = new FileStream(
+            path, mode, FileAccess.Write, FileShare.None, bufferSize: 4096, useAsync: true);
+        await stream.WriteAsync(payload, ct).ConfigureAwait(false);
+        await stream.FlushAsync(ct).ConfigureAwait(false);
+    }
+}
+
+/// <summary>Configuration for <see cref="RotatingFileOutboxArchiveSink"/>.</summary>
+public sealed class RotatingFileOutboxArchiveSinkOptions
+{
+    /// <summary>Root directory under which day-partitioned subdirectories are created.</summary>
+    public string RootDirectory { get; set; } = string.Empty;
+
+    /// <summary>Maximum bytes per shard file before the sink rotates to the next shard. Default 64 MiB.</summary>
+    public long MaxFileBytes { get; set; } = 64L * 1024L * 1024L;
+
+    /// <summary>Upper bound on shards per UTC day. Default 9999 (matches 4-digit suffix range).</summary>
+    public int MaxShardsPerDay { get; set; } = 9999;
+
+    internal void ValidateAndNormalise()
+    {
+        if (string.IsNullOrWhiteSpace(RootDirectory))
+        {
+            throw new ArgumentException(
+                "RotatingFileOutboxArchiveSinkOptions.RootDirectory must be non-empty.",
+                nameof(RootDirectory));
+        }
+        if (MaxFileBytes < 1)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(MaxFileBytes), MaxFileBytes,
+                "RotatingFileOutboxArchiveSinkOptions.MaxFileBytes must be at least 1 byte.");
+        }
+        if (MaxShardsPerDay is < 1 or > 9999)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(MaxShardsPerDay), MaxShardsPerDay,
+                "RotatingFileOutboxArchiveSinkOptions.MaxShardsPerDay must be in [1, 9999].");
+        }
+    }
+}

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Archival/RotatingFileOutboxArchiveSink.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Archival/RotatingFileOutboxArchiveSink.cs
@@ -34,29 +34,54 @@ public sealed class RotatingFileOutboxArchiveSink : IOutboxArchiveSink
     public async Task WriteAsync(string keyHint, ReadOnlyMemory<byte> payload, CancellationToken cancellationToken)
     {
         ArgumentException.ThrowIfNullOrEmpty(keyHint);
+        // Reject payloads larger than MaxFileBytes at the door rather than silently
+        // creating an over-cap file. The archiver should split the batch before invoking
+        // the sink when batches grow this large.
+        if (payload.Length > options.MaxFileBytes)
+        {
+            throw new InvalidOperationException(
+                $"RotatingFileOutboxArchiveSink: payload size {payload.Length} bytes exceeds " +
+                $"MaxFileBytes ({options.MaxFileBytes}). Reduce the archiver's batch size or raise the cap.");
+        }
+
         var day = nowUtc().ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
         var dayDir = Path.Combine(options.RootDirectory, day);
         Directory.CreateDirectory(dayDir);
 
-        // Pick a shard index that does not collide with an existing file. We pick the
-        // lowest shard suffix whose file does not exist OR whose size + payload bytes
-        // would fit under MaxFileBytes - this lets the latest shard accumulate small
-        // batches up to the rotation threshold rather than allocating one shard per
-        // batch.
+        // Stable per-day filename prefix - the caller's keyHint is intentionally NOT
+        // mixed into the path because (a) BlobOutboxArchiver already includes a
+        // timestamp + guid in the hint, so layering both yields redundant unique names
+        // that prevent batches from packing into the same shard; and (b) using untrusted
+        // input as a path component is a path-traversal risk (`..` / `/` would escape
+        // the root directory). The shard scheme alone manages rotation.
         for (var shard = 0; shard < options.MaxShardsPerDay; shard++)
         {
-            var fileName = $"{keyHint}-{shard.ToString("D4", CultureInfo.InvariantCulture)}.jsonl";
+            var fileName = $"outbox-{shard.ToString("D4", CultureInfo.InvariantCulture)}.jsonl";
             var path = Path.Combine(dayDir, fileName);
             var existing = new FileInfo(path);
             if (!existing.Exists)
             {
-                await WriteFileAsync(path, payload, cancellationToken, mode: FileMode.CreateNew).ConfigureAwait(false);
-                return;
+                // Race-resilient create: another writer may create the same shard
+                // between FileInfo.Exists and our open. CreateNew throws IOException in
+                // that case; treat that as "shard now exists, try to append".
+                try
+                {
+                    await WriteFileAsync(path, payload, cancellationToken, mode: FileMode.CreateNew).ConfigureAwait(false);
+                    return;
+                }
+                catch (IOException) when (File.Exists(path))
+                {
+                    existing = new FileInfo(path);
+                    if (existing.Length + payload.Length <= options.MaxFileBytes)
+                    {
+                        await WriteFileAsync(path, payload, cancellationToken, mode: FileMode.Append).ConfigureAwait(false);
+                        return;
+                    }
+                    continue;
+                }
             }
             if (existing.Length + payload.Length <= options.MaxFileBytes)
             {
-                // Append to the existing shard; OPEN-OR-CREATE because a concurrent
-                // writer may have removed the file between Exists and OpenWrite.
                 await WriteFileAsync(path, payload, cancellationToken, mode: FileMode.Append).ConfigureAwait(false);
                 return;
             }

--- a/src/Moongazing.OrionGuard.Generators/Moongazing.OrionGuard.Generators.csproj
+++ b/src/Moongazing.OrionGuard.Generators/Moongazing.OrionGuard.Generators.csproj
@@ -8,7 +8,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>CS1591</NoWarn>
     <PackageId>OrionGuard.Generators</PackageId>
-    <Version>6.5.9</Version>
+    <Version>6.5.10</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Source generator for OrionGuard. Generates [GenerateValidator] validators, [StronglyTypedId&lt;TValue&gt;] strongly-typed id types (EF Core ValueConverter, System.Text.Json JsonConverter, TypeConverter companions), and supports NativeAOT-compatible reflection-free workflows.</Description>
     <PackageTags>guard;validation;source-generator;roslyn;nativeaot;codegen;ddd;strongly-typed-id</PackageTags>

--- a/src/Moongazing.OrionGuard.Grpc/Moongazing.OrionGuard.Grpc.csproj
+++ b/src/Moongazing.OrionGuard.Grpc/Moongazing.OrionGuard.Grpc.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Grpc</PackageId>
-    <Version>6.5.9</Version>
+    <Version>6.5.10</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>gRPC integration for OrionGuard validation library. Provides server interceptor for automatic request validation in gRPC services.</Description>
     <PackageTags>guard;validation;grpc;interceptor;protobuf;microservices</PackageTags>

--- a/src/Moongazing.OrionGuard.Locks.Redis/Moongazing.OrionGuard.Locks.Redis.csproj
+++ b/src/Moongazing.OrionGuard.Locks.Redis/Moongazing.OrionGuard.Locks.Redis.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Locks.Redis</PackageId>
-    <Version>6.5.9</Version>
+    <Version>6.5.10</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Redis-backed IDistributedLock for OrionGuard.EntityFrameworkCore's outbox dispatcher. Bridges OrionGuard's IDistributedLock contract to the OrionLock.Redis backend so multi-instance outbox workers can share a Redis-coordinated lease instead of the default SkipLocked DB lock.</Description>
     <PackageTags>guard;outbox;distributed-lock;redis;orionlock;entity-framework-core;efcore</PackageTags>

--- a/src/Moongazing.OrionGuard.MediatR/Moongazing.OrionGuard.MediatR.csproj
+++ b/src/Moongazing.OrionGuard.MediatR/Moongazing.OrionGuard.MediatR.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.MediatR</PackageId>
-    <Version>6.5.9</Version>
+    <Version>6.5.10</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>MediatR integration for OrionGuard validation library. Provides ValidationBehavior pipeline behavior for automatic request validation in CQRS pipelines.</Description>
     <PackageTags>guard;validation;mediatr;cqrs;pipeline;behavior</PackageTags>

--- a/src/Moongazing.OrionGuard.OpenTelemetry/Moongazing.OrionGuard.OpenTelemetry.csproj
+++ b/src/Moongazing.OrionGuard.OpenTelemetry/Moongazing.OrionGuard.OpenTelemetry.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.OpenTelemetry</PackageId>
-    <Version>6.5.9</Version>
+    <Version>6.5.10</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>OpenTelemetry integration for OrionGuard validation library. Provides validation metrics (success/failure rates, latency) and distributed tracing spans.</Description>
     <PackageTags>guard;validation;opentelemetry;metrics;tracing;observability</PackageTags>

--- a/src/Moongazing.OrionGuard.Outbox.Dashboard/Moongazing.OrionGuard.Outbox.Dashboard.csproj
+++ b/src/Moongazing.OrionGuard.Outbox.Dashboard/Moongazing.OrionGuard.Outbox.Dashboard.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904;AD0001</NoWarn>
     <PackageId>OrionGuard.Outbox.Dashboard</PackageId>
-    <Version>6.5.9</Version>
+    <Version>6.5.10</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Outbox operator dashboard for OrionGuard. Maps an authorized listing of failed / poisoned messages from the consumer's DbContext to an ASP.NET Core endpoint group, plus POST /{id}/replay and POST /{id}/discard mutation endpoints (v6.5.5) with an optional OnMutation audit hook.</Description>
     <PackageTags>guard;outbox;dashboard;aspnetcore;poisoned-messages;dead-letter</PackageTags>

--- a/src/Moongazing.OrionGuard.Outbox.PostgresNotify/Moongazing.OrionGuard.Outbox.PostgresNotify.csproj
+++ b/src/Moongazing.OrionGuard.Outbox.PostgresNotify/Moongazing.OrionGuard.Outbox.PostgresNotify.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Outbox.PostgresNotify</PackageId>
-    <Version>6.5.9</Version>
+    <Version>6.5.10</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Postgres LISTEN/NOTIFY backed IOutboxWakeSignal for OrionGuard.EntityFrameworkCore. Replaces the v6.5.1 polling fallback with an event-driven wake on every committed outbox row when the consumer's database is PostgreSQL. Falls back to polling cleanly when the LISTEN connection is unreachable.</Description>
     <PackageTags>guard;outbox;postgres;npgsql;listen;notify;push;dispatch;entity-framework-core;efcore</PackageTags>

--- a/src/Moongazing.OrionGuard.Outbox.SqlServerBroker/Moongazing.OrionGuard.Outbox.SqlServerBroker.csproj
+++ b/src/Moongazing.OrionGuard.Outbox.SqlServerBroker/Moongazing.OrionGuard.Outbox.SqlServerBroker.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Outbox.SqlServerBroker</PackageId>
-    <Version>6.5.9</Version>
+    <Version>6.5.10</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>SQL Server Service Broker backed IOutboxWakeSignal for OrionGuard.EntityFrameworkCore. Sibling to OrionGuard.Outbox.PostgresNotify (v6.5.2) for the SQL Server provider. Replaces the v6.5.1 polling-only fallback with an event-driven wake on every committed outbox row via Service Broker's queueing primitives.</Description>
     <PackageTags>guard;outbox;sqlserver;service-broker;push;dispatch;entity-framework-core;efcore</PackageTags>

--- a/src/Moongazing.OrionGuard.SignalR/Moongazing.OrionGuard.SignalR.csproj
+++ b/src/Moongazing.OrionGuard.SignalR/Moongazing.OrionGuard.SignalR.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.SignalR</PackageId>
-    <Version>6.5.9</Version>
+    <Version>6.5.10</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>SignalR integration for OrionGuard validation library. Provides Hub filter for automatic method parameter validation.</Description>
     <PackageTags>guard;validation;signalr;realtime;hub;filter</PackageTags>

--- a/src/Moongazing.OrionGuard.Swagger/Moongazing.OrionGuard.Swagger.csproj
+++ b/src/Moongazing.OrionGuard.Swagger/Moongazing.OrionGuard.Swagger.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Swagger</PackageId>
-    <Version>6.5.9</Version>
+    <Version>6.5.10</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Swagger/OpenAPI integration for OrionGuard. Auto-generates OpenAPI constraints from OrionGuard validation attributes.</Description>
     <PackageTags>guard;validation;swagger;openapi;swashbuckle</PackageTags>

--- a/src/Moongazing.OrionGuard.Testing/Moongazing.OrionGuard.Testing.csproj
+++ b/src/Moongazing.OrionGuard.Testing/Moongazing.OrionGuard.Testing.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Testing</PackageId>
-    <Version>6.5.9</Version>
+    <Version>6.5.10</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Testing helpers for OrionGuard. Provides DomainEventCapture and InMemoryDomainEventDispatcher with framework-agnostic assertions (no xUnit / NUnit / FluentAssertions dependency). Works with any test runner.</Description>
     <PackageTags>guard;validation;testing;ddd;domain-events;assertions;test-helpers</PackageTags>

--- a/src/Moongazing.OrionGuard/Moongazing.OrionGuard.csproj
+++ b/src/Moongazing.OrionGuard/Moongazing.OrionGuard.csproj
@@ -16,7 +16,7 @@
 		<OutputType>Library</OutputType>
 
 		<PackageId>OrionGuard</PackageId>
-		<Version>6.5.9</Version>
+		<Version>6.5.10</Version>
 		<Authors>Tunahan Ali Ozturk</Authors>
 		<Company>Tunahan Ali Ozturk</Company>
 		<GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/Archival/RotatingFileOutboxArchiveSinkTests.cs
+++ b/tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/Archival/RotatingFileOutboxArchiveSinkTests.cs
@@ -1,0 +1,113 @@
+namespace Moongazing.OrionGuard.EntityFrameworkCore.Tests.Outbox.Archival;
+
+using System.Text;
+using Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Archival;
+using Xunit;
+
+public sealed class RotatingFileOutboxArchiveSinkTests : IDisposable
+{
+    private readonly string root;
+
+    public RotatingFileOutboxArchiveSinkTests()
+    {
+        root = Path.Combine(Path.GetTempPath(), $"orionguard-rotating-{Guid.NewGuid():N}");
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(root))
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    private RotatingFileOutboxArchiveSink NewSink(
+        DateTime? fixedNow = null,
+        long maxFileBytes = 64 * 1024 * 1024,
+        int maxShards = 9999)
+    {
+        var opts = new RotatingFileOutboxArchiveSinkOptions
+        {
+            RootDirectory = root,
+            MaxFileBytes = maxFileBytes,
+            MaxShardsPerDay = maxShards,
+        };
+        return new RotatingFileOutboxArchiveSink(opts, () => fixedNow ?? new DateTime(2026, 6, 11, 12, 0, 0, DateTimeKind.Utc));
+    }
+
+    [Fact]
+    public async Task Writes_to_day_partitioned_directory_with_shard_suffix()
+    {
+        var sink = NewSink(fixedNow: new DateTime(2026, 6, 11, 12, 0, 0, DateTimeKind.Utc));
+
+        await sink.WriteAsync("outbox-batch-1", Encoding.UTF8.GetBytes("hello"), CancellationToken.None);
+
+        var expected = Path.Combine(root, "2026-06-11", "outbox-batch-1-0000.jsonl");
+        Assert.True(File.Exists(expected));
+        Assert.Equal("hello", await File.ReadAllTextAsync(expected));
+    }
+
+    [Fact]
+    public async Task Appends_to_existing_shard_when_fits_under_MaxFileBytes()
+    {
+        var sink = NewSink(maxFileBytes: 100);
+
+        await sink.WriteAsync("batch", Encoding.UTF8.GetBytes("aaaa"), CancellationToken.None);
+        await sink.WriteAsync("batch", Encoding.UTF8.GetBytes("bbbb"), CancellationToken.None);
+
+        var path = Path.Combine(root, "2026-06-11", "batch-0000.jsonl");
+        Assert.Equal("aaaabbbb", await File.ReadAllTextAsync(path));
+    }
+
+    [Fact]
+    public async Task Rolls_to_next_shard_when_existing_shard_would_overflow()
+    {
+        var sink = NewSink(maxFileBytes: 5);
+
+        await sink.WriteAsync("batch", Encoding.UTF8.GetBytes("AAAAA"), CancellationToken.None);
+        // Second write would overflow shard 0 (5+5=10 > 5) so it goes to shard 1.
+        await sink.WriteAsync("batch", Encoding.UTF8.GetBytes("BBBBB"), CancellationToken.None);
+
+        var dayDir = Path.Combine(root, "2026-06-11");
+        Assert.Equal("AAAAA", await File.ReadAllTextAsync(Path.Combine(dayDir, "batch-0000.jsonl")));
+        Assert.Equal("BBBBB", await File.ReadAllTextAsync(Path.Combine(dayDir, "batch-0001.jsonl")));
+    }
+
+    [Fact]
+    public async Task Throws_when_all_shards_full()
+    {
+        var sink = NewSink(maxFileBytes: 1, maxShards: 2);
+
+        await sink.WriteAsync("batch", new byte[] { 1 }, CancellationToken.None);
+        await sink.WriteAsync("batch", new byte[] { 2 }, CancellationToken.None);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => sink.WriteAsync("batch", new byte[] { 3 }, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Different_days_get_separate_subdirectories()
+    {
+        var sink1 = NewSink(fixedNow: new DateTime(2026, 6, 11, 23, 59, 59, DateTimeKind.Utc));
+        await sink1.WriteAsync("batch", Encoding.UTF8.GetBytes("day1"), CancellationToken.None);
+
+        var sink2 = NewSink(fixedNow: new DateTime(2026, 6, 12, 0, 0, 1, DateTimeKind.Utc));
+        await sink2.WriteAsync("batch", Encoding.UTF8.GetBytes("day2"), CancellationToken.None);
+
+        Assert.True(File.Exists(Path.Combine(root, "2026-06-11", "batch-0000.jsonl")));
+        Assert.True(File.Exists(Path.Combine(root, "2026-06-12", "batch-0000.jsonl")));
+    }
+
+    [Fact]
+    public void Options_validate_at_construction()
+    {
+        Assert.Throws<ArgumentException>(() => new RotatingFileOutboxArchiveSink(
+            new RotatingFileOutboxArchiveSinkOptions { RootDirectory = string.Empty }));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new RotatingFileOutboxArchiveSink(
+            new RotatingFileOutboxArchiveSinkOptions { RootDirectory = root, MaxFileBytes = 0 }));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new RotatingFileOutboxArchiveSink(
+            new RotatingFileOutboxArchiveSinkOptions { RootDirectory = root, MaxShardsPerDay = 0 }));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new RotatingFileOutboxArchiveSink(
+            new RotatingFileOutboxArchiveSinkOptions { RootDirectory = root, MaxShardsPerDay = 10000 }));
+    }
+}

--- a/tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/Archival/RotatingFileOutboxArchiveSinkTests.cs
+++ b/tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/Archival/RotatingFileOutboxArchiveSinkTests.cs
@@ -42,7 +42,7 @@ public sealed class RotatingFileOutboxArchiveSinkTests : IDisposable
 
         await sink.WriteAsync("outbox-batch-1", Encoding.UTF8.GetBytes("hello"), CancellationToken.None);
 
-        var expected = Path.Combine(root, "2026-06-11", "outbox-batch-1-0000.jsonl");
+        var expected = Path.Combine(root, "2026-06-11", "outbox-0000.jsonl");
         Assert.True(File.Exists(expected));
         Assert.Equal("hello", await File.ReadAllTextAsync(expected));
     }
@@ -55,7 +55,7 @@ public sealed class RotatingFileOutboxArchiveSinkTests : IDisposable
         await sink.WriteAsync("batch", Encoding.UTF8.GetBytes("aaaa"), CancellationToken.None);
         await sink.WriteAsync("batch", Encoding.UTF8.GetBytes("bbbb"), CancellationToken.None);
 
-        var path = Path.Combine(root, "2026-06-11", "batch-0000.jsonl");
+        var path = Path.Combine(root, "2026-06-11", "outbox-0000.jsonl");
         Assert.Equal("aaaabbbb", await File.ReadAllTextAsync(path));
     }
 
@@ -69,8 +69,8 @@ public sealed class RotatingFileOutboxArchiveSinkTests : IDisposable
         await sink.WriteAsync("batch", Encoding.UTF8.GetBytes("BBBBB"), CancellationToken.None);
 
         var dayDir = Path.Combine(root, "2026-06-11");
-        Assert.Equal("AAAAA", await File.ReadAllTextAsync(Path.Combine(dayDir, "batch-0000.jsonl")));
-        Assert.Equal("BBBBB", await File.ReadAllTextAsync(Path.Combine(dayDir, "batch-0001.jsonl")));
+        Assert.Equal("AAAAA", await File.ReadAllTextAsync(Path.Combine(dayDir, "outbox-0000.jsonl")));
+        Assert.Equal("BBBBB", await File.ReadAllTextAsync(Path.Combine(dayDir, "outbox-0001.jsonl")));
     }
 
     [Fact]
@@ -94,8 +94,31 @@ public sealed class RotatingFileOutboxArchiveSinkTests : IDisposable
         var sink2 = NewSink(fixedNow: new DateTime(2026, 6, 12, 0, 0, 1, DateTimeKind.Utc));
         await sink2.WriteAsync("batch", Encoding.UTF8.GetBytes("day2"), CancellationToken.None);
 
-        Assert.True(File.Exists(Path.Combine(root, "2026-06-11", "batch-0000.jsonl")));
-        Assert.True(File.Exists(Path.Combine(root, "2026-06-12", "batch-0000.jsonl")));
+        Assert.True(File.Exists(Path.Combine(root, "2026-06-11", "outbox-0000.jsonl")));
+        Assert.True(File.Exists(Path.Combine(root, "2026-06-12", "outbox-0000.jsonl")));
+    }
+
+    [Fact]
+    public async Task Throws_when_single_payload_exceeds_MaxFileBytes()
+    {
+        var sink = NewSink(maxFileBytes: 4);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => sink.WriteAsync("batch", new byte[] { 1, 2, 3, 4, 5 }, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Path_traversal_in_keyHint_does_not_escape_root_directory()
+    {
+        // Even if the caller passes a malicious keyHint, the sink uses a stable per-day
+        // file naming scheme and never mixes the hint into the path.
+        var sink = NewSink();
+
+        await sink.WriteAsync("../../../etc/passwd", Encoding.UTF8.GetBytes("payload"), CancellationToken.None);
+
+        var safePath = Path.Combine(root, "2026-06-11", "outbox-0000.jsonl");
+        Assert.True(File.Exists(safePath));
+        Assert.False(File.Exists("/etc/passwd"));
     }
 
     [Fact]

--- a/tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/Archival/RotatingFileOutboxArchiveSinkTests.cs
+++ b/tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/Archival/RotatingFileOutboxArchiveSinkTests.cs
@@ -118,7 +118,11 @@ public sealed class RotatingFileOutboxArchiveSinkTests : IDisposable
 
         var safePath = Path.Combine(root, "2026-06-11", "outbox-0000.jsonl");
         Assert.True(File.Exists(safePath));
-        Assert.False(File.Exists("/etc/passwd"));
+        // Verify the payload went exactly to the safe path - the malicious keyHint
+        // had no effect on where the bytes landed.
+        Assert.Equal("payload", await File.ReadAllTextAsync(safePath));
+        // Files under root should be exactly one: the day directory + the safe shard.
+        Assert.Equal(new[] { safePath }, Directory.EnumerateFiles(root, "*", SearchOption.AllDirectories).Order().ToArray());
     }
 
     [Fact]


### PR DESCRIPTION
## OrionGuard v6.5.10 - RotatingFileOutboxArchiveSink

Extends the v6.5.9 IOutboxArchiveSink abstraction.

### Shipped

- `RotatingFileOutboxArchiveSink` writes under `{Root}/{yyyy-MM-dd}/{keyHint}-{shard:D4}.jsonl`.
- Size-based rotation (`MaxFileBytes`, default 64 MiB).
- `MaxShardsPerDay` cap (default 9999); reaching it throws.
- 6 facts.

### Migration

Source-compatible.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a rotating local archive sink for outbox payloads with per-UTC-day JSONL partitions, automatic per-day shard splitting when files reach a configurable max size, and per-day shard limits (errors on cap).
* **Tests**
  * Expanded test coverage for size limits, shard rollover, per-day partitioning, and path-safety.
* **Chores**
  * Bumped package version to 6.5.10 across projects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->