### PR TITLE
Release v6.5.16: orionguard.outbox.dispatcher.queue_lag histogram

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to OrionGuard will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.5.16] - 2026-06-11
+
+### Added
+
+#### `orionguard.outbox.dispatcher.queue_lag` histogram
+
+`Histogram<double>` exposed via the new `Moongazing.OrionGuard.Outbox.Dispatcher` Meter. Records per-row dispatch lag (`OccurredOnUtc -> ProcessedOnUtc`) on the success path so operators graph p50/p99 and spot dispatcher slowdown BEFORE rows pile up beyond the steady-state dispatched-count rate.
+
+- Recorded in `OutboxDispatcherHostedService` immediately after `dispatcher.DispatchAsync` succeeds.
+- Clock-skew negative deltas are clamped to 0 so they do not pull p50 down.
+- Public `OutboxDispatcherDiagnostics.RecordQueueLag(double)` so consumer-owned dispatchers can opt in.
+- Dead-letter paths do NOT emit; that latency is a separate operational signal.
+
+### Tests
+
+2 new facts.
+
+### Migration from v6.5.15
+
+Source-compatible.
+
 ## [6.5.15] - 2026-06-11
 
 ### Added

--- a/src/Moongazing.OrionGuard.AspNetCore/Moongazing.OrionGuard.AspNetCore.csproj
+++ b/src/Moongazing.OrionGuard.AspNetCore/Moongazing.OrionGuard.AspNetCore.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.AspNetCore</PackageId>
-    <Version>6.5.15</Version>
+    <Version>6.5.16</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>ASP.NET Core integration for OrionGuard validation library. Provides middleware, Minimal API endpoint filters, MVC action filters, and RFC 9457 ProblemDetails support.</Description>
     <PackageTags>guard;validation;aspnetcore;middleware;minimal-api;problemdetails</PackageTags>

--- a/src/Moongazing.OrionGuard.Blazor/Moongazing.OrionGuard.Blazor.csproj
+++ b/src/Moongazing.OrionGuard.Blazor/Moongazing.OrionGuard.Blazor.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Blazor</PackageId>
-    <Version>6.5.15</Version>
+    <Version>6.5.16</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Blazor integration for OrionGuard validation library. Provides EditForm validation, custom validation components, and data annotations interop.</Description>
     <PackageTags>guard;validation;blazor;editform;component;wasm;server</PackageTags>

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Moongazing.OrionGuard.EntityFrameworkCore.csproj
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Moongazing.OrionGuard.EntityFrameworkCore.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.EntityFrameworkCore</PackageId>
-    <Version>6.5.15</Version>
+    <Version>6.5.16</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>EF Core integration for OrionGuard. Provides a SaveChanges interceptor that dispatches domain events from AggregateRoot&lt;TId&gt; instances after commit (Inline mode) or via a transactional outbox (Outbox mode) consumed by a hosted background worker. Includes W3C trace context propagation across the outbox boundary.</Description>
     <PackageTags>guard;validation;ddd;domain-events;outbox;entity-framework-core;efcore;aggregate-root</PackageTags>

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/OutboxDispatcherDiagnostics.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/OutboxDispatcherDiagnostics.cs
@@ -1,0 +1,35 @@
+namespace Moongazing.OrionGuard.EntityFrameworkCore.Outbox;
+
+using System.Diagnostics.Metrics;
+
+/// <summary>
+/// v6.5.16 OpenTelemetry instrumentation for the outbox dispatcher. Exposes
+/// <see cref="QueueLag"/> so operators can graph p99 dispatch latency
+/// (<c>OccurredOnUtc</c> -> <c>ProcessedOnUtc</c>) and spot dispatcher backpressure
+/// before the queue depth gauge moves.
+/// </summary>
+public static class OutboxDispatcherDiagnostics
+{
+    /// <summary>Meter name used by the dispatcher.</summary>
+    public const string MeterName = "Moongazing.OrionGuard.Outbox.Dispatcher";
+
+    private static readonly Meter Meter = new(MeterName, "6.5.16");
+
+    /// <summary>
+    /// Per-row dispatch lag: <c>now - OccurredOnUtc</c> at the moment the dispatcher
+    /// completes the dispatch (success OR dead-letter). Operators graph p50/p99 to spot
+    /// dispatcher slowdown before rows pile up beyond the steady-state
+    /// <c>orionguard.outbox.dispatched_count</c> rate.
+    /// </summary>
+    internal static readonly Histogram<double> QueueLag = Meter.CreateHistogram<double>(
+        "orionguard.outbox.dispatcher.queue_lag", unit: "ms",
+        description: "Per-row dispatch lag (OccurredOnUtc -> ProcessedOnUtc).");
+
+    /// <summary>
+    /// Record one row's dispatch lag in milliseconds. Negative values (capture host
+    /// clock skewed past dispatch host) are clamped to 0 so they do not pull the
+    /// histogram p50 down.
+    /// </summary>
+    public static void RecordQueueLag(double milliseconds)
+        => QueueLag.Record(System.Math.Max(0d, milliseconds));
+}

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/OutboxDispatcherDiagnostics.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/OutboxDispatcherDiagnostics.cs
@@ -17,9 +17,10 @@ public static class OutboxDispatcherDiagnostics
 
     /// <summary>
     /// Per-row dispatch lag: <c>now - OccurredOnUtc</c> at the moment the dispatcher
