### PR TITLE
Release v6.5.22: orionguard.outbox.enqueued_rows_per_save histogram

### DIFF
--- a/src/Moongazing.OrionGuard.AspNetCore/Moongazing.OrionGuard.AspNetCore.csproj
+++ b/src/Moongazing.OrionGuard.AspNetCore/Moongazing.OrionGuard.AspNetCore.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.AspNetCore</PackageId>
-    <Version>6.5.21</Version>
+    <Version>6.5.22</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>ASP.NET Core integration for OrionGuard validation library. Provides middleware, Minimal API endpoint filters, MVC action filters, and RFC 9457 ProblemDetails support.</Description>
     <PackageTags>guard;validation;aspnetcore;middleware;minimal-api;problemdetails</PackageTags>

--- a/src/Moongazing.OrionGuard.Blazor/Moongazing.OrionGuard.Blazor.csproj
+++ b/src/Moongazing.OrionGuard.Blazor/Moongazing.OrionGuard.Blazor.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Blazor</PackageId>
-    <Version>6.5.21</Version>
+    <Version>6.5.22</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Blazor integration for OrionGuard validation library. Provides EditForm validation, custom validation components, and data annotations interop.</Description>
     <PackageTags>guard;validation;blazor;editform;component;wasm;server</PackageTags>

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/DomainEventSaveChangesInterceptor.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/DomainEventSaveChangesInterceptor.cs
@@ -33,6 +33,11 @@ public sealed class DomainEventSaveChangesInterceptor : SaveChangesInterceptor
         this.serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
     }
 
+    // v6.5.22 fix (codex P2): AsyncLocal stash so concurrent SaveChanges on different
+    // DbContexts do not race a single field. SavingChangesAsync writes the count;
+    // SavedChangesAsync (commit-confirmed) emits the histogram sample.
+    private readonly AsyncLocal<int?> pendingEnqueueCount = new();
+
     /// <inheritdoc />
     public override async ValueTask<InterceptionResult<int>> SavingChangesAsync(
         DbContextEventData eventData,
@@ -81,10 +86,11 @@ public sealed class DomainEventSaveChangesInterceptor : SaveChangesInterceptor
                     enqueued++;
                 }
             }
-            // v6.5.22: per-save enqueue size for operator visibility into producer-side
-            // fan-out. Zero-row saves intentionally skipped (every SaveChanges would
-            // otherwise emit, drowning the histogram tail signal in idle samples).
-            Outbox.OutboxDispatcherDiagnostics.RecordEnqueuedRowsPerSave(enqueued);
+            // v6.5.22 fix (codex P2): stash the count and emit AFTER the commit succeeds
+            // inside SavedChangesAsync. Emitting here (before EF flushes) would record a
+            // positive batch even when the save later fails on a constraint violation /
+            // cancellation, polluting the producer-side p99 with phantom enqueues.
+            pendingEnqueueCount.Value = enqueued;
         }
         return await base.SavingChangesAsync(eventData, result, cancellationToken).ConfigureAwait(false);
     }
@@ -106,6 +112,15 @@ public sealed class DomainEventSaveChangesInterceptor : SaveChangesInterceptor
     {
         ArgumentNullException.ThrowIfNull(eventData);
         var options = serviceProvider.GetRequiredService<OrionGuardEfCoreOptions>();
+        // v6.5.22: post-commit emission of the producer enqueue size. Pulled regardless
+        // of strategy so non-outbox SavingChangesAsync branches that did set a count
+        // (none today, but future strategies might) still benefit from the same fate
+        // model. Cleared after emit so a subsequent failure path does not double-count.
+        if (pendingEnqueueCount.Value is { } enqueuedCount)
+        {
+            Outbox.OutboxDispatcherDiagnostics.RecordEnqueuedRowsPerSave(enqueuedCount);
+            pendingEnqueueCount.Value = null;
+        }
         if (options.Strategy != DomainEventDispatchStrategy.Inline)
         {
             // Outbox mode: fire the optional push-dispatch wake so a ChannelOutboxWakeSignal
@@ -150,6 +165,9 @@ public sealed class DomainEventSaveChangesInterceptor : SaveChangesInterceptor
         // without draining, so the aggregate retains its domain events for the retry to observe.
         var collector = serviceProvider.GetRequiredService<DomainEventCollector>();
         collector.Reset();
+        // v6.5.22: clear the pending enqueue count on failure so a subsequent
+        // successful SaveChanges does not emit the failed batch's number.
+        pendingEnqueueCount.Value = null;
         return base.SaveChangesFailedAsync(eventData, cancellationToken);
     }
 }

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/DomainEventSaveChangesInterceptor.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/DomainEventSaveChangesInterceptor.cs
@@ -64,6 +64,7 @@ public sealed class DomainEventSaveChangesInterceptor : SaveChangesInterceptor
         {
             var current = Activity.Current;
             var typeMap = serviceProvider.GetService<OutboxTypeMapRegistry>();
+            int enqueued = 0;
             foreach (var aggregate in aggregates)
             {
                 var events = aggregate.PullDomainEvents();
@@ -77,8 +78,13 @@ public sealed class DomainEventSaveChangesInterceptor : SaveChangesInterceptor
                         TraceParent = current?.Id,
                         TraceState = current?.TraceStateString,
                     });
