### PR TITLE
Release v6.5.21: orionguard.outbox.archival.duration_ms histogram

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to OrionGuard will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.5.21] - 2026-06-11
+
+### Added
+
+#### `orionguard.outbox.archival.duration_ms` histogram
+
+`Histogram<double>` measuring `OutboxArchivalHostedService.ArchiveBatchAsync` wall-clock per cycle. Operators graph p99 to spot a backend whose archive write throughput has regressed independently of row count (slow blob sink keeps the dispatcher honest but hurts throughput).
+
+- ALL cycles emit including zero-row (poll cost matters too).
+- Recorded around the full `archiver.ArchiveAsync` round-trip.
+- Public `OutboxArchivalDiagnostics.RecordArchiveCycleDuration(double)` helper; negative inputs are clamped to 0 to tolerate clock skew across hosts.
+
+### Tests
+
+2 facts.
+
+### Migration from v6.5.20
+
+Source-compatible.
+
+## [6.5.17] - [6.5.20]
+
+Released to NuGet; see GitHub release notes for `orionguard.outbox.dispatcher.poll.idle` counter (v6.5.17), `dispatcher.errors` counter (v6.5.18), `dispatcher.row_size_bytes` histogram (v6.5.19), `archival.batch_size` histogram (v6.5.20).
+
 ## [6.5.16] - 2026-06-11
 
 ### Added

--- a/src/Moongazing.OrionGuard.AspNetCore/Moongazing.OrionGuard.AspNetCore.csproj
+++ b/src/Moongazing.OrionGuard.AspNetCore/Moongazing.OrionGuard.AspNetCore.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.AspNetCore</PackageId>
-    <Version>6.5.20</Version>
+    <Version>6.5.21</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>ASP.NET Core integration for OrionGuard validation library. Provides middleware, Minimal API endpoint filters, MVC action filters, and RFC 9457 ProblemDetails support.</Description>
     <PackageTags>guard;validation;aspnetcore;middleware;minimal-api;problemdetails</PackageTags>

--- a/src/Moongazing.OrionGuard.Blazor/Moongazing.OrionGuard.Blazor.csproj
+++ b/src/Moongazing.OrionGuard.Blazor/Moongazing.OrionGuard.Blazor.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Blazor</PackageId>
-    <Version>6.5.20</Version>
+    <Version>6.5.21</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Blazor integration for OrionGuard validation library. Provides EditForm validation, custom validation components, and data annotations interop.</Description>
     <PackageTags>guard;validation;blazor;editform;component;wasm;server</PackageTags>

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Moongazing.OrionGuard.EntityFrameworkCore.csproj
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Moongazing.OrionGuard.EntityFrameworkCore.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.EntityFrameworkCore</PackageId>
-    <Version>6.5.20</Version>
+    <Version>6.5.21</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>EF Core integration for OrionGuard. Provides a SaveChanges interceptor that dispatches domain events from AggregateRoot&lt;TId&gt; instances after commit (Inline mode) or via a transactional outbox (Outbox mode) consumed by a hosted background worker. Includes W3C trace context propagation across the outbox boundary.</Description>
     <PackageTags>guard;validation;ddd;domain-events;outbox;entity-framework-core;efcore;aggregate-root</PackageTags>

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Archival/OutboxArchivalDiagnostics.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Archival/OutboxArchivalDiagnostics.cs
@@ -57,4 +57,18 @@ public static class OutboxArchivalDiagnostics
         }
         ArchiveBatchSize.Record(rowCount);
     }
+
+    /// <summary>
+    /// v6.5.21 wall-clock duration of one archival cycle in milliseconds. Operators
+    /// graph p99 to spot a backend whose archive write throughput has regressed
+    /// independently of the row count (e.g. a slow blob sink keeps the dispatcher
+    /// honest but hurts throughput).
+    /// </summary>
+    internal static readonly Histogram<double> ArchiveCycleDuration = Meter.CreateHistogram<double>(
+        "orionguard.outbox.archival.duration_ms", unit: "ms",
+        description: "Wall-clock duration of one archival cycle (all cycles, including zero-row).");
+
+    /// <summary>Record an archival cycle's wall-clock. ALL cycles emit including zero-row.</summary>
+    public static void RecordArchiveCycleDuration(double milliseconds)
+        => ArchiveCycleDuration.Record(System.Math.Max(0d, milliseconds));
 }

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Archival/OutboxArchivalHostedService.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Archival/OutboxArchivalHostedService.cs
@@ -87,13 +87,21 @@ public sealed class OutboxArchivalHostedService : BackgroundService
         await using var scope = scopeFactory.CreateAsyncScope();
         var ctx = scope.ServiceProvider.GetRequiredService<DbContext>();
 
