### PR TITLE
Release v6.5.12: CompositeOutboxArchiveSink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to OrionGuard will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.5.12] - 2026-06-11
+
+### Added
+
+#### `CompositeOutboxArchiveSink` - fan-out to multiple sinks
+
+Deployments wanting archival redundancy can now wire two or more `IOutboxArchiveSink` instances (e.g. S3 + local rotating file) and the composite forwards every write to each in registration order.
+
+- `CompositeOutboxArchiveSink(IEnumerable<IOutboxArchiveSink>, CompositeOutboxArchiveSinkMode)`.
+- `FailFast` (default): first failure aborts and bubbles. Use when cross-sink consistency matters.
+- `BestEffort`: every sink is called; AggregateException is thrown ONLY if every sink threw. Use when archive needs to land in at least one destination.
+- Cancellation propagates without consuming remaining sinks.
+- Sequential fan-out by design - cloud-object-store clients benefit from serial calls more than from fan-out concurrency.
+
+### Tests
+
+8 new facts.
+
+### Migration from v6.5.11
+
+Source-compatible.
+
 ## [6.5.11] - 2026-06-11
 
 ### Added

--- a/src/Moongazing.OrionGuard.AspNetCore/Moongazing.OrionGuard.AspNetCore.csproj
+++ b/src/Moongazing.OrionGuard.AspNetCore/Moongazing.OrionGuard.AspNetCore.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.AspNetCore</PackageId>
-    <Version>6.5.11</Version>
+    <Version>6.5.12</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>ASP.NET Core integration for OrionGuard validation library. Provides middleware, Minimal API endpoint filters, MVC action filters, and RFC 9457 ProblemDetails support.</Description>
     <PackageTags>guard;validation;aspnetcore;middleware;minimal-api;problemdetails</PackageTags>

