### PR TITLE
Release v6.5.11: RetryingOutboxArchiveSink decorator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to OrionGuard will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.5.11] - 2026-06-11
+
+### Added
+
+#### `RetryingOutboxArchiveSink` decorator
+
+Decorator that wraps any `IOutboxArchiveSink` with jittered exponential retry. Useful for cloud-object-store sinks (S3, Azure Blob, GCS) where transient 503 / socket errors are common - instead of failing the archival sweep on the first transient failure, the decorator retries up to `MaxAttempts` times before giving up.
+
+- `RetryingOutboxArchiveSink(inner, options)`.
+- `RetryingOutboxArchiveSinkOptions`: `MaxAttempts` (default 5), `BaseDelay` (100 ms), `MaxDelay` (5 s), `IsRetryable` predicate (default retries everything), `RandomFactory` for seeded testing.
+- Backoff: `BaseDelay * 2^(attempt-1)` capped at `MaxDelay`, jittered in `[0.5x, 1.0x]` of the computed value.
+- Cancellation propagates immediately without consuming a retry slot.
+- Options validated at construction.
+
+### Tests
+
+6 new facts.
+
+### Migration from v6.5.10
+
+Source-compatible.
+
 ## [6.5.10] - 2026-06-11
 
 ### Added

--- a/src/Moongazing.OrionGuard.AspNetCore/Moongazing.OrionGuard.AspNetCore.csproj
+++ b/src/Moongazing.OrionGuard.AspNetCore/Moongazing.OrionGuard.AspNetCore.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.AspNetCore</PackageId>
-    <Version>6.5.10</Version>
+    <Version>6.5.11</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>ASP.NET Core integration for OrionGuard validation library. Provides middleware, Minimal API endpoint filters, MVC action filters, and RFC 9457 ProblemDetails support.</Description>
     <PackageTags>guard;validation;aspnetcore;middleware;minimal-api;problemdetails</PackageTags>

