### PR TITLE
Release v6.5.14: OutboxArchivalHealthCheck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to OrionGuard will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.5.14] - 2026-06-11
+
+### Added
+
+#### `OutboxArchivalHealthCheck` and `OutboxArchivalState`
+
+`IHealthCheck` that watches the `OutboxArchivalHostedService` liveness via a shared `OutboxArchivalState` singleton. Operators wire it into ASP.NET Core / generic-host pipelines so a stuck archival worker downgrades the `/health` probe before rows pile up.
+
+- `OutboxArchivalState.RecordSuccessfulBatch(DateTime)` called by the hosted service after every batch (including 0-row batches - the goal is liveness, not throughput).
+- `OutboxArchivalHealthCheck` returns `Healthy` / `Degraded` / `Unhealthy` based on the elapsed time since the last successful batch.
+- `OutboxArchivalHealthCheckOptions` (`DegradedAfter` default 5 min, `UnhealthyAfter` default 15 min) validated at construction.
+- Pre-startup state (no batch yet) reported as `Degraded` so operators can tell "warming up" apart from "stuck".
+- New 6-arg hosted-service ctor wires the optional state mirror; existing 5- and 4-arg ctors still work (zero-binary-break).
+- `Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions` added as a package reference.
+
+### Tests
+
+6 new facts.
+
+### Migration from v6.5.13
+
+Source-compatible.
+
+```csharp
+services.AddSingleton<OutboxArchivalState>();
+services.AddHealthChecks()
+    .AddCheck<OutboxArchivalHealthCheck>("orionguard-outbox-archival");
+```
+
 ## [6.5.13] - 2026-06-11
 
 ### Added

--- a/src/Moongazing.OrionGuard.AspNetCore/Moongazing.OrionGuard.AspNetCore.csproj
+++ b/src/Moongazing.OrionGuard.AspNetCore/Moongazing.OrionGuard.AspNetCore.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.AspNetCore</PackageId>
-    <Version>6.5.13</Version>
+    <Version>6.5.14</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>ASP.NET Core integration for OrionGuard validation library. Provides middleware, Minimal API endpoint filters, MVC action filters, and RFC 9457 ProblemDetails support.</Description>
     <PackageTags>guard;validation;aspnetcore;middleware;minimal-api;problemdetails</PackageTags>

--- a/src/Moongazing.OrionGuard.Blazor/Moongazing.OrionGuard.Blazor.csproj
+++ b/src/Moongazing.OrionGuard.Blazor/Moongazing.OrionGuard.Blazor.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Blazor</PackageId>
-    <Version>6.5.13</Version>
+    <Version>6.5.14</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Blazor integration for OrionGuard validation library. Provides EditForm validation, custom validation components, and data annotations interop.</Description>
     <PackageTags>guard;validation;blazor;editform;component;wasm;server</PackageTags>

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/AssemblyInfo.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/AssemblyInfo.cs
@@ -7,3 +7,4 @@ using System.Runtime.CompilerServices;
 // added here as they ship.
 [assembly: InternalsVisibleTo("Moongazing.OrionGuard.Locks.Redis")]
 [assembly: InternalsVisibleTo("Moongazing.OrionGuard.Locks.Redis.Tests")]
+[assembly: InternalsVisibleTo("Moongazing.OrionGuard.EntityFrameworkCore.Tests")]

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Moongazing.OrionGuard.EntityFrameworkCore.csproj
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Moongazing.OrionGuard.EntityFrameworkCore.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.EntityFrameworkCore</PackageId>
-    <Version>6.5.13</Version>
+    <Version>6.5.14</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>EF Core integration for OrionGuard. Provides a SaveChanges interceptor that dispatches domain events from AggregateRoot&lt;TId&gt; instances after commit (Inline mode) or via a transactional outbox (Outbox mode) consumed by a hosted background worker. Includes W3C trace context propagation across the outbox boundary.</Description>
     <PackageTags>guard;validation;ddd;domain-events;outbox;entity-framework-core;efcore;aggregate-root</PackageTags>