-    /// completes the dispatch (success OR dead-letter). Operators graph p50/p99 to spot
-    /// dispatcher slowdown before rows pile up beyond the steady-state
-    /// <c>orionguard.outbox.dispatched_count</c> rate.
+    /// successfully dispatches AND persists the row. Dead-letter paths emit their own
+    /// signals and are intentionally excluded here so the histogram tail reflects only
+    /// successful dispatch latency. Operators graph p50/p99 to spot dispatcher slowdown
+    /// before rows pile up beyond the steady-state <c>orionguard.outbox.dispatched_count</c> rate.
     /// </summary>
     internal static readonly Histogram<double> QueueLag = Meter.CreateHistogram<double>(
         "orionguard.outbox.dispatcher.queue_lag", unit: "ms",

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/OutboxDispatcherHostedService.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/OutboxDispatcherHostedService.cs
@@ -156,6 +156,10 @@ public sealed class OutboxDispatcherHostedService : BackgroundService
 
         foreach (var msg in batch)
         {
+            // v6.5.16: per-row queue lag captured during the success path and emitted
+            // after SaveChangesAsync confirms persistence (avoids double-count on
+            // re-dispatch).
+            double? pendingQueueLagMs = null;
             Activity? activity = null;
             if (!string.IsNullOrEmpty(msg.TraceParent)
                 && ActivityContext.TryParse(msg.TraceParent, msg.TraceState, out var parentContext))
@@ -219,11 +223,11 @@ public sealed class OutboxDispatcherHostedService : BackgroundService
                         var processedUtc = DateTime.UtcNow;
                         msg.ProcessedOnUtc = processedUtc;
                         msg.Error = null;
-                        // v6.5.16: record dispatch lag from OccurredOnUtc -> now. Sits on
-                        // the success path only; dead-letter paths above already recorded
-                        // their own ProcessedOnUtc and operators care about successful
-                        // dispatch latency (dead-letter latency is a separate signal).
-                        OutboxDispatcherDiagnostics.RecordQueueLag((processedUtc - msg.OccurredOnUtc).TotalMilliseconds);
+                        // v6.5.16: stash the lag so it can be recorded AFTER SaveChangesAsync
+                        // confirms the row is persisted. Recording before persistence would
+                        // double-count when SaveChanges fails and the row is re-dispatched on
+                        // the next poll.
+                        pendingQueueLagMs = (processedUtc - msg.OccurredOnUtc).TotalMilliseconds;
                     }
                 }
             }