--- a/src/Moongazing.OrionGuard.Blazor/Moongazing.OrionGuard.Blazor.csproj
+++ b/src/Moongazing.OrionGuard.Blazor/Moongazing.OrionGuard.Blazor.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Blazor</PackageId>
-    <Version>6.5.10</Version>
+    <Version>6.5.11</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Blazor integration for OrionGuard validation library. Provides EditForm validation, custom validation components, and data annotations interop.</Description>
     <PackageTags>guard;validation;blazor;editform;component;wasm;server</PackageTags>

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Moongazing.OrionGuard.EntityFrameworkCore.csproj
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Moongazing.OrionGuard.EntityFrameworkCore.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.EntityFrameworkCore</PackageId>
-    <Version>6.5.10</Version>
+    <Version>6.5.11</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>EF Core integration for OrionGuard. Provides a SaveChanges interceptor that dispatches domain events from AggregateRoot&lt;TId&gt; instances after commit (Inline mode) or via a transactional outbox (Outbox mode) consumed by a hosted background worker. Includes W3C trace context propagation across the outbox boundary.</Description>
     <PackageTags>guard;validation;ddd;domain-events;outbox;entity-framework-core;efcore;aggregate-root</PackageTags>

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Archival/RetryingOutboxArchiveSink.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Archival/RetryingOutboxArchiveSink.cs
@@ -1,0 +1,140 @@
+namespace Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Archival;
+
+/// <summary>
+/// <see cref="IOutboxArchiveSink"/> decorator that retries the inner sink's
+/// <see cref="IOutboxArchiveSink.WriteAsync"/> on transient failures with jittered
+/// exponential backoff. Pairs with cloud-object-store sinks (S3, Azure Blob, GCS) where
+/// transient socket failures are common; instead of failing the archival sweep on the
+/// first 503 the decorator retries up to <see cref="RetryingOutboxArchiveSinkOptions.MaxAttempts"/>
+/// times before giving up.
+/// </summary>
+/// <remarks>
+/// Retries apply to ALL exceptions by default; consumers wanting to fail-fast on
+/// non-transient classes (e.g. <see cref="ArgumentException"/>) supply a
+/// <see cref="RetryingOutboxArchiveSinkOptions.IsRetryable"/> predicate. The decorator
+/// honours <see cref="OperationCanceledException"/>: cancellation propagates immediately
+/// without consuming a retry slot.
+/// </remarks>
+public sealed class RetryingOutboxArchiveSink : IOutboxArchiveSink
+{
+    private readonly IOutboxArchiveSink inner;
+    private readonly RetryingOutboxArchiveSinkOptions options;
+
+    /// <summary>Construct over an inner sink and the retry options.</summary>
+    public RetryingOutboxArchiveSink(IOutboxArchiveSink inner, RetryingOutboxArchiveSinkOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(inner);
+        ArgumentNullException.ThrowIfNull(options);
+        options.ValidateAndNormalise();
+        this.inner = inner;
+        this.options = options;
+    }
+
+    /// <inheritdoc />
+    public async Task WriteAsync(string keyHint, ReadOnlyMemory<byte> payload, CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(keyHint);
+        Exception? lastFailure = null;
+        var rng = options.RandomFactory();
+        for (var attempt = 1; attempt <= options.MaxAttempts; attempt++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            try
+            {
+                await inner.WriteAsync(keyHint, payload, cancellationToken).ConfigureAwait(false);
+                return;
+            }
+            catch (OperationCanceledException)
+            {
+                // Cancellation is not a transient failure - propagate without consuming
+                // a retry slot.
+                throw;
+            }
+#pragma warning disable CA1031 // decorator catches by design - the IsRetryable predicate triages
+            catch (Exception ex)
+#pragma warning restore CA1031
+            {
+                lastFailure = ex;
+                if (attempt == options.MaxAttempts || !options.IsRetryable(ex))
+                {
+                    throw;
+                }
+                var delay = ComputeBackoff(attempt, rng);
+                try
+                {
+                    await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    // Cancelled while waiting to retry - surface the last failure as the
+                    // cause so the caller sees the underlying problem rather than a
+                    // synthetic TaskCanceledException.
+                    throw;
+                }
+            }
+        }
+        // Should be unreachable - the final attempt's failure throws above.
+        throw new InvalidOperationException(
+            "RetryingOutboxArchiveSink: retry loop exited without success or rethrow.",
+            lastFailure);
+    }
+
+    private TimeSpan ComputeBackoff(int attempt, Random rng)
+    {
+        // Exponential: BaseDelay * 2^(attempt-1), capped at MaxDelay. Apply random jitter
+        // in [0.5 * computed, 1.0 * computed] so concurrent waiters do not retry in lockstep.
+        var ceiling = options.BaseDelay.TotalMilliseconds * Math.Pow(2, Math.Min(attempt - 1, 30));
+        var capped = Math.Min(ceiling, options.MaxDelay.TotalMilliseconds);
+        var floor = capped * 0.5;
+        var jittered = floor + rng.NextDouble() * (capped - floor);
+        return TimeSpan.FromMilliseconds(jittered);
+    }
+}
+
+/// <summary>Configuration for <see cref="RetryingOutboxArchiveSink"/>.</summary>
+public sealed class RetryingOutboxArchiveSinkOptions
+{
+    /// <summary>Static default instance: 5 attempts, 100 ms base, 5 s cap.</summary>
+    public static RetryingOutboxArchiveSinkOptions Default { get; } = new();
+
+    /// <summary>Maximum number of attempts including the first try. Default 5.</summary>
+    public int MaxAttempts { get; set; } = 5;
+
+    /// <summary>Initial backoff delay. Default 100 ms.</summary>
+    public TimeSpan BaseDelay { get; set; } = TimeSpan.FromMilliseconds(100);
+
+    /// <summary>Upper bound on per-attempt backoff. Default 5 seconds.</summary>
+    public TimeSpan MaxDelay { get; set; } = TimeSpan.FromSeconds(5);
+
+    /// <summary>
+    /// Predicate that decides whether an exception type is retryable. Default returns
+    /// true for everything except <see cref="OperationCanceledException"/> (which is
+    /// already handled at the call site). Override to restrict retries to specific
+    /// transient classes (e.g. <c>S3.AmazonS3Exception</c> with code 503).
+    /// </summary>
+    public Func<Exception, bool> IsRetryable { get; set; } = _ => true;
+
+    /// <summary>Factory for the random generator used to pick jitter.</summary>
+    public Func<Random> RandomFactory { get; set; } = () => Random.Shared;
+
+    internal void ValidateAndNormalise()
+    {
+        if (MaxAttempts < 1)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(MaxAttempts), MaxAttempts,
+                "RetryingOutboxArchiveSinkOptions.MaxAttempts must be at least 1.");
+        }
+        if (BaseDelay <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(BaseDelay), BaseDelay,
+                "RetryingOutboxArchiveSinkOptions.BaseDelay must be positive.");
+        }
+        if (MaxDelay < BaseDelay)
+        {
+            throw new ArgumentException(
+                $"RetryingOutboxArchiveSinkOptions: MaxDelay ({MaxDelay}) must be >= BaseDelay ({BaseDelay}).");
+        }
+    }
+}

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Archival/RetryingOutboxArchiveSink.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Archival/RetryingOutboxArchiveSink.cs
@@ -44,10 +44,13 @@ public sealed class RetryingOutboxArchiveSink : IOutboxArchiveSink
                 await inner.WriteAsync(keyHint, payload, cancellationToken).ConfigureAwait(false);
                 return;
             }