-        // v6.5.21: time the full archival round-trip including the scope/context
-        // resolution above. Records on EVERY cycle (zero-row included) so a slow sink
-        // surfaces even when the backlog is empty.
+        // v6.5.21: time the archiver round-trip (excluding the cheap DI scope/DbContext
+        // resolution above). Records on EVERY cycle (success AND failure, zero-row
+        // included) so slow OR failing sinks both surface; try/finally guarantees the
+        // sample fires even if ArchiveAsync throws.
         var cycleSw = System.Diagnostics.Stopwatch.StartNew();
-        var archived = await archiver.ArchiveAsync(ctx, cutoff, options, cancellationToken).ConfigureAwait(false);
-        cycleSw.Stop();
-        OutboxArchivalDiagnostics.RecordArchiveCycleDuration(cycleSw.Elapsed.TotalMilliseconds);
+        int archived;
+        try
+        {
+            archived = await archiver.ArchiveAsync(ctx, cutoff, options, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            cycleSw.Stop();
+            OutboxArchivalDiagnostics.RecordArchiveCycleDuration(cycleSw.Elapsed.TotalMilliseconds);
+        }
 
         if (archived > 0)
         {

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Archival/OutboxArchivalHostedService.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Archival/OutboxArchivalHostedService.cs
@@ -87,7 +87,13 @@ public sealed class OutboxArchivalHostedService : BackgroundService
         await using var scope = scopeFactory.CreateAsyncScope();
         var ctx = scope.ServiceProvider.GetRequiredService<DbContext>();
 
+        // v6.5.21: time the full archival round-trip including the scope/context
+        // resolution above. Records on EVERY cycle (zero-row included) so a slow sink
+        // surfaces even when the backlog is empty.
+        var cycleSw = System.Diagnostics.Stopwatch.StartNew();
         var archived = await archiver.ArchiveAsync(ctx, cutoff, options, cancellationToken).ConfigureAwait(false);
+        cycleSw.Stop();
+        OutboxArchivalDiagnostics.RecordArchiveCycleDuration(cycleSw.Elapsed.TotalMilliseconds);
 
         if (archived > 0)
         {

--- a/src/Moongazing.OrionGuard.Grpc/Moongazing.OrionGuard.Grpc.csproj
+++ b/src/Moongazing.OrionGuard.Grpc/Moongazing.OrionGuard.Grpc.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Grpc</PackageId>
-    <Version>6.5.20</Version>
+    <Version>6.5.21</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>gRPC integration for OrionGuard validation library. Provides server interceptor for automatic request validation in gRPC services.</Description>
     <PackageTags>guard;validation;grpc;interceptor;protobuf;microservices</PackageTags>

--- a/src/Moongazing.OrionGuard.Locks.Redis/Moongazing.OrionGuard.Locks.Redis.csproj
+++ b/src/Moongazing.OrionGuard.Locks.Redis/Moongazing.OrionGuard.Locks.Redis.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Locks.Redis</PackageId>
-    <Version>6.5.20</Version>
+    <Version>6.5.21</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Redis-backed IDistributedLock for OrionGuard.EntityFrameworkCore's outbox dispatcher. Bridges OrionGuard's IDistributedLock contract to the OrionLock.Redis backend so multi-instance outbox workers can share a Redis-coordinated lease instead of the default SkipLocked DB lock.</Description>
     <PackageTags>guard;outbox;distributed-lock;redis;orionlock;entity-framework-core;efcore</PackageTags>

--- a/src/Moongazing.OrionGuard.MediatR/Moongazing.OrionGuard.MediatR.csproj
+++ b/src/Moongazing.OrionGuard.MediatR/Moongazing.OrionGuard.MediatR.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.MediatR</PackageId>
-    <Version>6.5.20</Version>
+    <Version>6.5.21</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>MediatR integration for OrionGuard validation library. Provides ValidationBehavior pipeline behavior for automatic request validation in CQRS pipelines.</Description>
     <PackageTags>guard;validation;mediatr;cqrs;pipeline;behavior</PackageTags>

--- a/src/Moongazing.OrionGuard.OpenTelemetry/Moongazing.OrionGuard.OpenTelemetry.csproj
+++ b/src/Moongazing.OrionGuard.OpenTelemetry/Moongazing.OrionGuard.OpenTelemetry.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.OpenTelemetry</PackageId>
-    <Version>6.5.20</Version>
+    <Version>6.5.21</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>OpenTelemetry integration for OrionGuard validation library. Provides validation metrics (success/failure rates, latency) and distributed tracing spans.</Description>
     <PackageTags>guard;validation;opentelemetry;metrics;tracing;observability</PackageTags>

--- a/src/Moongazing.OrionGuard.Outbox.Dashboard/Moongazing.OrionGuard.Outbox.Dashboard.csproj
+++ b/src/Moongazing.OrionGuard.Outbox.Dashboard/Moongazing.OrionGuard.Outbox.Dashboard.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904;AD0001</NoWarn>
     <PackageId>OrionGuard.Outbox.Dashboard</PackageId>
-    <Version>6.5.20</Version>
+    <Version>6.5.21</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Outbox operator dashboard for OrionGuard. Maps an authorized listing of failed / poisoned messages from the consumer's DbContext to an ASP.NET Core endpoint group, plus POST /{id}/replay and POST /{id}/discard mutation endpoints (v6.5.5) with an optional OnMutation audit hook.</Description>
     <PackageTags>guard;outbox;dashboard;aspnetcore;poisoned-messages;dead-letter</PackageTags>

--- a/src/Moongazing.OrionGuard.Outbox.PostgresNotify/Moongazing.OrionGuard.Outbox.PostgresNotify.csproj
+++ b/src/Moongazing.OrionGuard.Outbox.PostgresNotify/Moongazing.OrionGuard.Outbox.PostgresNotify.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Outbox.PostgresNotify</PackageId>
-    <Version>6.5.20</Version>
+    <Version>6.5.21</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Postgres LISTEN/NOTIFY backed IOutboxWakeSignal for OrionGuard.EntityFrameworkCore. Replaces the v6.5.1 polling fallback with an event-driven wake on every committed outbox row when the consumer's database is PostgreSQL. Falls back to polling cleanly when the LISTEN connection is unreachable.</Description>
     <PackageTags>guard;outbox;postgres;npgsql;listen;notify;push;dispatch;entity-framework-core;efcore</PackageTags>

--- a/src/Moongazing.OrionGuard.Outbox.SqlServerBroker/Moongazing.OrionGuard.Outbox.SqlServerBroker.csproj
+++ b/src/Moongazing.OrionGuard.Outbox.SqlServerBroker/Moongazing.OrionGuard.Outbox.SqlServerBroker.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Outbox.SqlServerBroker</PackageId>
-    <Version>6.5.20</Version>
+    <Version>6.5.21</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>SQL Server Service Broker backed IOutboxWakeSignal for OrionGuard.EntityFrameworkCore. Sibling to OrionGuard.Outbox.PostgresNotify (v6.5.2) for the SQL Server provider. Replaces the v6.5.1 polling-only fallback with an event-driven wake on every committed outbox row via Service Broker's queueing primitives.</Description>
     <PackageTags>guard;outbox;sqlserver;service-broker;push;dispatch;entity-framework-core;efcore</PackageTags>

--- a/src/Moongazing.OrionGuard.SignalR/Moongazing.OrionGuard.SignalR.csproj
+++ b/src/Moongazing.OrionGuard.SignalR/Moongazing.OrionGuard.SignalR.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.SignalR</PackageId>
-    <Version>6.5.20</Version>
+    <Version>6.5.21</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>SignalR integration for OrionGuard validation library. Provides Hub filter for automatic method parameter validation.</Description>
     <PackageTags>guard;validation;signalr;realtime;hub;filter</PackageTags>

--- a/src/Moongazing.OrionGuard.Swagger/Moongazing.OrionGuard.Swagger.csproj
+++ b/src/Moongazing.OrionGuard.Swagger/Moongazing.OrionGuard.Swagger.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Swagger</PackageId>
-    <Version>6.5.20</Version>
+    <Version>6.5.21</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Swagger/OpenAPI integration for OrionGuard. Auto-generates OpenAPI constraints from OrionGuard validation attributes.</Description>
     <PackageTags>guard;validation;swagger;openapi;swashbuckle</PackageTags>

--- a/src/Moongazing.OrionGuard.Testing/Moongazing.OrionGuard.Testing.csproj
+++ b/src/Moongazing.OrionGuard.Testing/Moongazing.OrionGuard.Testing.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Testing</PackageId>
-    <Version>6.5.20</Version>
+    <Version>6.5.21</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Testing helpers for OrionGuard. Provides DomainEventCapture and InMemoryDomainEventDispatcher with framework-agnostic assertions (no xUnit / NUnit / FluentAssertions dependency). Works with any test runner.</Description>
     <PackageTags>guard;validation;testing;ddd;domain-events;assertions;test-helpers</PackageTags>

--- a/src/Moongazing.OrionGuard/Moongazing.OrionGuard.csproj
+++ b/src/Moongazing.OrionGuard/Moongazing.OrionGuard.csproj
@@ -16,7 +16,7 @@
 		<OutputType>Library</OutputType>
 
 		<PackageId>OrionGuard</PackageId>
-		<Version>6.5.20</Version>
+		<Version>6.5.21</Version>
 		<Authors>Tunahan Ali Ozturk</Authors>
 		<Company>Tunahan Ali Ozturk</Company>
 		<GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/ArchiveCycleDurationTests.cs
+++ b/tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/ArchiveCycleDurationTests.cs
@@ -1,0 +1,56 @@
+namespace Moongazing.OrionGuard.EntityFrameworkCore.Tests.Outbox;
+
+using System.Diagnostics.Metrics;
+using Moongazing.OrionGuard.EntityFrameworkCore.Outbox.Archival;
+using Xunit;
+
+public sealed class ArchiveCycleDurationTests
+{
+    [Fact]
+    public void RecordArchiveCycleDuration_emits_for_positive_milliseconds()
+    {
+        var samples = new System.Collections.Generic.List<double>();
+        using var listener = new MeterListener();
+        listener.InstrumentPublished = (instrument, l) =>
+        {
+            if (instrument.Meter.Name == OutboxArchivalDiagnostics.MeterName
+                && instrument.Name == "orionguard.outbox.archival.duration_ms")
+            {
+                l.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<double>((_, val, _, _) =>
+        {
+            lock (samples) { samples.Add(val); }
+        });
+        listener.Start();
+
+        OutboxArchivalDiagnostics.RecordArchiveCycleDuration(125.5);
+
+        lock (samples) { Assert.Contains(125.5, samples); }
+    }
+
+    [Fact]
+    public void RecordArchiveCycleDuration_clamps_negative_input_to_zero()
+    {
+        var samples = new System.Collections.Generic.List<double>();
+        using var listener = new MeterListener();
+        listener.InstrumentPublished = (instrument, l) =>
+        {
+            if (instrument.Meter.Name == OutboxArchivalDiagnostics.MeterName
+                && instrument.Name == "orionguard.outbox.archival.duration_ms")
+            {
+                l.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<double>((_, val, _, _) =>
+        {
+            lock (samples) { samples.Add(val); }
+        });
+        listener.Start();
+
+        OutboxArchivalDiagnostics.RecordArchiveCycleDuration(-50.0);
+
+        lock (samples) { Assert.Contains(0.0, samples); }
+    }
+}


### PR DESCRIPTION
Histogram<double> for archival cycle wall-clock. ALL cycles emit. 2 facts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added outbox archival cycle duration metric (wall‑clock ms) via OpenTelemetry to measure every archival cycle, improving observability.

* **Tests**
  * Added tests verifying metric emission for positive durations and clamping of negative inputs to zero.

* **Documentation**
  * Updated changelog with the observability entry, testing notes, and migration guidance from v6.5.20.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->