@@ -24,6 +24,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="9.0.0" />
     <ProjectReference Include="..\Moongazing.OrionGuard\Moongazing.OrionGuard.csproj" />
   </ItemGroup>
 

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/OrionGuardEfCoreOptions.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/OrionGuardEfCoreOptions.cs
@@ -96,7 +96,25 @@ public sealed class OrionGuardEfCoreOptions
         ServiceCustomizations.Add(services =>
         {
             services.Replace(ServiceDescriptor.Singleton(options));
-            services.AddHostedService<OutboxArchivalHostedService>();
+            // v6.5.14: register the optional liveness mirror as a singleton so the
+            // OutboxArchivalHealthCheck can observe RecordSuccessfulBatch updates.
+            // The hosted service resolves it via the new 6-arg constructor path.
+            services.TryAddSingleton<OutboxArchivalState>();
+            // Register the default health-check options so consumers can wire the check
+            // with AddCheck<OutboxArchivalHealthCheck>(...) without also writing
+            // services.AddSingleton(new OutboxArchivalHealthCheckOptions()) by hand.
+            services.TryAddSingleton<OutboxArchivalHealthCheckOptions>();
+            // Force the DI container to pick the 6-arg state-aware constructor by
+            // registering the hosted service via a factory that explicitly resolves
+            // OutboxArchivalState. Otherwise MS.DI falls back to the 4-arg ctor (which
+            // hard-codes state: null) when IOutboxArchiver is not registered.
+            services.AddHostedService(sp => new OutboxArchivalHostedService(
+                sp.GetRequiredService<OutboxArchivalOptions>(),
+                sp.GetRequiredService<IServiceScopeFactory>(),
+                sp.GetRequiredService<IDistributedLock>(),
+                sp.GetService<Microsoft.Extensions.Logging.ILogger<OutboxArchivalHostedService>>(),
+                sp.GetService<IOutboxArchiver>(),
+                sp.GetRequiredService<OutboxArchivalState>()));
         });
         return this;
     }

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Archival/OutboxArchivalHealthCheck.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Archival/OutboxArchivalHealthCheck.cs
@@ -1,0 +1,103 @@
+namespace Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Archival;
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+/// <summary>
+/// <see cref="IHealthCheck"/> that watches the
+/// <see cref="OutboxArchivalHostedService"/> liveness via the shared
+/// <see cref="OutboxArchivalState"/>. Returns <see cref="HealthStatus.Healthy"/> when the
+/// last successful batch is within <see cref="OutboxArchivalHealthCheckOptions.DegradedAfter"/>,
+/// <see cref="HealthStatus.Degraded"/> when between <c>DegradedAfter</c> and
+/// <c>UnhealthyAfter</c>, and <see cref="HealthStatus.Unhealthy"/> when older than
+/// <c>UnhealthyAfter</c>. A service that has never produced a batch yet is reported as
+/// <see cref="HealthStatus.Degraded"/> with the start-time context so operators can tell
+/// "warming up" apart from "stuck".
+/// </summary>
+public sealed class OutboxArchivalHealthCheck : IHealthCheck
+{
+    private readonly OutboxArchivalState state;
+    private readonly OutboxArchivalHealthCheckOptions options;
+    private readonly TimeProvider clock;
+
+    public OutboxArchivalHealthCheck(OutboxArchivalState state, OutboxArchivalHealthCheckOptions options)
+        : this(state, options, TimeProvider.System)
+    {
+    }
+
+    internal OutboxArchivalHealthCheck(
+        OutboxArchivalState state,
+        OutboxArchivalHealthCheckOptions options,
+        TimeProvider clock)
+    {
+        ArgumentNullException.ThrowIfNull(state);
+        ArgumentNullException.ThrowIfNull(options);
+        this.state = state;
+        this.options = options;
+        this.options.Validate();
+        this.clock = clock ?? TimeProvider.System;
+    }
+
+    /// <inheritdoc />
+    public Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context, CancellationToken cancellationToken = default)
+    {
+        var now = clock.GetUtcNow().UtcDateTime;
+        var last = state.LastSuccessfulBatchUtc;
+        var data = new Dictionary<string, object>
+        {
+            ["totalBatches"] = state.TotalBatches,
+            ["lastSuccessfulBatchUtc"] = (object?)last ?? "never",
+            ["nowUtc"] = now,
+        };
+
+        if (last is null)
+        {
+            return Task.FromResult(HealthCheckResult.Degraded(
+                "OrionGuard outbox archival has not completed a batch yet.", data: data));
+        }
+        var age = now - last.Value;
+        if (age >= options.UnhealthyAfter)
+        {
+            return Task.FromResult(HealthCheckResult.Unhealthy(
+                $"Last archival batch was {age.TotalMinutes:F1} minutes ago (>= {options.UnhealthyAfter.TotalMinutes:F0}).",
+                data: data));
+        }
+        if (age >= options.DegradedAfter)
+        {
+            return Task.FromResult(HealthCheckResult.Degraded(
+                $"Last archival batch was {age.TotalMinutes:F1} minutes ago (>= {options.DegradedAfter.TotalMinutes:F0}).",
+                data: data));
+        }
+        return Task.FromResult(HealthCheckResult.Healthy(
+            $"Last archival batch was {age.TotalSeconds:F0}s ago.", data: data));
+    }
+}
+
+/// <summary>Options for <see cref="OutboxArchivalHealthCheck"/>.</summary>
+public sealed class OutboxArchivalHealthCheckOptions
+{
+    /// <summary>Threshold past which the health check downgrades to Degraded. Default 5 min.</summary>
+    public TimeSpan DegradedAfter { get; set; } = TimeSpan.FromMinutes(5);
+
+    /// <summary>Threshold past which the health check returns Unhealthy. Default 15 min.</summary>
+    public TimeSpan UnhealthyAfter { get; set; } = TimeSpan.FromMinutes(15);
+
+    internal void Validate()
+    {
+        if (DegradedAfter <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(DegradedAfter), DegradedAfter,
+                "OutboxArchivalHealthCheckOptions.DegradedAfter must be positive.");
+        }
+        if (UnhealthyAfter <= DegradedAfter)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(UnhealthyAfter), UnhealthyAfter,
+                $"OutboxArchivalHealthCheckOptions.UnhealthyAfter ({UnhealthyAfter}) must be greater than DegradedAfter ({DegradedAfter}).");
+        }
+    }
+}

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Archival/OutboxArchivalHostedService.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Archival/OutboxArchivalHostedService.cs
@@ -19,6 +19,8 @@ public sealed class OutboxArchivalHostedService : BackgroundService
     private readonly IDistributedLock distributedLock;
     private readonly IOutboxArchiver archiver;
     private readonly ILogger<OutboxArchivalHostedService>? logger;