--- a/src/Moongazing.OrionGuard.Blazor/Moongazing.OrionGuard.Blazor.csproj
+++ b/src/Moongazing.OrionGuard.Blazor/Moongazing.OrionGuard.Blazor.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Blazor</PackageId>
-    <Version>6.5.11</Version>
+    <Version>6.5.12</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Blazor integration for OrionGuard validation library. Provides EditForm validation, custom validation components, and data annotations interop.</Description>
     <PackageTags>guard;validation;blazor;editform;component;wasm;server</PackageTags>

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Moongazing.OrionGuard.EntityFrameworkCore.csproj
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Moongazing.OrionGuard.EntityFrameworkCore.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.EntityFrameworkCore</PackageId>
-    <Version>6.5.11</Version>
+    <Version>6.5.12</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>EF Core integration for OrionGuard. Provides a SaveChanges interceptor that dispatches domain events from AggregateRoot&lt;TId&gt; instances after commit (Inline mode) or via a transactional outbox (Outbox mode) consumed by a hosted background worker. Includes W3C trace context propagation across the outbox boundary.</Description>
     <PackageTags>guard;validation;ddd;domain-events;outbox;entity-framework-core;efcore;aggregate-root</PackageTags>

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Archival/CompositeOutboxArchiveSink.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Archival/CompositeOutboxArchiveSink.cs
@@ -1,0 +1,105 @@
+namespace Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Archival;
+
+using System.Collections.Generic;
+
+/// <summary>
+/// <see cref="IOutboxArchiveSink"/> that forwards every <see cref="WriteAsync"/> to a
+/// configured fan-out of inner sinks. Pairs with deployments that want archival
+/// redundancy - e.g. write to both S3 (long-term cold storage) AND a local rotating-file
+/// sink (operator-readable shadow). Failure semantics are configurable:
+/// </summary>
+/// <remarks>
+/// <list type="bullet">
+///   <item><description><see cref="CompositeOutboxArchiveSinkMode.FailFast"/> (default): the first sink that throws aborts the composite write and bubbles the exception. Remaining sinks are NOT called. Use when consistency across sinks matters more than coverage.</description></item>
+///   <item><description><see cref="CompositeOutboxArchiveSinkMode.BestEffort"/>: every sink is called; any exceptions are aggregated and surfaced as an <see cref="AggregateException"/> ONLY if EVERY sink threw. If at least one sink succeeded the call returns successfully. Use when you want the archive to land in at least one destination but cannot afford a fan-out failure to abort the sweep.</description></item>
+/// </list>
+/// <para>
+/// Sinks are invoked SEQUENTIALLY in registration order. Parallel fan-out is intentionally
+/// not built in - cloud-object-store clients typically have their own connection-pool
+/// constraints that benefit from serial calls more than from fan-out concurrency. A
+/// future <c>ParallelCompositeOutboxArchiveSink</c> can ship if measurements justify it.
+/// </para>
+/// </remarks>
+public sealed class CompositeOutboxArchiveSink : IOutboxArchiveSink
+{
+    private readonly IReadOnlyList<IOutboxArchiveSink> sinks;
+    private readonly CompositeOutboxArchiveSinkMode mode;
+
+    /// <summary>Construct with the inner sinks and the failure-mode policy.</summary>
+    public CompositeOutboxArchiveSink(
+        IEnumerable<IOutboxArchiveSink> sinks,
+        CompositeOutboxArchiveSinkMode mode = CompositeOutboxArchiveSinkMode.FailFast)
+    {
+        ArgumentNullException.ThrowIfNull(sinks);
+        var snapshot = sinks.ToArray();
+        if (snapshot.Length == 0)
+        {
+            throw new ArgumentException(
+                "CompositeOutboxArchiveSink requires at least one inner sink.",
+                nameof(sinks));
+        }
+        if (snapshot.Any(s => s is null))
+        {
+            throw new ArgumentException(
+                "CompositeOutboxArchiveSink: every inner sink must be non-null.",
+                nameof(sinks));
+        }
+        this.sinks = snapshot;
+        this.mode = mode;
+    }
+
+    /// <inheritdoc />
+    public async Task WriteAsync(string keyHint, ReadOnlyMemory<byte> payload, CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(keyHint);
+        if (mode == CompositeOutboxArchiveSinkMode.FailFast)
+        {
+            foreach (var sink in sinks)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                await sink.WriteAsync(keyHint, payload, cancellationToken).ConfigureAwait(false);
+            }
+            return;
+        }
+
+        // BestEffort: collect failures; return success when at least one sink succeeded.
+        List<Exception>? failures = null;
+        var anySuccess = false;
+        foreach (var sink in sinks)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            try
+            {
+                await sink.WriteAsync(keyHint, payload, cancellationToken).ConfigureAwait(false);
+                anySuccess = true;
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                // Caller cancellation - propagate immediately without aggregating.
+                throw;
+            }
+#pragma warning disable CA1031 // composite captures by design; aggregation decision is at the bottom
+            catch (Exception ex)
+#pragma warning restore CA1031
+            {
+                (failures ??= new List<Exception>()).Add(ex);
+            }
+        }
+        if (!anySuccess && failures is not null)
+        {
+            throw new AggregateException(
+                $"CompositeOutboxArchiveSink (BestEffort): all {sinks.Count} sinks failed.",
+                failures);
+        }
+    }
+}
+
+/// <summary>Failure policy for <see cref="CompositeOutboxArchiveSink"/>.</summary>
+public enum CompositeOutboxArchiveSinkMode
+{
+    /// <summary>First-failure aborts; remaining sinks are not called.</summary>
+    FailFast = 0,
+
+    /// <summary>Every sink is called; aggregated failure thrown ONLY if every sink threw.</summary>
+    BestEffort = 1,
+}

--- a/src/Moongazing.OrionGuard.Generators/Moongazing.OrionGuard.Generators.csproj
+++ b/src/Moongazing.OrionGuard.Generators/Moongazing.OrionGuard.Generators.csproj
@@ -8,7 +8,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>CS1591</NoWarn>
     <PackageId>OrionGuard.Generators</PackageId>
-    <Version>6.5.11</Version>
+    <Version>6.5.12</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Source generator for OrionGuard. Generates [GenerateValidator] validators, [StronglyTypedId&lt;TValue&gt;] strongly-typed id types (EF Core ValueConverter, System.Text.Json JsonConverter, TypeConverter companions), and supports NativeAOT-compatible reflection-free workflows.</Description>
     <PackageTags>guard;validation;source-generator;roslyn;nativeaot;codegen;ddd;strongly-typed-id</PackageTags>