-            catch (OperationCanceledException)
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
-                // Cancellation is not a transient failure - propagate without consuming
-                // a retry slot.
+                // CALLER cancellation. Propagate without consuming a retry slot. We gate
+                // on the caller's token because inner sinks built on HttpClient can
+                // surface request timeouts as TaskCanceledException even when the
+                // caller's token never fired - those are transient and SHOULD go through
+                // the IsRetryable predicate, not bypass the retry loop.
                 throw;
             }
 #pragma warning disable CA1031 // decorator catches by design - the IsRetryable predicate triages
@@ -64,12 +67,15 @@ public sealed class RetryingOutboxArchiveSink : IOutboxArchiveSink
                 {
                     await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
                 }
-                catch (OperationCanceledException)
+                catch (OperationCanceledException oce)
                 {
                     // Cancelled while waiting to retry - surface the last failure as the
-                    // cause so the caller sees the underlying problem rather than a
-                    // synthetic TaskCanceledException.
-                    throw;
+                    // InnerException so the caller sees the underlying problem rather
+                    // than a synthetic TaskCanceledException with no context.
+                    throw new OperationCanceledException(
+                        "RetryingOutboxArchiveSink cancelled while waiting to retry.",
+                        innerException: lastFailure ?? oce,
+                        token: oce.CancellationToken);
                 }
             }
         }
@@ -135,6 +141,23 @@ public sealed class RetryingOutboxArchiveSinkOptions
         {
             throw new ArgumentException(
                 $"RetryingOutboxArchiveSinkOptions: MaxDelay ({MaxDelay}) must be >= BaseDelay ({BaseDelay}).");
+        }
+        // Configuration binding (IConfiguration.Bind / Options.Configure with null
+        // explicit assignments) can leave these delegates null even when callers pass an
+        // options object that nominally satisfies the type. Surface that as a fast
+        // construction failure so the first WriteAsync call does not blow up with a
+        // NullReferenceException.
+        if (IsRetryable is null)
+        {
+            throw new ArgumentNullException(
+                nameof(IsRetryable),
+                "RetryingOutboxArchiveSinkOptions.IsRetryable must not be null. Default retries everything.");
+        }
+        if (RandomFactory is null)
+        {
+            throw new ArgumentNullException(
+                nameof(RandomFactory),
+                "RetryingOutboxArchiveSinkOptions.RandomFactory must not be null. Default returns Random.Shared.");
         }
     }
 }

--- a/src/Moongazing.OrionGuard.Generators/Moongazing.OrionGuard.Generators.csproj
+++ b/src/Moongazing.OrionGuard.Generators/Moongazing.OrionGuard.Generators.csproj
@@ -8,7 +8,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>CS1591</NoWarn>
     <PackageId>OrionGuard.Generators</PackageId>
-    <Version>6.5.10</Version>
+    <Version>6.5.11</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Source generator for OrionGuard. Generates [GenerateValidator] validators, [StronglyTypedId&lt;TValue&gt;] strongly-typed id types (EF Core ValueConverter, System.Text.Json JsonConverter, TypeConverter companions), and supports NativeAOT-compatible reflection-free workflows.</Description>
     <PackageTags>guard;validation;source-generator;roslyn;nativeaot;codegen;ddd;strongly-typed-id</PackageTags>

--- a/src/Moongazing.OrionGuard.Grpc/Moongazing.OrionGuard.Grpc.csproj
+++ b/src/Moongazing.OrionGuard.Grpc/Moongazing.OrionGuard.Grpc.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Grpc</PackageId>
-    <Version>6.5.10</Version>
+    <Version>6.5.11</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>gRPC integration for OrionGuard validation library. Provides server interceptor for automatic request validation in gRPC services.</Description>
     <PackageTags>guard;validation;grpc;interceptor;protobuf;microservices</PackageTags>

