### PR TITLE
Release v6.5.15: OutboxDashboardOptions.SecurityHeaders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to OrionGuard will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.5.15] - 2026-06-11
+
+### Added
+
+#### `OutboxDashboardOptions.SecurityHeaders`
+
+Every dashboard response now carries production-friendly hardening headers via an endpoint filter on the route group.
+
+Defaults:
+- `X-Frame-Options: DENY` (clickjacking guard)
+- `X-Content-Type-Options: nosniff` (MIME-sniff guard)
+- `Referrer-Policy: no-referrer`
+- `Cache-Control: no-store`
+
+The filter writes headers BEFORE the response body so they apply even when the endpoint short-circuits via `Results.NotFound()`.
+
+Consumers can set `SecurityHeaders` to an empty dictionary to disable defaults, or assign a custom dictionary to replace them entirely (no merge).
+
+### Tests
+
+3 new facts.
+
+### Migration from v6.5.14
+
+Source-compatible. Existing deployments inherit the defaults transparently.
+
 ## [6.5.14] - 2026-06-11
 
 ### Added

--- a/src/Moongazing.OrionGuard.AspNetCore/Moongazing.OrionGuard.AspNetCore.csproj
+++ b/src/Moongazing.OrionGuard.AspNetCore/Moongazing.OrionGuard.AspNetCore.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.AspNetCore</PackageId>
-    <Version>6.5.14</Version>
+    <Version>6.5.15</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>ASP.NET Core integration for OrionGuard validation library. Provides middleware, Minimal API endpoint filters, MVC action filters, and RFC 9457 ProblemDetails support.</Description>
     <PackageTags>guard;validation;aspnetcore;middleware;minimal-api;problemdetails</PackageTags>

--- a/src/Moongazing.OrionGuard.Blazor/Moongazing.OrionGuard.Blazor.csproj
+++ b/src/Moongazing.OrionGuard.Blazor/Moongazing.OrionGuard.Blazor.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Blazor</PackageId>
-    <Version>6.5.14</Version>
+    <Version>6.5.15</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Blazor integration for OrionGuard validation library. Provides EditForm validation, custom validation components, and data annotations interop.</Description>
     <PackageTags>guard;validation;blazor;editform;component;wasm;server</PackageTags>

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Moongazing.OrionGuard.EntityFrameworkCore.csproj
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Moongazing.OrionGuard.EntityFrameworkCore.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.EntityFrameworkCore</PackageId>
-    <Version>6.5.14</Version>
+    <Version>6.5.15</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>EF Core integration for OrionGuard. Provides a SaveChanges interceptor that dispatches domain events from AggregateRoot&lt;TId&gt; instances after commit (Inline mode) or via a transactional outbox (Outbox mode) consumed by a hosted background worker. Includes W3C trace context propagation across the outbox boundary.</Description>
     <PackageTags>guard;validation;ddd;domain-events;outbox;entity-framework-core;efcore;aggregate-root</PackageTags>

--- a/src/Moongazing.OrionGuard.Generators/Moongazing.OrionGuard.Generators.csproj
+++ b/src/Moongazing.OrionGuard.Generators/Moongazing.OrionGuard.Generators.csproj
@@ -8,7 +8,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>CS1591</NoWarn>
     <PackageId>OrionGuard.Generators</PackageId>
-    <Version>6.5.14</Version>
+    <Version>6.5.15</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Source generator for OrionGuard. Generates [GenerateValidator] validators, [StronglyTypedId&lt;TValue&gt;] strongly-typed id types (EF Core ValueConverter, System.Text.Json JsonConverter, TypeConverter companions), and supports NativeAOT-compatible reflection-free workflows.</Description>
     <PackageTags>guard;validation;source-generator;roslyn;nativeaot;codegen;ddd;strongly-typed-id</PackageTags>

--- a/src/Moongazing.OrionGuard.Grpc/Moongazing.OrionGuard.Grpc.csproj
+++ b/src/Moongazing.OrionGuard.Grpc/Moongazing.OrionGuard.Grpc.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Grpc</PackageId>
-    <Version>6.5.14</Version>
+    <Version>6.5.15</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>gRPC integration for OrionGuard validation library. Provides server interceptor for automatic request validation in gRPC services.</Description>
     <PackageTags>guard;validation;grpc;interceptor;protobuf;microservices</PackageTags>