+    // v6.5.14: optional liveness mirror consumed by OutboxArchivalHealthCheck.
+    private readonly OutboxArchivalState? state;
 
     /// <summary>Initializes a new archival worker.</summary>
     /// <param name="options">Archival configuration.</param>
@@ -40,12 +42,25 @@ public sealed class OutboxArchivalHostedService : BackgroundService
         IDistributedLock distributedLock,
         ILogger<OutboxArchivalHostedService>? logger,
         IOutboxArchiver? archiver)
+        : this(options, scopeFactory, distributedLock, logger, archiver, state: null)
+    {
+    }
+
+    /// <summary>v6.5.14 6-arg overload that wires the optional <see cref="OutboxArchivalState"/> mirror.</summary>
+    public OutboxArchivalHostedService(
+        OutboxArchivalOptions options,
+        IServiceScopeFactory scopeFactory,
+        IDistributedLock distributedLock,
+        ILogger<OutboxArchivalHostedService>? logger,
+        IOutboxArchiver? archiver,
+        OutboxArchivalState? state)
     {
         this.options = options ?? throw new ArgumentNullException(nameof(options));
         this.scopeFactory = scopeFactory ?? throw new ArgumentNullException(nameof(scopeFactory));
         this.distributedLock = distributedLock ?? throw new ArgumentNullException(nameof(distributedLock));
         this.archiver = archiver ?? new DeleteOutboxArchiver();
         this.logger = logger;
+        this.state = state;
     }
 
     /// <summary>