--- a/src/Moongazing.OrionGuard.Locks.Redis/Moongazing.OrionGuard.Locks.Redis.csproj
+++ b/src/Moongazing.OrionGuard.Locks.Redis/Moongazing.OrionGuard.Locks.Redis.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Locks.Redis</PackageId>
-    <Version>6.5.10</Version>
+    <Version>6.5.11</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Redis-backed IDistributedLock for OrionGuard.EntityFrameworkCore's outbox dispatcher. Bridges OrionGuard's IDistributedLock contract to the OrionLock.Redis backend so multi-instance outbox workers can share a Redis-coordinated lease instead of the default SkipLocked DB lock.</Description>
     <PackageTags>guard;outbox;distributed-lock;redis;orionlock;entity-framework-core;efcore</PackageTags>

--- a/src/Moongazing.OrionGuard.MediatR/Moongazing.OrionGuard.MediatR.csproj
+++ b/src/Moongazing.OrionGuard.MediatR/Moongazing.OrionGuard.MediatR.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.MediatR</PackageId>
-    <Version>6.5.10</Version>
+    <Version>6.5.11</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>MediatR integration for OrionGuard validation library. Provides ValidationBehavior pipeline behavior for automatic request validation in CQRS pipelines.</Description>
     <PackageTags>guard;validation;mediatr;cqrs;pipeline;behavior</PackageTags>

--- a/src/Moongazing.OrionGuard.OpenTelemetry/Moongazing.OrionGuard.OpenTelemetry.csproj
+++ b/src/Moongazing.OrionGuard.OpenTelemetry/Moongazing.OrionGuard.OpenTelemetry.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.OpenTelemetry</PackageId>
-    <Version>6.5.10</Version>
+    <Version>6.5.11</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>OpenTelemetry integration for OrionGuard validation library. Provides validation metrics (success/failure rates, latency) and distributed tracing spans.</Description>
     <PackageTags>guard;validation;opentelemetry;metrics;tracing;observability</PackageTags>

--- a/src/Moongazing.OrionGuard.Outbox.Dashboard/Moongazing.OrionGuard.Outbox.Dashboard.csproj
+++ b/src/Moongazing.OrionGuard.Outbox.Dashboard/Moongazing.OrionGuard.Outbox.Dashboard.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904;AD0001</NoWarn>
     <PackageId>OrionGuard.Outbox.Dashboard</PackageId>
-    <Version>6.5.10</Version>
+    <Version>6.5.11</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Outbox operator dashboard for OrionGuard. Maps an authorized listing of failed / poisoned messages from the consumer's DbContext to an ASP.NET Core endpoint group, plus POST /{id}/replay and POST /{id}/discard mutation endpoints (v6.5.5) with an optional OnMutation audit hook.</Description>
     <PackageTags>guard;outbox;dashboard;aspnetcore;poisoned-messages;dead-letter</PackageTags>

--- a/src/Moongazing.OrionGuard.Outbox.PostgresNotify/Moongazing.OrionGuard.Outbox.PostgresNotify.csproj
+++ b/src/Moongazing.OrionGuard.Outbox.PostgresNotify/Moongazing.OrionGuard.Outbox.PostgresNotify.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Outbox.PostgresNotify</PackageId>
-    <Version>6.5.10</Version>
+    <Version>6.5.11</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Postgres LISTEN/NOTIFY backed IOutboxWakeSignal for OrionGuard.EntityFrameworkCore. Replaces the v6.5.1 polling fallback with an event-driven wake on every committed outbox row when the consumer's database is PostgreSQL. Falls back to polling cleanly when the LISTEN connection is unreachable.</Description>
     <PackageTags>guard;outbox;postgres;npgsql;listen;notify;push;dispatch;entity-framework-core;efcore</PackageTags>

--- a/src/Moongazing.OrionGuard.Outbox.SqlServerBroker/Moongazing.OrionGuard.Outbox.SqlServerBroker.csproj
+++ b/src/Moongazing.OrionGuard.Outbox.SqlServerBroker/Moongazing.OrionGuard.Outbox.SqlServerBroker.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Outbox.SqlServerBroker</PackageId>
-    <Version>6.5.10</Version>
+    <Version>6.5.11</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>SQL Server Service Broker backed IOutboxWakeSignal for OrionGuard.EntityFrameworkCore. Sibling to OrionGuard.Outbox.PostgresNotify (v6.5.2) for the SQL Server provider. Replaces the v6.5.1 polling-only fallback with an event-driven wake on every committed outbox row via Service Broker's queueing primitives.</Description>
     <PackageTags>guard;outbox;sqlserver;service-broker;push;dispatch;entity-framework-core;efcore</PackageTags>