+                    enqueued++;
                 }
             }
+            // v6.5.22: per-save enqueue size for operator visibility into producer-side
+            // fan-out. Zero-row saves intentionally skipped (every SaveChanges would
+            // otherwise emit, drowning the histogram tail signal in idle samples).
+            Outbox.OutboxDispatcherDiagnostics.RecordEnqueuedRowsPerSave(enqueued);
         }
         return await base.SavingChangesAsync(eventData, result, cancellationToken).ConfigureAwait(false);
     }

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Moongazing.OrionGuard.EntityFrameworkCore.csproj
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Moongazing.OrionGuard.EntityFrameworkCore.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.EntityFrameworkCore</PackageId>
-    <Version>6.5.21</Version>
+    <Version>6.5.22</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>EF Core integration for OrionGuard. Provides a SaveChanges interceptor that dispatches domain events from AggregateRoot&lt;TId&gt; instances after commit (Inline mode) or via a transactional outbox (Outbox mode) consumed by a hosted background worker. Includes W3C trace context propagation across the outbox boundary.</Description>
     <PackageTags>guard;validation;ddd;domain-events;outbox;entity-framework-core;efcore;aggregate-root</PackageTags>

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/OutboxDispatcherDiagnostics.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/OutboxDispatcherDiagnostics.cs
@@ -63,6 +63,27 @@ public static class OutboxDispatcherDiagnostics
         => DispatchErrors.Add(1, new System.Collections.Generic.KeyValuePair<string, object?>("exception_type", exceptionType));
 
     /// <summary>
+    /// v6.5.22 distribution of OutboxMessage rows added per SaveChangesAsync invocation
+    /// on the producer side. Operators graph p99 to spot a SaveChanges call that emits
+    /// an unusually large batch (often a sign of bulk-imports or accidental fan-out
+    /// from aggregate domain events). Zero-row saves do NOT emit (every SaveChanges
+    /// would otherwise pollute the histogram with 0 samples).
+    /// </summary>
+    internal static readonly Histogram<int> EnqueuedRowsPerSave = Meter.CreateHistogram<int>(
+        "orionguard.outbox.enqueued_rows_per_save", unit: "{rows}",
+        description: "Outbox rows added by the DomainEventSaveChangesInterceptor per SaveChanges (non-zero only).");
+
+    /// <summary>Record one non-empty SaveChanges enqueue batch. Public for consumer-owned producers.</summary>
+    public static void RecordEnqueuedRowsPerSave(int rowCount)
+    {
+        if (rowCount <= 0)
+        {
+            return;
+        }
+        EnqueuedRowsPerSave.Record(rowCount);
+    }
+
+    /// <summary>
     /// v6.5.19 distribution of dispatched row payload sizes in bytes (the JSON Payload
     /// column length). Operators graph p99 to size storage column types, connection-
     /// pool buffers, and spot tenant bulk-import paths whose payloads grew suddenly.

--- a/src/Moongazing.OrionGuard.Grpc/Moongazing.OrionGuard.Grpc.csproj
+++ b/src/Moongazing.OrionGuard.Grpc/Moongazing.OrionGuard.Grpc.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Grpc</PackageId>
-    <Version>6.5.21</Version>
+    <Version>6.5.22</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>gRPC integration for OrionGuard validation library. Provides server interceptor for automatic request validation in gRPC services.</Description>
     <PackageTags>guard;validation;grpc;interceptor;protobuf;microservices</PackageTags>

--- a/src/Moongazing.OrionGuard.Locks.Redis/Moongazing.OrionGuard.Locks.Redis.csproj
+++ b/src/Moongazing.OrionGuard.Locks.Redis/Moongazing.OrionGuard.Locks.Redis.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Locks.Redis</PackageId>
-    <Version>6.5.21</Version>
+    <Version>6.5.22</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Redis-backed IDistributedLock for OrionGuard.EntityFrameworkCore's outbox dispatcher. Bridges OrionGuard's IDistributedLock contract to the OrionLock.Redis backend so multi-instance outbox workers can share a Redis-coordinated lease instead of the default SkipLocked DB lock.</Description>
     <PackageTags>guard;outbox;distributed-lock;redis;orionlock;entity-framework-core;efcore</PackageTags>