@@ -79,6 +94,10 @@ public sealed class OutboxArchivalHostedService : BackgroundService
             logger?.LogInformation(
                 "Outbox archival processed {Count} rows older than {Cutoff:O}.", archived, cutoff);
         }
+        // v6.5.14: record liveness regardless of whether rows were archived. A successful
+        // call with archived == 0 still proves the worker reached the backend - exactly
+        // what the OutboxArchivalHealthCheck needs to distinguish "stuck" from "idle".
+        state?.RecordSuccessfulBatch(DateTime.UtcNow);
 
         return archived;
     }

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Archival/OutboxArchivalState.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Archival/OutboxArchivalState.cs
@@ -1,0 +1,34 @@
+namespace Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Archival;
+
+/// <summary>
+/// v6.5.14 shared singleton that records when the
+/// <see cref="OutboxArchivalHostedService"/> last completed a batch successfully. The
+/// <see cref="OutboxArchivalHealthCheck"/> consults this state to decide whether the
+/// background worker is alive (recent) or stuck (stale). The hosted service is the only
+/// writer; the health check is the only reader.
+/// </summary>
+public sealed class OutboxArchivalState
+{
+    private long lastSuccessfulBatchUtcTicks;
+    private int totalBatches;
+
+    /// <summary>UTC timestamp of the most recent successful <c>ArchiveBatchAsync</c> call, or null if none yet.</summary>
+    public DateTime? LastSuccessfulBatchUtc
+    {
+        get
+        {
+            var ticks = Interlocked.Read(ref lastSuccessfulBatchUtcTicks);
+            return ticks == 0 ? null : new DateTime(ticks, DateTimeKind.Utc);
+        }
+    }
+
+    /// <summary>Number of successful batches observed since service start. Monotonic.</summary>
+    public int TotalBatches => Interlocked.CompareExchange(ref totalBatches, 0, 0);
+
+    /// <summary>Called by the hosted service after each successful batch. Idempotent on the timestamp.</summary>
+    public void RecordSuccessfulBatch(DateTime utcNow)
+    {
+        Interlocked.Exchange(ref lastSuccessfulBatchUtcTicks, utcNow.Ticks);
+        Interlocked.Increment(ref totalBatches);
+    }
+}

--- a/src/Moongazing.OrionGuard.Generators/Moongazing.OrionGuard.Generators.csproj
+++ b/src/Moongazing.OrionGuard.Generators/Moongazing.OrionGuard.Generators.csproj
@@ -8,7 +8,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>CS1591</NoWarn>
     <PackageId>OrionGuard.Generators</PackageId>
-    <Version>6.5.13</Version>
+    <Version>6.5.14</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Source generator for OrionGuard. Generates [GenerateValidator] validators, [StronglyTypedId&lt;TValue&gt;] strongly-typed id types (EF Core ValueConverter, System.Text.Json JsonConverter, TypeConverter companions), and supports NativeAOT-compatible reflection-free workflows.</Description>
     <PackageTags>guard;validation;source-generator;roslyn;nativeaot;codegen;ddd;strongly-typed-id</PackageTags>

--- a/src/Moongazing.OrionGuard.Grpc/Moongazing.OrionGuard.Grpc.csproj
+++ b/src/Moongazing.OrionGuard.Grpc/Moongazing.OrionGuard.Grpc.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Grpc</PackageId>
-    <Version>6.5.13</Version>
+    <Version>6.5.14</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>gRPC integration for OrionGuard validation library. Provides server interceptor for automatic request validation in gRPC services.</Description>
     <PackageTags>guard;validation;grpc;interceptor;protobuf;microservices</PackageTags>