--- a/src/Moongazing.OrionGuard.Grpc/Moongazing.OrionGuard.Grpc.csproj
+++ b/src/Moongazing.OrionGuard.Grpc/Moongazing.OrionGuard.Grpc.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Grpc</PackageId>
-    <Version>6.5.11</Version>
+    <Version>6.5.12</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>gRPC integration for OrionGuard validation library. Provides server interceptor for automatic request validation in gRPC services.</Description>
     <PackageTags>guard;validation;grpc;interceptor;protobuf;microservices</PackageTags>

--- a/src/Moongazing.OrionGuard.Locks.Redis/Moongazing.OrionGuard.Locks.Redis.csproj
+++ b/src/Moongazing.OrionGuard.Locks.Redis/Moongazing.OrionGuard.Locks.Redis.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Locks.Redis</PackageId>
-    <Version>6.5.11</Version>
+    <Version>6.5.12</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Redis-backed IDistributedLock for OrionGuard.EntityFrameworkCore's outbox dispatcher. Bridges OrionGuard's IDistributedLock contract to the OrionLock.Redis backend so multi-instance outbox workers can share a Redis-coordinated lease instead of the default SkipLocked DB lock.</Description>
     <PackageTags>guard;outbox;distributed-lock;redis;orionlock;entity-framework-core;efcore</PackageTags>

--- a/src/Moongazing.OrionGuard.MediatR/Moongazing.OrionGuard.MediatR.csproj
+++ b/src/Moongazing.OrionGuard.MediatR/Moongazing.OrionGuard.MediatR.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.MediatR</PackageId>
-    <Version>6.5.11</Version>
+    <Version>6.5.12</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>MediatR integration for OrionGuard validation library. Provides ValidationBehavior pipeline behavior for automatic request validation in CQRS pipelines.</Description>
     <PackageTags>guard;validation;mediatr;cqrs;pipeline;behavior</PackageTags>

--- a/src/Moongazing.OrionGuard.OpenTelemetry/Moongazing.OrionGuard.OpenTelemetry.csproj
+++ b/src/Moongazing.OrionGuard.OpenTelemetry/Moongazing.OrionGuard.OpenTelemetry.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.OpenTelemetry</PackageId>
-    <Version>6.5.11</Version>
+    <Version>6.5.12</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>OpenTelemetry integration for OrionGuard validation library. Provides validation metrics (success/failure rates, latency) and distributed tracing spans.</Description>
     <PackageTags>guard;validation;opentelemetry;metrics;tracing;observability</PackageTags>

--- a/src/Moongazing.OrionGuard.Outbox.Dashboard/Moongazing.OrionGuard.Outbox.Dashboard.csproj
+++ b/src/Moongazing.OrionGuard.Outbox.Dashboard/Moongazing.OrionGuard.Outbox.Dashboard.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904;AD0001</NoWarn>
     <PackageId>OrionGuard.Outbox.Dashboard</PackageId>
-    <Version>6.5.11</Version>
+    <Version>6.5.12</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Outbox operator dashboard for OrionGuard. Maps an authorized listing of failed / poisoned messages from the consumer's DbContext to an ASP.NET Core endpoint group, plus POST /{id}/replay and POST /{id}/discard mutation endpoints (v6.5.5) with an optional OnMutation audit hook.</Description>
     <PackageTags>guard;outbox;dashboard;aspnetcore;poisoned-messages;dead-letter</PackageTags>

--- a/src/Moongazing.OrionGuard.Outbox.PostgresNotify/Moongazing.OrionGuard.Outbox.PostgresNotify.csproj
+++ b/src/Moongazing.OrionGuard.Outbox.PostgresNotify/Moongazing.OrionGuard.Outbox.PostgresNotify.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Outbox.PostgresNotify</PackageId>
-    <Version>6.5.11</Version>
+    <Version>6.5.12</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Postgres LISTEN/NOTIFY backed IOutboxWakeSignal for OrionGuard.EntityFrameworkCore. Replaces the v6.5.1 polling fallback with an event-driven wake on every committed outbox row when the consumer's database is PostgreSQL. Falls back to polling cleanly when the LISTEN connection is unreachable.</Description>
     <PackageTags>guard;outbox;postgres;npgsql;listen;notify;push;dispatch;entity-framework-core;efcore</PackageTags>