@@ -253,6 +257,11 @@ public sealed class OutboxDispatcherHostedService : BackgroundService
             try
             {
                 await ctx.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+                if (pendingQueueLagMs is { } lag)
+                {
+                    OutboxDispatcherDiagnostics.RecordQueueLag(lag);
+                    pendingQueueLagMs = null;
+                }
             }
             catch (OperationCanceledException)
             {

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/OutboxDispatcherHostedService.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/OutboxDispatcherHostedService.cs
@@ -216,8 +216,14 @@ public sealed class OutboxDispatcherHostedService : BackgroundService
                     else
                     {
                         await dispatcher.DispatchAsync(@event, cancellationToken).ConfigureAwait(false);
-                        msg.ProcessedOnUtc = DateTime.UtcNow;
+                        var processedUtc = DateTime.UtcNow;
+                        msg.ProcessedOnUtc = processedUtc;
                         msg.Error = null;
+                        // v6.5.16: record dispatch lag from OccurredOnUtc -> now. Sits on
+                        // the success path only; dead-letter paths above already recorded
+                        // their own ProcessedOnUtc and operators care about successful
+                        // dispatch latency (dead-letter latency is a separate signal).
+                        OutboxDispatcherDiagnostics.RecordQueueLag((processedUtc - msg.OccurredOnUtc).TotalMilliseconds);
                     }
                 }
             }

--- a/src/Moongazing.OrionGuard.Generators/Moongazing.OrionGuard.Generators.csproj
+++ b/src/Moongazing.OrionGuard.Generators/Moongazing.OrionGuard.Generators.csproj
@@ -8,7 +8,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>CS1591</NoWarn>
     <PackageId>OrionGuard.Generators</PackageId>
-    <Version>6.5.15</Version>
+    <Version>6.5.16</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Source generator for OrionGuard. Generates [GenerateValidator] validators, [StronglyTypedId&lt;TValue&gt;] strongly-typed id types (EF Core ValueConverter, System.Text.Json JsonConverter, TypeConverter companions), and supports NativeAOT-compatible reflection-free workflows.</Description>
     <PackageTags>guard;validation;source-generator;roslyn;nativeaot;codegen;ddd;strongly-typed-id</PackageTags>

--- a/src/Moongazing.OrionGuard.Grpc/Moongazing.OrionGuard.Grpc.csproj
+++ b/src/Moongazing.OrionGuard.Grpc/Moongazing.OrionGuard.Grpc.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Grpc</PackageId>
-    <Version>6.5.15</Version>
+    <Version>6.5.16</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>gRPC integration for OrionGuard validation library. Provides server interceptor for automatic request validation in gRPC services.</Description>
     <PackageTags>guard;validation;grpc;interceptor;protobuf;microservices</PackageTags>

--- a/src/Moongazing.OrionGuard.Locks.Redis/Moongazing.OrionGuard.Locks.Redis.csproj
+++ b/src/Moongazing.OrionGuard.Locks.Redis/Moongazing.OrionGuard.Locks.Redis.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Locks.Redis</PackageId>
-    <Version>6.5.15</Version>
+    <Version>6.5.16</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Redis-backed IDistributedLock for OrionGuard.EntityFrameworkCore's outbox dispatcher. Bridges OrionGuard's IDistributedLock contract to the OrionLock.Redis backend so multi-instance outbox workers can share a Redis-coordinated lease instead of the default SkipLocked DB lock.</Description>
     <PackageTags>guard;outbox;distributed-lock;redis;orionlock;entity-framework-core;efcore</PackageTags>

--- a/src/Moongazing.OrionGuard.MediatR/Moongazing.OrionGuard.MediatR.csproj
+++ b/src/Moongazing.OrionGuard.MediatR/Moongazing.OrionGuard.MediatR.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.MediatR</PackageId>
-    <Version>6.5.15</Version>
+    <Version>6.5.16</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>MediatR integration for OrionGuard validation library. Provides ValidationBehavior pipeline behavior for automatic request validation in CQRS pipelines.</Description>
     <PackageTags>guard;validation;mediatr;cqrs;pipeline;behavior</PackageTags>

--- a/src/Moongazing.OrionGuard.OpenTelemetry/Moongazing.OrionGuard.OpenTelemetry.csproj
+++ b/src/Moongazing.OrionGuard.OpenTelemetry/Moongazing.OrionGuard.OpenTelemetry.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.OpenTelemetry</PackageId>
-    <Version>6.5.15</Version>
+    <Version>6.5.16</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>OpenTelemetry integration for OrionGuard validation library. Provides validation metrics (success/failure rates, latency) and distributed tracing spans.</Description>
     <PackageTags>guard;validation;opentelemetry;metrics;tracing;observability</PackageTags>