--- a/src/Moongazing.OrionGuard.Locks.Redis/Moongazing.OrionGuard.Locks.Redis.csproj
+++ b/src/Moongazing.OrionGuard.Locks.Redis/Moongazing.OrionGuard.Locks.Redis.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Locks.Redis</PackageId>
-    <Version>6.5.13</Version>
+    <Version>6.5.14</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Redis-backed IDistributedLock for OrionGuard.EntityFrameworkCore's outbox dispatcher. Bridges OrionGuard's IDistributedLock contract to the OrionLock.Redis backend so multi-instance outbox workers can share a Redis-coordinated lease instead of the default SkipLocked DB lock.</Description>
     <PackageTags>guard;outbox;distributed-lock;redis;orionlock;entity-framework-core;efcore</PackageTags>

--- a/src/Moongazing.OrionGuard.MediatR/Moongazing.OrionGuard.MediatR.csproj
+++ b/src/Moongazing.OrionGuard.MediatR/Moongazing.OrionGuard.MediatR.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.MediatR</PackageId>
-    <Version>6.5.13</Version>
+    <Version>6.5.14</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>MediatR integration for OrionGuard validation library. Provides ValidationBehavior pipeline behavior for automatic request validation in CQRS pipelines.</Description>
     <PackageTags>guard;validation;mediatr;cqrs;pipeline;behavior</PackageTags>

--- a/src/Moongazing.OrionGuard.OpenTelemetry/Moongazing.OrionGuard.OpenTelemetry.csproj
+++ b/src/Moongazing.OrionGuard.OpenTelemetry/Moongazing.OrionGuard.OpenTelemetry.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.OpenTelemetry</PackageId>
-    <Version>6.5.13</Version>
+    <Version>6.5.14</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>OpenTelemetry integration for OrionGuard validation library. Provides validation metrics (success/failure rates, latency) and distributed tracing spans.</Description>
     <PackageTags>guard;validation;opentelemetry;metrics;tracing;observability</PackageTags>

--- a/src/Moongazing.OrionGuard.Outbox.Dashboard/Moongazing.OrionGuard.Outbox.Dashboard.csproj
+++ b/src/Moongazing.OrionGuard.Outbox.Dashboard/Moongazing.OrionGuard.Outbox.Dashboard.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904;AD0001</NoWarn>
     <PackageId>OrionGuard.Outbox.Dashboard</PackageId>
-    <Version>6.5.13</Version>
+    <Version>6.5.14</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Outbox operator dashboard for OrionGuard. Maps an authorized listing of failed / poisoned messages from the consumer's DbContext to an ASP.NET Core endpoint group, plus POST /{id}/replay and POST /{id}/discard mutation endpoints (v6.5.5) with an optional OnMutation audit hook.</Description>
     <PackageTags>guard;outbox;dashboard;aspnetcore;poisoned-messages;dead-letter</PackageTags>

--- a/src/Moongazing.OrionGuard.Outbox.PostgresNotify/Moongazing.OrionGuard.Outbox.PostgresNotify.csproj
+++ b/src/Moongazing.OrionGuard.Outbox.PostgresNotify/Moongazing.OrionGuard.Outbox.PostgresNotify.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Outbox.PostgresNotify</PackageId>
-    <Version>6.5.13</Version>
+    <Version>6.5.14</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Postgres LISTEN/NOTIFY backed IOutboxWakeSignal for OrionGuard.EntityFrameworkCore. Replaces the v6.5.1 polling fallback with an event-driven wake on every committed outbox row when the consumer's database is PostgreSQL. Falls back to polling cleanly when the LISTEN connection is unreachable.</Description>
     <PackageTags>guard;outbox;postgres;npgsql;listen;notify;push;dispatch;entity-framework-core;efcore</PackageTags>

--- a/src/Moongazing.OrionGuard.Outbox.SqlServerBroker/Moongazing.OrionGuard.Outbox.SqlServerBroker.csproj
+++ b/src/Moongazing.OrionGuard.Outbox.SqlServerBroker/Moongazing.OrionGuard.Outbox.SqlServerBroker.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Outbox.SqlServerBroker</PackageId>
-    <Version>6.5.13</Version>
+    <Version>6.5.14</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>SQL Server Service Broker backed IOutboxWakeSignal for OrionGuard.EntityFrameworkCore. Sibling to OrionGuard.Outbox.PostgresNotify (v6.5.2) for the SQL Server provider. Replaces the v6.5.1 polling-only fallback with an event-driven wake on every committed outbox row via Service Broker's queueing primitives.</Description>
     <PackageTags>guard;outbox;sqlserver;service-broker;push;dispatch;entity-framework-core;efcore</PackageTags>

