### PR TITLE
Release v6.5.18: orionguard.outbox.dispatcher.errors counter

### DIFF
--- a/src/Moongazing.OrionGuard.AspNetCore/Moongazing.OrionGuard.AspNetCore.csproj
+++ b/src/Moongazing.OrionGuard.AspNetCore/Moongazing.OrionGuard.AspNetCore.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.AspNetCore</PackageId>
-    <Version>6.5.17</Version>
+    <Version>6.5.18</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>ASP.NET Core integration for OrionGuard validation library. Provides middleware, Minimal API endpoint filters, MVC action filters, and RFC 9457 ProblemDetails support.</Description>
     <PackageTags>guard;validation;aspnetcore;middleware;minimal-api;problemdetails</PackageTags>

--- a/src/Moongazing.OrionGuard.Blazor/Moongazing.OrionGuard.Blazor.csproj
+++ b/src/Moongazing.OrionGuard.Blazor/Moongazing.OrionGuard.Blazor.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Blazor</PackageId>
-    <Version>6.5.17</Version>
+    <Version>6.5.18</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Blazor integration for OrionGuard validation library. Provides EditForm validation, custom validation components, and data annotations interop.</Description>
     <PackageTags>guard;validation;blazor;editform;component;wasm;server</PackageTags>

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Moongazing.OrionGuard.EntityFrameworkCore.csproj
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Moongazing.OrionGuard.EntityFrameworkCore.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.EntityFrameworkCore</PackageId>
-    <Version>6.5.17</Version>
+    <Version>6.5.18</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>EF Core integration for OrionGuard. Provides a SaveChanges interceptor that dispatches domain events from AggregateRoot&lt;TId&gt; instances after commit (Inline mode) or via a transactional outbox (Outbox mode) consumed by a hosted background worker. Includes W3C trace context propagation across the outbox boundary.</Description>
     <PackageTags>guard;validation;ddd;domain-events;outbox;entity-framework-core;efcore;aggregate-root</PackageTags>

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/OutboxDispatcherDiagnostics.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/OutboxDispatcherDiagnostics.cs
@@ -47,4 +47,18 @@ public static class OutboxDispatcherDiagnostics
 
     /// <summary>Record one idle poll. Public so consumer-owned dispatchers can opt in.</summary>
     public static void RecordIdlePoll() => IdlePolls.Add(1);