--- a/src/Moongazing.OrionGuard.Outbox.Dashboard/Moongazing.OrionGuard.Outbox.Dashboard.csproj
+++ b/src/Moongazing.OrionGuard.Outbox.Dashboard/Moongazing.OrionGuard.Outbox.Dashboard.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904;AD0001</NoWarn>
     <PackageId>OrionGuard.Outbox.Dashboard</PackageId>
-    <Version>6.5.15</Version>
+    <Version>6.5.16</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Outbox operator dashboard for OrionGuard. Maps an authorized listing of failed / poisoned messages from the consumer's DbContext to an ASP.NET Core endpoint group, plus POST /{id}/replay and POST /{id}/discard mutation endpoints (v6.5.5) with an optional OnMutation audit hook.</Description>
     <PackageTags>guard;outbox;dashboard;aspnetcore;poisoned-messages;dead-letter</PackageTags>

--- a/src/Moongazing.OrionGuard.Outbox.PostgresNotify/Moongazing.OrionGuard.Outbox.PostgresNotify.csproj
+++ b/src/Moongazing.OrionGuard.Outbox.PostgresNotify/Moongazing.OrionGuard.Outbox.PostgresNotify.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Outbox.PostgresNotify</PackageId>
-    <Version>6.5.15</Version>
+    <Version>6.5.16</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Postgres LISTEN/NOTIFY backed IOutboxWakeSignal for OrionGuard.EntityFrameworkCore. Replaces the v6.5.1 polling fallback with an event-driven wake on every committed outbox row when the consumer's database is PostgreSQL. Falls back to polling cleanly when the LISTEN connection is unreachable.</Description>
     <PackageTags>guard;outbox;postgres;npgsql;listen;notify;push;dispatch;entity-framework-core;efcore</PackageTags>

--- a/src/Moongazing.OrionGuard.Outbox.SqlServerBroker/Moongazing.OrionGuard.Outbox.SqlServerBroker.csproj
+++ b/src/Moongazing.OrionGuard.Outbox.SqlServerBroker/Moongazing.OrionGuard.Outbox.SqlServerBroker.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Outbox.SqlServerBroker</PackageId>
-    <Version>6.5.15</Version>
+    <Version>6.5.16</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>SQL Server Service Broker backed IOutboxWakeSignal for OrionGuard.EntityFrameworkCore. Sibling to OrionGuard.Outbox.PostgresNotify (v6.5.2) for the SQL Server provider. Replaces the v6.5.1 polling-only fallback with an event-driven wake on every committed outbox row via Service Broker's queueing primitives.</Description>
     <PackageTags>guard;outbox;sqlserver;service-broker;push;dispatch;entity-framework-core;efcore</PackageTags>

--- a/src/Moongazing.OrionGuard.SignalR/Moongazing.OrionGuard.SignalR.csproj
+++ b/src/Moongazing.OrionGuard.SignalR/Moongazing.OrionGuard.SignalR.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.SignalR</PackageId>
-    <Version>6.5.15</Version>
+    <Version>6.5.16</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>SignalR integration for OrionGuard validation library. Provides Hub filter for automatic method parameter validation.</Description>
     <PackageTags>guard;validation;signalr;realtime;hub;filter</PackageTags>

--- a/src/Moongazing.OrionGuard.Swagger/Moongazing.OrionGuard.Swagger.csproj
+++ b/src/Moongazing.OrionGuard.Swagger/Moongazing.OrionGuard.Swagger.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Swagger</PackageId>
-    <Version>6.5.15</Version>
+    <Version>6.5.16</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Swagger/OpenAPI integration for OrionGuard. Auto-generates OpenAPI constraints from OrionGuard validation attributes.</Description>
     <PackageTags>guard;validation;swagger;openapi;swashbuckle</PackageTags>