--- a/src/Moongazing.OrionGuard.SignalR/Moongazing.OrionGuard.SignalR.csproj
+++ b/src/Moongazing.OrionGuard.SignalR/Moongazing.OrionGuard.SignalR.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.SignalR</PackageId>
-    <Version>6.5.13</Version>
+    <Version>6.5.14</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>SignalR integration for OrionGuard validation library. Provides Hub filter for automatic method parameter validation.</Description>
     <PackageTags>guard;validation;signalr;realtime;hub;filter</PackageTags>

--- a/src/Moongazing.OrionGuard.Swagger/Moongazing.OrionGuard.Swagger.csproj
+++ b/src/Moongazing.OrionGuard.Swagger/Moongazing.OrionGuard.Swagger.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Swagger</PackageId>
-    <Version>6.5.13</Version>
+    <Version>6.5.14</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Swagger/OpenAPI integration for OrionGuard. Auto-generates OpenAPI constraints from OrionGuard validation attributes.</Description>
     <PackageTags>guard;validation;swagger;openapi;swashbuckle</PackageTags>

--- a/src/Moongazing.OrionGuard.Testing/Moongazing.OrionGuard.Testing.csproj
+++ b/src/Moongazing.OrionGuard.Testing/Moongazing.OrionGuard.Testing.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Testing</PackageId>
-    <Version>6.5.13</Version>
+    <Version>6.5.14</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Testing helpers for OrionGuard. Provides DomainEventCapture and InMemoryDomainEventDispatcher with framework-agnostic assertions (no xUnit / NUnit / FluentAssertions dependency). Works with any test runner.</Description>
     <PackageTags>guard;validation;testing;ddd;domain-events;assertions;test-helpers</PackageTags>

--- a/src/Moongazing.OrionGuard/Moongazing.OrionGuard.csproj
+++ b/src/Moongazing.OrionGuard/Moongazing.OrionGuard.csproj
@@ -16,7 +16,7 @@
 		<OutputType>Library</OutputType>
 
 		<PackageId>OrionGuard</PackageId>
-		<Version>6.5.13</Version>
+		<Version>6.5.14</Version>
 		<Authors>Tunahan Ali Ozturk</Authors>
 		<Company>Tunahan Ali Ozturk</Company>
 		<GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/Archival/OutboxArchivalHealthCheckTests.cs