+
+    /// <summary>
+    /// v6.5.18 per-row dispatch failure counter. Increments for EVERY swallowed exception
+    /// in the dispatcher's row loop (transient + terminal). Distinct from the dead-letter
+    /// path which only fires when RetryCount >= MaxRetries; this counter exposes the full
+    /// failure surface so operators see the upstream pressure that precedes a dead-letter.
+    /// </summary>
+    internal static readonly Counter<long> DispatchErrors = Meter.CreateCounter<long>(
+        "orionguard.outbox.dispatcher.errors", unit: "{errors}",
+        description: "Per-row dispatch failures swallowed by the dispatcher (transient + terminal).");
+
+    /// <summary>Record a per-row dispatch failure tagged with the exception type.</summary>
+    public static void RecordDispatchError(string exceptionType)
+        => DispatchErrors.Add(1, new System.Collections.Generic.KeyValuePair<string, object?>("exception_type", exceptionType));
 }

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/OutboxDispatcherHostedService.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/OutboxDispatcherHostedService.cs
@@ -240,6 +240,11 @@ public sealed class OutboxDispatcherHostedService : BackgroundService
             }
             catch (Exception ex)
             {
+                // v6.5.18: emit the dispatch error counter for EVERY swallowed failure
+                // (transient + terminal). Pairs with the dead-letter path (which only
+                // fires when MaxRetries is reached) so operators see the upstream
+                // pressure leading to a dead-letter.
+                OutboxDispatcherDiagnostics.RecordDispatchError(ex.GetType().Name);
                 msg.RetryCount++;
                 msg.Error = ex.ToString();
                 if (msg.RetryCount >= options.MaxRetries)

--- a/src/Moongazing.OrionGuard.Grpc/Moongazing.OrionGuard.Grpc.csproj
+++ b/src/Moongazing.OrionGuard.Grpc/Moongazing.OrionGuard.Grpc.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Grpc</PackageId>
-    <Version>6.5.17</Version>
+    <Version>6.5.18</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>gRPC integration for OrionGuard validation library. Provides server interceptor for automatic request validation in gRPC services.</Description>
     <PackageTags>guard;validation;grpc;interceptor;protobuf;microservices</PackageTags>

--- a/src/Moongazing.OrionGuard.Locks.Redis/Moongazing.OrionGuard.Locks.Redis.csproj
+++ b/src/Moongazing.OrionGuard.Locks.Redis/Moongazing.OrionGuard.Locks.Redis.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Locks.Redis</PackageId>
-    <Version>6.5.17</Version>
+    <Version>6.5.18</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Redis-backed IDistributedLock for OrionGuard.EntityFrameworkCore's outbox dispatcher. Bridges OrionGuard's IDistributedLock contract to the OrionLock.Redis backend so multi-instance outbox workers can share a Redis-coordinated lease instead of the default SkipLocked DB lock.</Description>
     <PackageTags>guard;outbox;distributed-lock;redis;orionlock;entity-framework-core;efcore</PackageTags>

--- a/src/Moongazing.OrionGuard.MediatR/Moongazing.OrionGuard.MediatR.csproj
+++ b/src/Moongazing.OrionGuard.MediatR/Moongazing.OrionGuard.MediatR.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.MediatR</PackageId>
-    <Version>6.5.17</Version>
+    <Version>6.5.18</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>MediatR integration for OrionGuard validation library. Provides ValidationBehavior pipeline behavior for automatic request validation in CQRS pipelines.</Description>
     <PackageTags>guard;validation;mediatr;cqrs;pipeline;behavior</PackageTags>

--- a/src/Moongazing.OrionGuard.OpenTelemetry/Moongazing.OrionGuard.OpenTelemetry.csproj
+++ b/src/Moongazing.OrionGuard.OpenTelemetry/Moongazing.OrionGuard.OpenTelemetry.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.OpenTelemetry</PackageId>
-    <Version>6.5.17</Version>
+    <Version>6.5.18</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>OpenTelemetry integration for OrionGuard validation library. Provides validation metrics (success/failure rates, latency) and distributed tracing spans.</Description>
     <PackageTags>guard;validation;opentelemetry;metrics;tracing;observability</PackageTags>

--- a/src/Moongazing.OrionGuard.Outbox.Dashboard/Moongazing.OrionGuard.Outbox.Dashboard.csproj
+++ b/src/Moongazing.OrionGuard.Outbox.Dashboard/Moongazing.OrionGuard.Outbox.Dashboard.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904;AD0001</NoWarn>
     <PackageId>OrionGuard.Outbox.Dashboard</PackageId>
-    <Version>6.5.17</Version>
+    <Version>6.5.18</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Outbox operator dashboard for OrionGuard. Maps an authorized listing of failed / poisoned messages from the consumer's DbContext to an ASP.NET Core endpoint group, plus POST /{id}/replay and POST /{id}/discard mutation endpoints (v6.5.5) with an optional OnMutation audit hook.</Description>
     <PackageTags>guard;outbox;dashboard;aspnetcore;poisoned-messages;dead-letter</PackageTags>

--- a/src/Moongazing.OrionGuard.Outbox.PostgresNotify/Moongazing.OrionGuard.Outbox.PostgresNotify.csproj
+++ b/src/Moongazing.OrionGuard.Outbox.PostgresNotify/Moongazing.OrionGuard.Outbox.PostgresNotify.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Outbox.PostgresNotify</PackageId>
-    <Version>6.5.17</Version>
+    <Version>6.5.18</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Postgres LISTEN/NOTIFY backed IOutboxWakeSignal for OrionGuard.EntityFrameworkCore. Replaces the v6.5.1 polling fallback with an event-driven wake on every committed outbox row when the consumer's database is PostgreSQL. Falls back to polling cleanly when the LISTEN connection is unreachable.</Description>
     <PackageTags>guard;outbox;postgres;npgsql;listen;notify;push;dispatch;entity-framework-core;efcore</PackageTags>

--- a/src/Moongazing.OrionGuard.Outbox.SqlServerBroker/Moongazing.OrionGuard.Outbox.SqlServerBroker.csproj
+++ b/src/Moongazing.OrionGuard.Outbox.SqlServerBroker/Moongazing.OrionGuard.Outbox.SqlServerBroker.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Outbox.SqlServerBroker</PackageId>
-    <Version>6.5.17</Version>
+    <Version>6.5.18</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>SQL Server Service Broker backed IOutboxWakeSignal for OrionGuard.EntityFrameworkCore. Sibling to OrionGuard.Outbox.PostgresNotify (v6.5.2) for the SQL Server provider. Replaces the v6.5.1 polling-only fallback with an event-driven wake on every committed outbox row via Service Broker's queueing primitives.</Description>
     <PackageTags>guard;outbox;sqlserver;service-broker;push;dispatch;entity-framework-core;efcore</PackageTags>

--- a/src/Moongazing.OrionGuard.SignalR/Moongazing.OrionGuard.SignalR.csproj
+++ b/src/Moongazing.OrionGuard.SignalR/Moongazing.OrionGuard.SignalR.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.SignalR</PackageId>
-    <Version>6.5.17</Version>
+    <Version>6.5.18</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>SignalR integration for OrionGuard validation library. Provides Hub filter for automatic method parameter validation.</Description>
     <PackageTags>guard;validation;signalr;realtime;hub;filter</PackageTags>

--- a/src/Moongazing.OrionGuard.Swagger/Moongazing.OrionGuard.Swagger.csproj
+++ b/src/Moongazing.OrionGuard.Swagger/Moongazing.OrionGuard.Swagger.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Swagger</PackageId>
-    <Version>6.5.17</Version>
+    <Version>6.5.18</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Swagger/OpenAPI integration for OrionGuard. Auto-generates OpenAPI constraints from OrionGuard validation attributes.</Description>
     <PackageTags>guard;validation;swagger;openapi;swashbuckle</PackageTags>

--- a/src/Moongazing.OrionGuard.Testing/Moongazing.OrionGuard.Testing.csproj
+++ b/src/Moongazing.OrionGuard.Testing/Moongazing.OrionGuard.Testing.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Testing</PackageId>
-    <Version>6.5.17</Version>
+    <Version>6.5.18</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Testing helpers for OrionGuard. Provides DomainEventCapture and InMemoryDomainEventDispatcher with framework-agnostic assertions (no xUnit / NUnit / FluentAssertions dependency). Works with any test runner.</Description>
     <PackageTags>guard;validation;testing;ddd;domain-events;assertions;test-helpers</PackageTags>

--- a/src/Moongazing.OrionGuard/Moongazing.OrionGuard.csproj
+++ b/src/Moongazing.OrionGuard/Moongazing.OrionGuard.csproj
@@ -16,7 +16,7 @@
 		<OutputType>Library</OutputType>
 
 		<PackageId>OrionGuard</PackageId>
-		<Version>6.5.17</Version>
+		<Version>6.5.18</Version>
 		<Authors>Tunahan Ali Ozturk</Authors>
 		<Company>Tunahan Ali Ozturk</Company>
 		<GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/OutboxDispatcherErrorsCounterTests.cs
+++ b/tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/OutboxDispatcherErrorsCounterTests.cs
@@ -1,0 +1,40 @@
+namespace Moongazing.OrionGuard.EntityFrameworkCore.Tests.Outbox;
+
+using System.Diagnostics.Metrics;
+using Moongazing.OrionGuard.EntityFrameworkCore.Outbox;
+using Xunit;
+
+public sealed class OutboxDispatcherErrorsCounterTests
+{
+    [Fact]
+    public void RecordDispatchError_emits_a_measurement_tagged_with_exception_type()
+    {
+        var samples = new System.Collections.Generic.List<(string exceptionType, long val)>();
+        using var listener = new MeterListener();
+        listener.InstrumentPublished = (instrument, l) =>
+        {
+            if (instrument.Meter.Name == OutboxDispatcherDiagnostics.MeterName
+                && instrument.Name == "orionguard.outbox.dispatcher.errors")
+            {
+                l.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((_, val, tags, _) =>
+        {
+            string type = string.Empty;
+            foreach (var t in tags)
+            {
+                if (t.Key == "exception_type" && t.Value is string s) { type = s; }
+            }
+            lock (samples) { samples.Add((type, val)); }
+        });
+        listener.Start();
+
+        OutboxDispatcherDiagnostics.RecordDispatchError("JsonException");
+
+        lock (samples)
+        {
+            Assert.Contains(samples, s => s.exceptionType == "JsonException" && s.val == 1);
+        }
+    }
+}


### PR DESCRIPTION
Counter<long> per swallowed dispatch exception with exception_type tag. Pairs with v6.5.17 idle poll + v6.5.16 queue_lag for complete visibility. 1 fact.