--- a/src/Moongazing.OrionGuard.Locks.Redis/Moongazing.OrionGuard.Locks.Redis.csproj
+++ b/src/Moongazing.OrionGuard.Locks.Redis/Moongazing.OrionGuard.Locks.Redis.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Locks.Redis</PackageId>
-    <Version>6.5.14</Version>
+    <Version>6.5.15</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Redis-backed IDistributedLock for OrionGuard.EntityFrameworkCore's outbox dispatcher. Bridges OrionGuard's IDistributedLock contract to the OrionLock.Redis backend so multi-instance outbox workers can share a Redis-coordinated lease instead of the default SkipLocked DB lock.</Description>
     <PackageTags>guard;outbox;distributed-lock;redis;orionlock;entity-framework-core;efcore</PackageTags>

--- a/src/Moongazing.OrionGuard.MediatR/Moongazing.OrionGuard.MediatR.csproj
+++ b/src/Moongazing.OrionGuard.MediatR/Moongazing.OrionGuard.MediatR.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.MediatR</PackageId>
-    <Version>6.5.14</Version>
+    <Version>6.5.15</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>MediatR integration for OrionGuard validation library. Provides ValidationBehavior pipeline behavior for automatic request validation in CQRS pipelines.</Description>
     <PackageTags>guard;validation;mediatr;cqrs;pipeline;behavior</PackageTags>

--- a/src/Moongazing.OrionGuard.OpenTelemetry/Moongazing.OrionGuard.OpenTelemetry.csproj
+++ b/src/Moongazing.OrionGuard.OpenTelemetry/Moongazing.OrionGuard.OpenTelemetry.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.OpenTelemetry</PackageId>
-    <Version>6.5.14</Version>
+    <Version>6.5.15</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>OpenTelemetry integration for OrionGuard validation library. Provides validation metrics (success/failure rates, latency) and distributed tracing spans.</Description>
     <PackageTags>guard;validation;opentelemetry;metrics;tracing;observability</PackageTags>

--- a/src/Moongazing.OrionGuard.Outbox.Dashboard/Moongazing.OrionGuard.Outbox.Dashboard.csproj
+++ b/src/Moongazing.OrionGuard.Outbox.Dashboard/Moongazing.OrionGuard.Outbox.Dashboard.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904;AD0001</NoWarn>
     <PackageId>OrionGuard.Outbox.Dashboard</PackageId>
-    <Version>6.5.14</Version>
+    <Version>6.5.15</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Outbox operator dashboard for OrionGuard. Maps an authorized listing of failed / poisoned messages from the consumer's DbContext to an ASP.NET Core endpoint group, plus POST /{id}/replay and POST /{id}/discard mutation endpoints (v6.5.5) with an optional OnMutation audit hook.</Description>
     <PackageTags>guard;outbox;dashboard;aspnetcore;poisoned-messages;dead-letter</PackageTags>

--- a/src/Moongazing.OrionGuard.Outbox.Dashboard/OutboxDashboardEndpointRouteBuilderExtensions.cs
+++ b/src/Moongazing.OrionGuard.Outbox.Dashboard/OutboxDashboardEndpointRouteBuilderExtensions.cs
@@ -38,6 +38,24 @@ public static class OutboxDashboardEndpointRouteBuilderExtensions
 
         var group = endpoints.MapGroup(options.RoutePrefix.TrimEnd('/'));
 
+        // v6.5.15 security headers: stamped via AddEndpointFilter so the dashboard's HTML
+        // / JSON responses carry hardening defaults without the consumer having to wire
+        // a separate middleware. The filter runs per-request and writes headers BEFORE
+        // the response body so they apply even when the endpoint short-circuits via
+        // Results.NotFound() or similar.
+        if (options.SecurityHeaders is { Count: > 0 })
+        {
+            var headers = options.SecurityHeaders;
+            group.AddEndpointFilter(async (ctx, next) =>
+            {
+                foreach (var (k, v) in headers)
+                {
+                    ctx.HttpContext.Response.Headers[k] = v;
+                }
+                return await next(ctx);
+            });
+        }
+
         // Authorization wiring:
         //   AllowAnonymous   -> mark anonymous (NOT recommended in production).
         //   Named policy     -> evaluate that policy explicitly.