+++ b/tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/Archival/OutboxArchivalHealthCheckTests.cs
@@ -1,0 +1,111 @@
+namespace Moongazing.OrionGuard.EntityFrameworkCore.Tests.Outbox.Archival;
+
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Archival;
+using Xunit;
+
+public sealed class OutboxArchivalHealthCheckTests
+{
+    private sealed class FixedClock : TimeProvider
+    {
+        public DateTimeOffset Now { get; set; }
+        public override DateTimeOffset GetUtcNow() => Now;
+    }
+
+    private static OutboxArchivalHealthCheck NewSut(
+        OutboxArchivalState state, DateTime nowUtc,
+        TimeSpan? degraded = null, TimeSpan? unhealthy = null)
+    {
+        var clock = new FixedClock { Now = new DateTimeOffset(nowUtc, TimeSpan.Zero) };
+        return new OutboxArchivalHealthCheck(
+            state,
+            new OutboxArchivalHealthCheckOptions
+            {
+                DegradedAfter = degraded ?? TimeSpan.FromMinutes(5),
+                UnhealthyAfter = unhealthy ?? TimeSpan.FromMinutes(15),
+            },
+            clock);
+    }
+
+    [Fact]
+    public async Task Reports_Degraded_when_no_batch_has_completed_yet()
+    {
+        var sut = NewSut(new OutboxArchivalState(), nowUtc: DateTime.UtcNow);
+
+        var result = await sut.CheckHealthAsync(new HealthCheckContext());
+
+        Assert.Equal(HealthStatus.Degraded, result.Status);
+        Assert.Equal("never", result.Data["lastSuccessfulBatchUtc"]);
+    }
+
+    [Fact]
+    public async Task Reports_Healthy_when_last_batch_is_within_DegradedAfter()
+    {
+        var state = new OutboxArchivalState();
+        var now = new DateTime(2026, 6, 11, 12, 0, 0, DateTimeKind.Utc);
+        state.RecordSuccessfulBatch(now.AddSeconds(-30));
+        var sut = NewSut(state, nowUtc: now);
+
+        var result = await sut.CheckHealthAsync(new HealthCheckContext());
+
+        Assert.Equal(HealthStatus.Healthy, result.Status);
+    }
+
+    [Fact]
+    public async Task Reports_Degraded_when_last_batch_is_between_thresholds()
+    {
+        var state = new OutboxArchivalState();
+        var now = new DateTime(2026, 6, 11, 12, 0, 0, DateTimeKind.Utc);
+        state.RecordSuccessfulBatch(now.AddMinutes(-8));
+        var sut = NewSut(state, nowUtc: now);
+
+        var result = await sut.CheckHealthAsync(new HealthCheckContext());
+
+        Assert.Equal(HealthStatus.Degraded, result.Status);
+    }
+
+    [Fact]
+    public async Task Reports_Unhealthy_when_last_batch_is_older_than_UnhealthyAfter()
+    {
+        var state = new OutboxArchivalState();
+        var now = new DateTime(2026, 6, 11, 12, 0, 0, DateTimeKind.Utc);
+        state.RecordSuccessfulBatch(now.AddMinutes(-20));
+        var sut = NewSut(state, nowUtc: now);
+
+        var result = await sut.CheckHealthAsync(new HealthCheckContext());
+
+        Assert.Equal(HealthStatus.Unhealthy, result.Status);
+    }
+
+    [Fact]
+    public void Options_Validate_rejects_UnhealthyAfter_le_DegradedAfter()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            new OutboxArchivalHealthCheck(
+                new OutboxArchivalState(),
+                new OutboxArchivalHealthCheckOptions
+                {
+                    DegradedAfter = TimeSpan.FromMinutes(10),
+                    UnhealthyAfter = TimeSpan.FromMinutes(5),
+                }));
+    }
+
+    [Fact]
+    public void State_RecordSuccessfulBatch_increments_total_and_updates_timestamp()
+    {
+        var state = new OutboxArchivalState();
+        var t1 = new DateTime(2026, 6, 11, 12, 0, 0, DateTimeKind.Utc);
+        var t2 = t1.AddMinutes(1);
+
+        Assert.Null(state.LastSuccessfulBatchUtc);
+        Assert.Equal(0, state.TotalBatches);
+
+        state.RecordSuccessfulBatch(t1);
+        Assert.Equal(t1, state.LastSuccessfulBatchUtc);
+        Assert.Equal(1, state.TotalBatches);
+
+        state.RecordSuccessfulBatch(t2);
+        Assert.Equal(t2, state.LastSuccessfulBatchUtc);
+        Assert.Equal(2, state.TotalBatches);
+    }
+}


### PR DESCRIPTION
## OrionGuard v6.5.14 - OutboxArchivalHealthCheck

### Shipped

- `OutboxArchivalState` shared liveness mirror.
- `OutboxArchivalHealthCheck` (`IHealthCheck`) with `DegradedAfter` (5 min default) and `UnhealthyAfter` (15 min default).
- 6-arg hosted-service ctor (state mirror); 4/5-arg ctors preserved.
- 6 facts.

### Migration

Source-compatible.

```csharp
services.AddSingleton<OutboxArchivalState>();
services.AddHealthChecks()
    .AddCheck<OutboxArchivalHealthCheck>("orionguard-outbox-archival");
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added health monitoring for outbox archival service liveness with configurable thresholds to detect service degradation and failures.

* **Tests**
  * Added comprehensive test coverage for health check status transitions and configuration validation.

* **Chores**
  * Updated all packages to version 6.5.14.
  * Added dependency on health checks abstractions library.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->