--- a/src/Moongazing.OrionGuard.Outbox.SqlServerBroker/Moongazing.OrionGuard.Outbox.SqlServerBroker.csproj
+++ b/src/Moongazing.OrionGuard.Outbox.SqlServerBroker/Moongazing.OrionGuard.Outbox.SqlServerBroker.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Outbox.SqlServerBroker</PackageId>
-    <Version>6.5.11</Version>
+    <Version>6.5.12</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>SQL Server Service Broker backed IOutboxWakeSignal for OrionGuard.EntityFrameworkCore. Sibling to OrionGuard.Outbox.PostgresNotify (v6.5.2) for the SQL Server provider. Replaces the v6.5.1 polling-only fallback with an event-driven wake on every committed outbox row via Service Broker's queueing primitives.</Description>
     <PackageTags>guard;outbox;sqlserver;service-broker;push;dispatch;entity-framework-core;efcore</PackageTags>

--- a/src/Moongazing.OrionGuard.SignalR/Moongazing.OrionGuard.SignalR.csproj
+++ b/src/Moongazing.OrionGuard.SignalR/Moongazing.OrionGuard.SignalR.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.SignalR</PackageId>
-    <Version>6.5.11</Version>
+    <Version>6.5.12</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>SignalR integration for OrionGuard validation library. Provides Hub filter for automatic method parameter validation.</Description>
     <PackageTags>guard;validation;signalr;realtime;hub;filter</PackageTags>

--- a/src/Moongazing.OrionGuard.Swagger/Moongazing.OrionGuard.Swagger.csproj
+++ b/src/Moongazing.OrionGuard.Swagger/Moongazing.OrionGuard.Swagger.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Swagger</PackageId>
-    <Version>6.5.11</Version>
+    <Version>6.5.12</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Swagger/OpenAPI integration for OrionGuard. Auto-generates OpenAPI constraints from OrionGuard validation attributes.</Description>
     <PackageTags>guard;validation;swagger;openapi;swashbuckle</PackageTags>

--- a/src/Moongazing.OrionGuard.Testing/Moongazing.OrionGuard.Testing.csproj
+++ b/src/Moongazing.OrionGuard.Testing/Moongazing.OrionGuard.Testing.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Testing</PackageId>
-    <Version>6.5.11</Version>
+    <Version>6.5.12</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Testing helpers for OrionGuard. Provides DomainEventCapture and InMemoryDomainEventDispatcher with framework-agnostic assertions (no xUnit / NUnit / FluentAssertions dependency). Works with any test runner.</Description>
     <PackageTags>guard;validation;testing;ddd;domain-events;assertions;test-helpers</PackageTags>

--- a/src/Moongazing.OrionGuard/Moongazing.OrionGuard.csproj
+++ b/src/Moongazing.OrionGuard/Moongazing.OrionGuard.csproj
@@ -16,7 +16,7 @@
 		<OutputType>Library</OutputType>
 
 		<PackageId>OrionGuard</PackageId>
-		<Version>6.5.11</Version>
+		<Version>6.5.12</Version>
 		<Authors>Tunahan Ali Ozturk</Authors>
 		<Company>Tunahan Ali Ozturk</Company>
 		<GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/Archival/CompositeOutboxArchiveSinkTests.cs