--- a/src/Moongazing.OrionGuard.Outbox.Dashboard/OutboxDashboardOptions.cs
+++ b/src/Moongazing.OrionGuard.Outbox.Dashboard/OutboxDashboardOptions.cs
@@ -80,6 +80,21 @@ public sealed class OutboxDashboardOptions
     /// most operators want to triage the longest-failing rows first.
     /// </summary>
     public OutboxFailedListingSort DefaultSort { get; set; } = OutboxFailedListingSort.OldestFirst;
+
+    /// <summary>
+    /// v6.5.15 security headers applied to every dashboard response. The defaults are
+    /// production-friendly: X-Frame-Options=DENY (clickjacking guard),
+    /// X-Content-Type-Options=nosniff (MIME-sniff guard), Referrer-Policy=no-referrer,
+    /// Cache-Control=no-store. Set <see cref="SecurityHeaders"/> to an empty dictionary
+    /// to disable all defaults; assign your own dictionary to merge custom headers.
+    /// </summary>
+    public IDictionary<string, string> SecurityHeaders { get; set; } = new Dictionary<string, string>(StringComparer.Ordinal)
+    {
+        ["X-Frame-Options"] = "DENY",
+        ["X-Content-Type-Options"] = "nosniff",
+        ["Referrer-Policy"] = "no-referrer",
+        ["Cache-Control"] = "no-store",
+    };
 }
 
 /// <summary>

--- a/src/Moongazing.OrionGuard.Outbox.Dashboard/OutboxDashboardSecurityHeadersMiddleware.cs
+++ b/src/Moongazing.OrionGuard.Outbox.Dashboard/OutboxDashboardSecurityHeadersMiddleware.cs
@@ -1,0 +1,51 @@
+namespace Moongazing.OrionGuard.Outbox.Dashboard;
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+
+/// <summary>
+/// v6.5.15 IApplicationBuilder extension that registers a middleware writing the
+/// configured security headers on EVERY response for paths under the dashboard's route
+/// prefix. The endpoint filter shipped with <see cref="OutboxDashboardEndpointRouteBuilderExtensions.MapOutboxDashboard{TDbContext}"/>
+/// only fires for responses the dashboard handler produces; this middleware is the path
+/// for consumers who want the hardening defaults to also stamp 401 / 403 / 404 responses
+/// short-circuited by authentication / authorization before the endpoint handler runs.
+/// </summary>
+public static class OutboxDashboardSecurityHeadersMiddleware
+{
+    /// <summary>
+    /// Wire the security-headers middleware in the consumer's pipeline. Place it BEFORE
+    /// <c>UseAuthentication()</c> / <c>UseAuthorization()</c> so the headers also land on
+    /// auth-short-circuited responses.
+    /// </summary>
+    public static IApplicationBuilder UseOutboxDashboardSecurityHeaders(
+        this IApplicationBuilder app, string routePrefix, IDictionary<string, string> headers)
+    {
+        ArgumentNullException.ThrowIfNull(app);
+        ArgumentException.ThrowIfNullOrEmpty(routePrefix);
+        ArgumentNullException.ThrowIfNull(headers);
+
+        var prefix = routePrefix.TrimEnd('/');
+        // Snapshot the headers so a later mutation on the caller's dictionary does not
+        // affect the middleware's behaviour after registration.
+        var snapshot = new Dictionary<string, string>(headers, StringComparer.Ordinal);
+
+        return app.Use(async (HttpContext ctx, RequestDelegate next) =>
+        {
+            if (ctx.Request.Path.StartsWithSegments(prefix))
+            {
+                ctx.Response.OnStarting(() =>
+                {
+                    foreach (var (k, v) in snapshot)
+                    {
+                        ctx.Response.Headers[k] = v;
+                    }
+                    return Task.CompletedTask;
+                });
+            }
+            await next(ctx).ConfigureAwait(false);
+        });
+    }
+}