--- a/src/Moongazing.OrionGuard.MediatR/Moongazing.OrionGuard.MediatR.csproj
+++ b/src/Moongazing.OrionGuard.MediatR/Moongazing.OrionGuard.MediatR.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.MediatR</PackageId>
-    <Version>6.5.21</Version>
+    <Version>6.5.22</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>MediatR integration for OrionGuard validation library. Provides ValidationBehavior pipeline behavior for automatic request validation in CQRS pipelines.</Description>
     <PackageTags>guard;validation;mediatr;cqrs;pipeline;behavior</PackageTags>

--- a/src/Moongazing.OrionGuard.OpenTelemetry/Moongazing.OrionGuard.OpenTelemetry.csproj
+++ b/src/Moongazing.OrionGuard.OpenTelemetry/Moongazing.OrionGuard.OpenTelemetry.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.OpenTelemetry</PackageId>
-    <Version>6.5.21</Version>
+    <Version>6.5.22</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>OpenTelemetry integration for OrionGuard validation library. Provides validation metrics (success/failure rates, latency) and distributed tracing spans.</Description>
     <PackageTags>guard;validation;opentelemetry;metrics;tracing;observability</PackageTags>

--- a/src/Moongazing.OrionGuard.Outbox.Dashboard/Moongazing.OrionGuard.Outbox.Dashboard.csproj
+++ b/src/Moongazing.OrionGuard.Outbox.Dashboard/Moongazing.OrionGuard.Outbox.Dashboard.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904;AD0001</NoWarn>
     <PackageId>OrionGuard.Outbox.Dashboard</PackageId>
-    <Version>6.5.21</Version>
+    <Version>6.5.22</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Outbox operator dashboard for OrionGuard. Maps an authorized listing of failed / poisoned messages from the consumer's DbContext to an ASP.NET Core endpoint group, plus POST /{id}/replay and POST /{id}/discard mutation endpoints (v6.5.5) with an optional OnMutation audit hook.</Description>
     <PackageTags>guard;outbox;dashboard;aspnetcore;poisoned-messages;dead-letter</PackageTags>

--- a/src/Moongazing.OrionGuard.Outbox.PostgresNotify/Moongazing.OrionGuard.Outbox.PostgresNotify.csproj
+++ b/src/Moongazing.OrionGuard.Outbox.PostgresNotify/Moongazing.OrionGuard.Outbox.PostgresNotify.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Outbox.PostgresNotify</PackageId>
-    <Version>6.5.21</Version>
+    <Version>6.5.22</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Postgres LISTEN/NOTIFY backed IOutboxWakeSignal for OrionGuard.EntityFrameworkCore. Replaces the v6.5.1 polling fallback with an event-driven wake on every committed outbox row when the consumer's database is PostgreSQL. Falls back to polling cleanly when the LISTEN connection is unreachable.</Description>
     <PackageTags>guard;outbox;postgres;npgsql;listen;notify;push;dispatch;entity-framework-core;efcore</PackageTags>

--- a/src/Moongazing.OrionGuard.Outbox.SqlServerBroker/Moongazing.OrionGuard.Outbox.SqlServerBroker.csproj
+++ b/src/Moongazing.OrionGuard.Outbox.SqlServerBroker/Moongazing.OrionGuard.Outbox.SqlServerBroker.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Outbox.SqlServerBroker</PackageId>
-    <Version>6.5.21</Version>
+    <Version>6.5.22</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>SQL Server Service Broker backed IOutboxWakeSignal for OrionGuard.EntityFrameworkCore. Sibling to OrionGuard.Outbox.PostgresNotify (v6.5.2) for the SQL Server provider. Replaces the v6.5.1 polling-only fallback with an event-driven wake on every committed outbox row via Service Broker's queueing primitives.</Description>
     <PackageTags>guard;outbox;sqlserver;service-broker;push;dispatch;entity-framework-core;efcore</PackageTags>

--- a/src/Moongazing.OrionGuard.SignalR/Moongazing.OrionGuard.SignalR.csproj
+++ b/src/Moongazing.OrionGuard.SignalR/Moongazing.OrionGuard.SignalR.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.SignalR</PackageId>
-    <Version>6.5.21</Version>
+    <Version>6.5.22</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>SignalR integration for OrionGuard validation library. Provides Hub filter for automatic method parameter validation.</Description>
     <PackageTags>guard;validation;signalr;realtime;hub;filter</PackageTags>