+++ b/tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/Archival/CompositeOutboxArchiveSinkTests.cs
@@ -1,0 +1,120 @@
+namespace Moongazing.OrionGuard.EntityFrameworkCore.Tests.Outbox.Archival;
+
+using System.Text;
+using Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Archival;
+using Xunit;
+
+public sealed class CompositeOutboxArchiveSinkTests
+{
+    private sealed class RecordingSink : IOutboxArchiveSink
+    {
+        public int Calls { get; private set; }
+        public Func<Task>? Behaviour { get; set; }
+        public Task WriteAsync(string keyHint, ReadOnlyMemory<byte> payload, CancellationToken ct)
+        {
+            Calls++;
+            return Behaviour?.Invoke() ?? Task.CompletedTask;
+        }
+    }
+
+    [Fact]
+    public async Task FailFast_forwards_to_every_sink_in_order_on_success()
+    {
+        var a = new RecordingSink();
+        var b = new RecordingSink();
+        var c = new RecordingSink();
+        var sut = new CompositeOutboxArchiveSink(new[] { a, b, c });
+
+        await sut.WriteAsync("k", Encoding.UTF8.GetBytes("p"), CancellationToken.None);
+
+        Assert.Equal(1, a.Calls);
+        Assert.Equal(1, b.Calls);
+        Assert.Equal(1, c.Calls);
+    }
+
+    [Fact]
+    public async Task FailFast_aborts_on_first_failure_and_does_not_call_remaining_sinks()
+    {
+        var a = new RecordingSink();
+        var b = new RecordingSink { Behaviour = () => throw new InvalidOperationException("boom") };
+        var c = new RecordingSink();
+        var sut = new CompositeOutboxArchiveSink(new[] { a, b, c });
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => sut.WriteAsync("k", Encoding.UTF8.GetBytes("p"), CancellationToken.None));
+
+        Assert.Equal(1, a.Calls);
+        Assert.Equal(1, b.Calls);
+        Assert.Equal(0, c.Calls);
+    }
+
+    [Fact]
+    public async Task BestEffort_calls_every_sink_even_after_a_failure()
+    {
+        var a = new RecordingSink();
+        var b = new RecordingSink { Behaviour = () => throw new InvalidOperationException("boom") };
+        var c = new RecordingSink();
+        var sut = new CompositeOutboxArchiveSink(new[] { a, b, c }, CompositeOutboxArchiveSinkMode.BestEffort);
+
+        await sut.WriteAsync("k", Encoding.UTF8.GetBytes("p"), CancellationToken.None);
+
+        Assert.Equal(1, a.Calls);
+        Assert.Equal(1, b.Calls);
+        Assert.Equal(1, c.Calls);
+    }
+
+    [Fact]
+    public async Task BestEffort_throws_AggregateException_when_every_sink_fails()
+    {
+        var a = new RecordingSink { Behaviour = () => throw new InvalidOperationException("a") };
+        var b = new RecordingSink { Behaviour = () => throw new InvalidOperationException("b") };
+        var sut = new CompositeOutboxArchiveSink(new[] { a, b }, CompositeOutboxArchiveSinkMode.BestEffort);
+
+        var ex = await Assert.ThrowsAsync<AggregateException>(
+            () => sut.WriteAsync("k", Encoding.UTF8.GetBytes("p"), CancellationToken.None));
+        Assert.Equal(2, ex.InnerExceptions.Count);
+    }
+
+    [Fact]
+    public async Task BestEffort_returns_success_when_at_least_one_sink_succeeds()
+    {
+        var a = new RecordingSink { Behaviour = () => throw new InvalidOperationException("boom") };
+        var b = new RecordingSink();
+        var sut = new CompositeOutboxArchiveSink(new[] { a, b }, CompositeOutboxArchiveSinkMode.BestEffort);
+
+        await sut.WriteAsync("k", Encoding.UTF8.GetBytes("p"), CancellationToken.None);
+
+        Assert.Equal(1, a.Calls);
+        Assert.Equal(1, b.Calls);
+    }
+
+    [Fact]
+    public async Task Cancellation_propagates_in_both_modes_without_consuming_remaining_sinks()
+    {
+        using var cts = new CancellationTokenSource();
+        var a = new RecordingSink
+        {
+            Behaviour = () => { cts.Cancel(); throw new OperationCanceledException(cts.Token); },
+        };
+        var b = new RecordingSink();
+        var sut = new CompositeOutboxArchiveSink(new[] { a, b }, CompositeOutboxArchiveSinkMode.BestEffort);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => sut.WriteAsync("k", Encoding.UTF8.GetBytes("p"), cts.Token));
+        Assert.Equal(0, b.Calls);
+    }
+
+    [Fact]
+    public void Constructor_rejects_empty_sink_list()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            new CompositeOutboxArchiveSink(Array.Empty<IOutboxArchiveSink>()));
+    }
+
+    [Fact]
+    public void Constructor_rejects_null_sink_in_list()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            new CompositeOutboxArchiveSink(new IOutboxArchiveSink?[] { null }!));
+    }
+}


### PR DESCRIPTION
## OrionGuard v6.5.12 - CompositeOutboxArchiveSink

### Shipped

- `CompositeOutboxArchiveSink` forwards each `WriteAsync` to N inner sinks (S3 + local file for redundancy).
- `FailFast` / `BestEffort` failure modes.
- 8 facts.

### Migration

Source-compatible.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for distributing archival writes across multiple archival sinks with configurable failure handling (immediate abort or best-effort with collection of all failures).

* **Chores**
  * Version bumped to 6.5.12 across all packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->