--- a/src/Moongazing.OrionGuard.Outbox.PostgresNotify/Moongazing.OrionGuard.Outbox.PostgresNotify.csproj
+++ b/src/Moongazing.OrionGuard.Outbox.PostgresNotify/Moongazing.OrionGuard.Outbox.PostgresNotify.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Outbox.PostgresNotify</PackageId>
-    <Version>6.5.14</Version>
+    <Version>6.5.15</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Postgres LISTEN/NOTIFY backed IOutboxWakeSignal for OrionGuard.EntityFrameworkCore. Replaces the v6.5.1 polling fallback with an event-driven wake on every committed outbox row when the consumer's database is PostgreSQL. Falls back to polling cleanly when the LISTEN connection is unreachable.</Description>
     <PackageTags>guard;outbox;postgres;npgsql;listen;notify;push;dispatch;entity-framework-core;efcore</PackageTags>

--- a/src/Moongazing.OrionGuard.Outbox.SqlServerBroker/Moongazing.OrionGuard.Outbox.SqlServerBroker.csproj
+++ b/src/Moongazing.OrionGuard.Outbox.SqlServerBroker/Moongazing.OrionGuard.Outbox.SqlServerBroker.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Outbox.SqlServerBroker</PackageId>
-    <Version>6.5.14</Version>
+    <Version>6.5.15</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>SQL Server Service Broker backed IOutboxWakeSignal for OrionGuard.EntityFrameworkCore. Sibling to OrionGuard.Outbox.PostgresNotify (v6.5.2) for the SQL Server provider. Replaces the v6.5.1 polling-only fallback with an event-driven wake on every committed outbox row via Service Broker's queueing primitives.</Description>
     <PackageTags>guard;outbox;sqlserver;service-broker;push;dispatch;entity-framework-core;efcore</PackageTags>

--- a/src/Moongazing.OrionGuard.SignalR/Moongazing.OrionGuard.SignalR.csproj
+++ b/src/Moongazing.OrionGuard.SignalR/Moongazing.OrionGuard.SignalR.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.SignalR</PackageId>
-    <Version>6.5.14</Version>
+    <Version>6.5.15</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>SignalR integration for OrionGuard validation library. Provides Hub filter for automatic method parameter validation.</Description>
     <PackageTags>guard;validation;signalr;realtime;hub;filter</PackageTags>

--- a/src/Moongazing.OrionGuard.Swagger/Moongazing.OrionGuard.Swagger.csproj
+++ b/src/Moongazing.OrionGuard.Swagger/Moongazing.OrionGuard.Swagger.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Swagger</PackageId>
-    <Version>6.5.14</Version>
+    <Version>6.5.15</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Swagger/OpenAPI integration for OrionGuard. Auto-generates OpenAPI constraints from OrionGuard validation attributes.</Description>
     <PackageTags>guard;validation;swagger;openapi;swashbuckle</PackageTags>

--- a/src/Moongazing.OrionGuard.Testing/Moongazing.OrionGuard.Testing.csproj
+++ b/src/Moongazing.OrionGuard.Testing/Moongazing.OrionGuard.Testing.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Testing</PackageId>
-    <Version>6.5.14</Version>
+    <Version>6.5.15</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Testing helpers for OrionGuard. Provides DomainEventCapture and InMemoryDomainEventDispatcher with framework-agnostic assertions (no xUnit / NUnit / FluentAssertions dependency). Works with any test runner.</Description>
     <PackageTags>guard;validation;testing;ddd;domain-events;assertions;test-helpers</PackageTags>

--- a/src/Moongazing.OrionGuard/Moongazing.OrionGuard.csproj
+++ b/src/Moongazing.OrionGuard/Moongazing.OrionGuard.csproj
@@ -16,7 +16,7 @@
 		<OutputType>Library</OutputType>
 
 		<PackageId>OrionGuard</PackageId>
-		<Version>6.5.14</Version>
+		<Version>6.5.15</Version>
 		<Authors>Tunahan Ali Ozturk</Authors>
 		<Company>Tunahan Ali Ozturk</Company>
 		<GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/tests/Moongazing.OrionGuard.Outbox.Dashboard.Tests/OutboxDashboardSecurityHeadersTests.cs