--- a/src/Moongazing.OrionGuard.Swagger/Moongazing.OrionGuard.Swagger.csproj
+++ b/src/Moongazing.OrionGuard.Swagger/Moongazing.OrionGuard.Swagger.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Swagger</PackageId>
-    <Version>6.5.21</Version>
+    <Version>6.5.22</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Swagger/OpenAPI integration for OrionGuard. Auto-generates OpenAPI constraints from OrionGuard validation attributes.</Description>
     <PackageTags>guard;validation;swagger;openapi;swashbuckle</PackageTags>

--- a/src/Moongazing.OrionGuard.Testing/Moongazing.OrionGuard.Testing.csproj
+++ b/src/Moongazing.OrionGuard.Testing/Moongazing.OrionGuard.Testing.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Testing</PackageId>
-    <Version>6.5.21</Version>
+    <Version>6.5.22</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Testing helpers for OrionGuard. Provides DomainEventCapture and InMemoryDomainEventDispatcher with framework-agnostic assertions (no xUnit / NUnit / FluentAssertions dependency). Works with any test runner.</Description>
     <PackageTags>guard;validation;testing;ddd;domain-events;assertions;test-helpers</PackageTags>

--- a/src/Moongazing.OrionGuard/Moongazing.OrionGuard.csproj
+++ b/src/Moongazing.OrionGuard/Moongazing.OrionGuard.csproj
@@ -16,7 +16,7 @@
 		<OutputType>Library</OutputType>
 
 		<PackageId>OrionGuard</PackageId>
-		<Version>6.5.21</Version>
+		<Version>6.5.22</Version>
 		<Authors>Tunahan Ali Ozturk</Authors>
 		<Company>Tunahan Ali Ozturk</Company>
 		<GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/EnqueuedRowsPerSaveTests.cs
+++ b/tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/EnqueuedRowsPerSaveTests.cs
@@ -1,0 +1,61 @@
+namespace Moongazing.OrionGuard.EntityFrameworkCore.Tests.Outbox;
+
+using System.Diagnostics.Metrics;
+using Moongazing.OrionGuard.EntityFrameworkCore.Outbox;
+using Xunit;
+
+public sealed class EnqueuedRowsPerSaveTests
+{
+    [Fact]
+    public void RecordEnqueuedRowsPerSave_emits_for_positive_count()
+    {
+        var samples = new System.Collections.Generic.List<int>();
+        using var listener = new MeterListener();
+        listener.InstrumentPublished = (instrument, l) =>
+        {
+            if (instrument.Meter.Name == OutboxDispatcherDiagnostics.MeterName
+                && instrument.Name == "orionguard.outbox.enqueued_rows_per_save")
+            {
+                l.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<int>((_, val, _, _) =>
+        {
+            lock (samples) { samples.Add(val); }
+        });
+        listener.Start();
+
+        OutboxDispatcherDiagnostics.RecordEnqueuedRowsPerSave(15);
+
+        lock (samples) { Assert.Contains(15, samples); }
+    }
+
+    [Fact]
+    public void RecordEnqueuedRowsPerSave_ignores_zero_and_negative_input()
+    {
+        var samples = new System.Collections.Generic.List<int>();
+        using var listener = new MeterListener();
+        listener.InstrumentPublished = (instrument, l) =>
+        {
+            if (instrument.Meter.Name == OutboxDispatcherDiagnostics.MeterName
+                && instrument.Name == "orionguard.outbox.enqueued_rows_per_save")
+            {
+                l.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<int>((_, val, _, _) =>
+        {
+            lock (samples) { samples.Add(val); }
+        });
+        listener.Start();
+
+        OutboxDispatcherDiagnostics.RecordEnqueuedRowsPerSave(0);
+        OutboxDispatcherDiagnostics.RecordEnqueuedRowsPerSave(-3);
+
+        lock (samples)
+        {
+            Assert.DoesNotContain(0, samples);
+            Assert.DoesNotContain(-3, samples);
+        }
+    }
+}


### PR DESCRIPTION
Histogram<int> per non-empty SaveChanges enqueue batch. First producer-side outbox instrument. 2 facts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OpenTelemetry metrics to track the number of outbox messages enqueued per save operation, improving visibility into message persistence behavior.

* **Tests**
  * Added test coverage for outbox diagnostics metrics.

* **Chores**
  * Bumped patch version to 6.5.22.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->