--- a/src/Moongazing.OrionGuard.SignalR/Moongazing.OrionGuard.SignalR.csproj
+++ b/src/Moongazing.OrionGuard.SignalR/Moongazing.OrionGuard.SignalR.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.SignalR</PackageId>
-    <Version>6.5.10</Version>
+    <Version>6.5.11</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>SignalR integration for OrionGuard validation library. Provides Hub filter for automatic method parameter validation.</Description>
     <PackageTags>guard;validation;signalr;realtime;hub;filter</PackageTags>

--- a/src/Moongazing.OrionGuard.Swagger/Moongazing.OrionGuard.Swagger.csproj
+++ b/src/Moongazing.OrionGuard.Swagger/Moongazing.OrionGuard.Swagger.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Swagger</PackageId>
-    <Version>6.5.10</Version>
+    <Version>6.5.11</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Swagger/OpenAPI integration for OrionGuard. Auto-generates OpenAPI constraints from OrionGuard validation attributes.</Description>
     <PackageTags>guard;validation;swagger;openapi;swashbuckle</PackageTags>

--- a/src/Moongazing.OrionGuard.Testing/Moongazing.OrionGuard.Testing.csproj
+++ b/src/Moongazing.OrionGuard.Testing/Moongazing.OrionGuard.Testing.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Testing</PackageId>
-    <Version>6.5.10</Version>
+    <Version>6.5.11</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Testing helpers for OrionGuard. Provides DomainEventCapture and InMemoryDomainEventDispatcher with framework-agnostic assertions (no xUnit / NUnit / FluentAssertions dependency). Works with any test runner.</Description>
     <PackageTags>guard;validation;testing;ddd;domain-events;assertions;test-helpers</PackageTags>

--- a/src/Moongazing.OrionGuard/Moongazing.OrionGuard.csproj
+++ b/src/Moongazing.OrionGuard/Moongazing.OrionGuard.csproj
@@ -16,7 +16,7 @@
 		<OutputType>Library</OutputType>
 
 		<PackageId>OrionGuard</PackageId>
-		<Version>6.5.10</Version>
+		<Version>6.5.11</Version>
 		<Authors>Tunahan Ali Ozturk</Authors>
 		<Company>Tunahan Ali Ozturk</Company>
 		<GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/Archival/RetryingOutboxArchiveSinkTests.cs