+++ b/tests/Moongazing.OrionGuard.Outbox.Dashboard.Tests/OutboxDashboardSecurityHeadersTests.cs
@@ -1,0 +1,90 @@
+namespace Moongazing.OrionGuard.Outbox.Dashboard.Tests;
+
+using System.Net.Http;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Moongazing.OrionGuard.Outbox.Dashboard;
+
+public sealed class OutboxDashboardSecurityHeadersTests
+{
+    private sealed class SecDbContext : DbContext
+    {
+        public SecDbContext(DbContextOptions<SecDbContext> options) : base(options) { }
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Moongazing.OrionGuard.EntityFrameworkCore.Outbox.OutboxMessage>(b =>
+            {
+                b.ToTable("OutboxMessages");
+                b.HasKey(x => x.Id);
+            });
+        }
+    }
+
+    private static async Task<HttpResponseMessage> RequestAsync(
+        Action<OutboxDashboardOptions>? configure = null)
+    {
+        var dbName = "sec-tests-" + Guid.NewGuid().ToString("N");
+        var inMemoryRoot = new Microsoft.EntityFrameworkCore.Storage.InMemoryDatabaseRoot();
+        var host = await new HostBuilder()
+            .ConfigureWebHost(builder =>
+            {
+                builder.UseTestServer();
+                builder.ConfigureServices(s =>
+                {
+                    s.AddRouting();
+                    s.AddDbContext<SecDbContext>(opts => opts
+                        .UseInMemoryDatabase(dbName, inMemoryRoot)
+                        .ConfigureWarnings(w => w.Ignore(Microsoft.EntityFrameworkCore.Diagnostics.CoreEventId.ManyServiceProvidersCreatedWarning)));
+                });
+                builder.Configure(app =>
+                {
+                    app.UseRouting();
+                    app.UseEndpoints(e => e.MapOutboxDashboard<SecDbContext>(o =>
+                    {
+                        o.AllowAnonymous = true;
+                        configure?.Invoke(o);
+                    }));
+                });
+            })
+            .StartAsync();
+        var client = host.GetTestClient();
+        return await client.GetAsync("/_orion/outbox/failed");
+    }
+
+    [Fact]
+    public async Task Failed_endpoint_response_carries_default_security_headers()
+    {
+        var response = await RequestAsync();
+
+        Assert.Equal("DENY", response.Headers.GetValues("X-Frame-Options").Single());
+        Assert.Equal("nosniff", response.Headers.GetValues("X-Content-Type-Options").Single());
+        Assert.Equal("no-referrer", response.Headers.GetValues("Referrer-Policy").Single());
+    }
+
+    [Fact]
+    public async Task SecurityHeaders_can_be_replaced_with_custom_set()
+    {
+        var response = await RequestAsync(o => o.SecurityHeaders = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["X-Custom"] = "ok",
+        });
+
+        Assert.Equal("ok", response.Headers.GetValues("X-Custom").Single());
+        Assert.False(response.Headers.Contains("X-Frame-Options"),
+            "Custom SecurityHeaders dictionary should fully replace the defaults, not merge");
+    }
+
+    [Fact]
+    public async Task SecurityHeaders_can_be_disabled_via_empty_dictionary()
+    {
+        var response = await RequestAsync(o => o.SecurityHeaders = new Dictionary<string, string>(StringComparer.Ordinal));
+
+        Assert.False(response.Headers.Contains("X-Frame-Options"));
+        Assert.False(response.Headers.Contains("X-Content-Type-Options"));
+        Assert.False(response.Headers.Contains("Referrer-Policy"));
+    }
+}


### PR DESCRIPTION
## OrionGuard v6.5.15 - OutboxDashboardOptions.SecurityHeaders

### Shipped

- `OutboxDashboardOptions.SecurityHeaders` (IDictionary<string, string>).
- Defaults: X-Frame-Options=DENY, X-Content-Type-Options=nosniff, Referrer-Policy=no-referrer, Cache-Control=no-store.
- Endpoint filter on the route group; writes headers before response body.
- Empty dictionary disables; custom dictionary replaces (no merge).
- 3 facts.

### Migration

Source-compatible.