--- a/src/Moongazing.OrionGuard.Testing/Moongazing.OrionGuard.Testing.csproj
+++ b/src/Moongazing.OrionGuard.Testing/Moongazing.OrionGuard.Testing.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Testing</PackageId>
-    <Version>6.5.15</Version>
+    <Version>6.5.16</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Testing helpers for OrionGuard. Provides DomainEventCapture and InMemoryDomainEventDispatcher with framework-agnostic assertions (no xUnit / NUnit / FluentAssertions dependency). Works with any test runner.</Description>
     <PackageTags>guard;validation;testing;ddd;domain-events;assertions;test-helpers</PackageTags>

--- a/src/Moongazing.OrionGuard/Moongazing.OrionGuard.csproj
+++ b/src/Moongazing.OrionGuard/Moongazing.OrionGuard.csproj
@@ -16,7 +16,7 @@
 		<OutputType>Library</OutputType>
 
 		<PackageId>OrionGuard</PackageId>
-		<Version>6.5.15</Version>
+		<Version>6.5.16</Version>
 		<Authors>Tunahan Ali Ozturk</Authors>
 		<Company>Tunahan Ali Ozturk</Company>
 		<GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/OutboxDispatcherQueueLagTests.cs
+++ b/tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/OutboxDispatcherQueueLagTests.cs
@@ -1,0 +1,66 @@
+namespace Moongazing.OrionGuard.EntityFrameworkCore.Tests.Outbox;
+
+using System.Diagnostics.Metrics;
+using Moongazing.OrionGuard.EntityFrameworkCore.Outbox;
+using Xunit;
+
+public sealed class OutboxDispatcherQueueLagTests
+{
+    [Fact]
+    public void RecordQueueLag_emits_a_non_negative_sample()
+    {
+        var samples = new System.Collections.Generic.List<double>();
+        using var listener = new MeterListener();
+        listener.InstrumentPublished = (instrument, l) =>
+        {
+            if (instrument.Meter.Name == OutboxDispatcherDiagnostics.MeterName
+                && instrument.Name == "orionguard.outbox.dispatcher.queue_lag")
+            {
+                l.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<double>((_, val, _, _) =>
+        {
+            lock (samples) { samples.Add(val); }
+        });
+        listener.Start();
+
+        OutboxDispatcherDiagnostics.RecordQueueLag(125.5);
+
+        lock (samples)
+        {
+            Assert.Contains(125.5, samples);
+        }
+    }
+
+    [Fact]
+    public void RecordQueueLag_clamps_negative_values_to_zero()
+    {
+        var samples = new System.Collections.Generic.List<double>();
+        using var listener = new MeterListener();
+        listener.InstrumentPublished = (instrument, l) =>
+        {
+            if (instrument.Meter.Name == OutboxDispatcherDiagnostics.MeterName
+                && instrument.Name == "orionguard.outbox.dispatcher.queue_lag")
+            {
+                l.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<double>((_, val, _, _) =>
+        {
+            lock (samples) { samples.Add(val); }
+        });
+        listener.Start();
+
+        // Clock skew between capture host and dispatcher host would surface here. The
+        // contract is: skewed-negative -> recorded as 0 so the histogram p50 stays
+        // meaningful.
+        OutboxDispatcherDiagnostics.RecordQueueLag(-50);
+
+        lock (samples)
+        {
+            Assert.Contains(0d, samples);
+            Assert.DoesNotContain(-50d, samples);
+        }
+    }
+}


### PR DESCRIPTION
## OrionGuard v6.5.16 - `orionguard.outbox.dispatcher.queue_lag` histogram

### Shipped

- `Histogram<double>` per dispatch success.
- Clock-skew clamp via `Math.Max(0, ...)`.
- Public `RecordQueueLag` helper.
- 2 facts.

### Migration

Source-compatible.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OpenTelemetry queue-lag observability for the outbox dispatcher with a new histogram metric measuring per-row dispatch lag in milliseconds.
  * Introduced a public API hook to allow consumer-owned dispatchers to record queue lag measurements.
  * Negative lag values are automatically clamped to zero to ensure metric integrity.

* **Tests**
  * Added test coverage for queue-lag metric recording and clamping behavior.

* **Chores**
  * Bumped all packages to version 6.5.16.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->