+++ b/tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/Archival/RetryingOutboxArchiveSinkTests.cs
@@ -1,0 +1,119 @@
+namespace Moongazing.OrionGuard.EntityFrameworkCore.Tests.Outbox.Archival;
+
+using System.Text;
+using Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Archival;
+using Xunit;
+
+public sealed class RetryingOutboxArchiveSinkTests
+{
+    private sealed class ScriptedSink : IOutboxArchiveSink
+    {
+        private readonly Queue<Func<Task>> script;
+        public int Calls { get; private set; }
+        public ScriptedSink(params Func<Task>[] actions) => script = new Queue<Func<Task>>(actions);
+        public Task WriteAsync(string keyHint, ReadOnlyMemory<byte> payload, CancellationToken ct)
+        {
+            Calls++;
+            return script.Count > 0 ? script.Dequeue()() : Task.CompletedTask;
+        }
+    }
+
+    private static RetryingOutboxArchiveSinkOptions FastRetry(int maxAttempts = 5) => new()
+    {
+        MaxAttempts = maxAttempts,
+        BaseDelay = TimeSpan.FromMilliseconds(1),
+        MaxDelay = TimeSpan.FromMilliseconds(5),
+    };
+
+    [Fact]
+    public async Task Succeeds_immediately_when_inner_does_not_throw()
+    {
+        var inner = new ScriptedSink();
+        var sut = new RetryingOutboxArchiveSink(inner, FastRetry());
+
+        await sut.WriteAsync("k", Encoding.UTF8.GetBytes("p"), CancellationToken.None);
+
+        Assert.Equal(1, inner.Calls);
+    }
+
+    [Fact]
+    public async Task Retries_until_inner_succeeds()
+    {
+        var failuresLeft = 2;
+        var inner = new ScriptedSink(
+            () => failuresLeft-- > 0 ? Task.FromException(new InvalidOperationException("transient")) : Task.CompletedTask,
+            () => failuresLeft-- > 0 ? Task.FromException(new InvalidOperationException("transient")) : Task.CompletedTask,
+            () => Task.CompletedTask);
+        var sut = new RetryingOutboxArchiveSink(inner, FastRetry());
+
+        await sut.WriteAsync("k", Encoding.UTF8.GetBytes("p"), CancellationToken.None);
+
+        Assert.Equal(3, inner.Calls);
+    }
+
+    [Fact]
+    public async Task Rethrows_last_exception_after_MaxAttempts()
+    {
+        var inner = new ScriptedSink(
+            () => Task.FromException(new InvalidOperationException("attempt-1")),
+            () => Task.FromException(new InvalidOperationException("attempt-2")),
+            () => Task.FromException(new InvalidOperationException("attempt-3-final")));
+        var sut = new RetryingOutboxArchiveSink(inner, FastRetry(maxAttempts: 3));
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => sut.WriteAsync("k", Encoding.UTF8.GetBytes("p"), CancellationToken.None));
+        Assert.Equal("attempt-3-final", ex.Message);
+        Assert.Equal(3, inner.Calls);
+    }
+
+    [Fact]
+    public async Task IsRetryable_predicate_short_circuits_non_transient_failures()
+    {
+        var inner = new ScriptedSink(
+            () => Task.FromException(new ArgumentException("invalid payload")));
+        var sut = new RetryingOutboxArchiveSink(inner, new RetryingOutboxArchiveSinkOptions
+        {
+            MaxAttempts = 5,
+            BaseDelay = TimeSpan.FromMilliseconds(1),
+            MaxDelay = TimeSpan.FromMilliseconds(5),
+            IsRetryable = ex => ex is not ArgumentException,
+        });
+
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => sut.WriteAsync("k", Encoding.UTF8.GetBytes("p"), CancellationToken.None));
+        Assert.Equal(1, inner.Calls);
+    }
+
+    [Fact]
+    public async Task Cancellation_propagates_without_consuming_retries()
+    {
+        using var cts = new CancellationTokenSource();
+        var inner = new ScriptedSink(
+            () =>
+            {
+                cts.Cancel();
+                throw new OperationCanceledException(cts.Token);
+            });
+        var sut = new RetryingOutboxArchiveSink(inner, FastRetry());
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => sut.WriteAsync("k", Encoding.UTF8.GetBytes("p"), cts.Token));
+        Assert.Equal(1, inner.Calls);
+    }
+
+    [Fact]
+    public void Options_validate_at_construction()
+    {
+        var inner = new ScriptedSink();
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            new RetryingOutboxArchiveSink(inner, new RetryingOutboxArchiveSinkOptions { MaxAttempts = 0 }));
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            new RetryingOutboxArchiveSink(inner, new RetryingOutboxArchiveSinkOptions { BaseDelay = TimeSpan.Zero }));
+        Assert.Throws<ArgumentException>(() =>
+            new RetryingOutboxArchiveSink(inner, new RetryingOutboxArchiveSinkOptions
+            {
+                BaseDelay = TimeSpan.FromMilliseconds(100),
+                MaxDelay = TimeSpan.FromMilliseconds(50),
+            }));
+    }
+}


### PR DESCRIPTION
## OrionGuard v6.5.11 - RetryingOutboxArchiveSink decorator

### Shipped

- `RetryingOutboxArchiveSink` wraps any `IOutboxArchiveSink` with jittered exponential retry.
- `RetryingOutboxArchiveSinkOptions` (`MaxAttempts`, `BaseDelay`, `MaxDelay`, `IsRetryable`, `RandomFactory`).
- Cancellation propagates without consuming retries.
- 6 new facts.

### Migration

Source-compatible.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added retrying behavior for outbox archival operations with jittered exponential backoff and configurable max attempts, base/max delays, retry predicate, and seeded jitter support; cancellation from callers does not consume retry attempts.
* **Tests**
  * Added tests covering success, retrying, failure after max attempts, non-retryable short-circuit, cancellation propagation, and option validation.
* **Documentation**
  * Changelog updated for v6.5.11.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->