### PR TITLE
Release v6.5.23: IOutboxRowFailureObserver extensibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to OrionGuard will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.5.23] - 2026-06-12
+
+### Added
+
+#### `IOutboxRowFailureObserver` extensibility
+
+Consumer-supplied observer invoked when the dispatcher swallows a per-row failure. Mirror of v0.2.18 Patch `IDeadLetterSink` on the Guard side.
+
+- `IOutboxRowFailureObserver` interface + `NullOutboxRowFailureObserver` default.
+- Optional 8th ctor parameter on `OutboxDispatcherHostedService`.
+- Fires for EVERY swallowed failure with `attempt` + `isTerminal` flags.
+- Observer fires BEFORE `SaveChangesAsync` so the notification is best-effort.
+
+### Tests
+
+2 facts.
+
+### Migration from v6.5.22
+
+Source-compatible.
+
+## [6.5.22] - 2026-06-11
+
+OrionGuard `orionguard.outbox.enqueued_rows_per_save` histogram (post-commit AsyncLocal pattern).
+
 ## [6.5.21] - 2026-06-11
 
 ### Added

--- a/src/Moongazing.OrionGuard.AspNetCore/Moongazing.OrionGuard.AspNetCore.csproj
+++ b/src/Moongazing.OrionGuard.AspNetCore/Moongazing.OrionGuard.AspNetCore.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.AspNetCore</PackageId>
-    <Version>6.5.22</Version>
+    <Version>6.5.23</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>ASP.NET Core integration for OrionGuard validation library. Provides middleware, Minimal API endpoint filters, MVC action filters, and RFC 9457 ProblemDetails support.</Description>
     <PackageTags>guard;validation;aspnetcore;middleware;minimal-api;problemdetails</PackageTags>

--- a/src/Moongazing.OrionGuard.Blazor/Moongazing.OrionGuard.Blazor.csproj
+++ b/src/Moongazing.OrionGuard.Blazor/Moongazing.OrionGuard.Blazor.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Blazor</PackageId>
-    <Version>6.5.22</Version>
+    <Version>6.5.23</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Blazor integration for OrionGuard validation library. Provides EditForm validation, custom validation components, and data annotations interop.</Description>
     <PackageTags>guard;validation;blazor;editform;component;wasm;server</PackageTags>

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Moongazing.OrionGuard.EntityFrameworkCore.csproj
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Moongazing.OrionGuard.EntityFrameworkCore.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.EntityFrameworkCore</PackageId>
-    <Version>6.5.22</Version>
+    <Version>6.5.23</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>EF Core integration for OrionGuard. Provides a SaveChanges interceptor that dispatches domain events from AggregateRoot&lt;TId&gt; instances after commit (Inline mode) or via a transactional outbox (Outbox mode) consumed by a hosted background worker. Includes W3C trace context propagation across the outbox boundary.</Description>
     <PackageTags>guard;validation;ddd;domain-events;outbox;entity-framework-core;efcore;aggregate-root</PackageTags>

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/IOutboxRowFailureObserver.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/IOutboxRowFailureObserver.cs
@@ -1,0 +1,55 @@
+namespace Moongazing.OrionGuard.EntityFrameworkCore.Outbox;
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+/// <summary>
+/// v6.5.23 consumer-supplied observer invoked when the dispatcher swallows a per-row
+/// failure. Mirror of v0.2.18 Patch <c>IDeadLetterSink</c> on the Guard producer side.
+/// Useful for routing failures to triage / alerting systems (Slack, PagerDuty,
+/// follow-up review queue) without tangling that logic into the load-bearing dispatch
+/// transaction.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The observer fires for EVERY swallowed failure (transient + terminal), pairing with
+/// the v6.5.18 <c>dispatcher.errors</c> counter shape. A throwing observer does NOT
+/// affect the database state (the row's RetryCount/Error fields are already updated by
+/// the dispatcher); observer exceptions are caught and logged at warning level.
+/// </para>
+/// <para>
+/// No observer is registered by default. Consumers wire one via
+/// <c>services.AddSingleton&lt;IOutboxRowFailureObserver, MyObserver&gt;()</c>.
+/// </para>
+/// </remarks>
+public interface IOutboxRowFailureObserver
+{
+    /// <summary>Notify the observer that a dispatcher row failed.</summary>
+    /// <param name="rowId">Outbox row id.</param>
+    /// <param name="eventType">Logical event type id resolved from the registry / AQN.</param>
+    /// <param name="attempt">Attempt number that just failed (1 = first try).</param>
+    /// <param name="isTerminal">True when this failure pushed RetryCount >= MaxRetries.</param>
+    /// <param name="exception">The exception the dispatcher caught.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task OnRowFailedAsync(
+        Guid rowId,
+        string eventType,
+        int attempt,
+        bool isTerminal,
+        Exception exception,
+        CancellationToken cancellationToken);
+}
+
+/// <summary>Default no-op observer used when no consumer-registered observer is present.</summary>
+public sealed class NullOutboxRowFailureObserver : IOutboxRowFailureObserver
+{
+    /// <inheritdoc />
+    public Task OnRowFailedAsync(
+        Guid rowId,
+        string eventType,
+        int attempt,
+        bool isTerminal,
+        Exception exception,
+        CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/OutboxDispatcherHostedService.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/OutboxDispatcherHostedService.cs
@@ -89,6 +89,33 @@ public sealed class OutboxDispatcherHostedService : BackgroundService
         this.rowFailureObserver = rowFailureObserver is NullOutboxRowFailureObserver ? null : rowFailureObserver;
     }
 
+    // v6.5.23 fix (codex P2 + coderabbit Major): centralised observer notification so
+    // every terminal/transient failure path calls the observer. OperationCanceledException
+    // unconditionally propagates so cancellation is never downgraded to a warning.
+    private async Task NotifyRowFailureAsync(OutboxMessage msg, int attempt, bool isTerminal, Exception exception, CancellationToken cancellationToken)
+    {
+        var observerRef = rowFailureObserver;
+        if (observerRef is null or NullOutboxRowFailureObserver)
+        {
+            return;
+        }
+        try
+        {
+            await observerRef.OnRowFailedAsync(msg.Id, msg.EventType, attempt, isTerminal, exception, cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+#pragma warning disable CA1031
+        catch (Exception observerEx)
+#pragma warning restore CA1031
+        {
+            logger?.LogWarning(observerEx,
+                "IOutboxRowFailureObserver faulted for row {RowId}; dispatcher continued.", msg.Id);
+        }
+    }
+
     /// <inheritdoc />
     [SuppressMessage("Design", "CA1031:Do not catch general exception types",
         Justification = "Per-batch faults are intentionally swallowed; per-row faults are already recorded on the OutboxMessage row.")]
@@ -216,6 +243,11 @@ public sealed class OutboxDispatcherHostedService : BackgroundService
                     logger?.LogWarning(
                         "Outbox row {RowId} dead-lettered: type '{EventType}' could not be resolved.",
                         msg.Id, msg.EventType);
+                    // v6.5.23 fix (codex P2): notify observer on validation dead-letter
+                    // paths too, not just the catch block. Synthesise an exception so
+                    // the contract surface stays uniform across all terminal paths.
+                    await NotifyRowFailureAsync(msg, msg.RetryCount, isTerminal: true,
+                        new InvalidOperationException(msg.Error), cancellationToken).ConfigureAwait(false);
                 }
                 else if (!typeof(IDomainEvent).IsAssignableFrom(type))
                 {
@@ -224,6 +256,8 @@ public sealed class OutboxDispatcherHostedService : BackgroundService
                     logger?.LogWarning(
                         "Outbox row {RowId} dead-lettered: type '{EventType}' is not IDomainEvent.",
                         msg.Id, msg.EventType);
+                    await NotifyRowFailureAsync(msg, msg.RetryCount, isTerminal: true,
+                        new InvalidOperationException(msg.Error), cancellationToken).ConfigureAwait(false);
                 }
                 else
                 {
@@ -235,6 +269,8 @@ public sealed class OutboxDispatcherHostedService : BackgroundService
                         logger?.LogWarning(
                             "Outbox row {RowId} dead-lettered: payload deserialized to null or wrong type.",
                             msg.Id);
+                        await NotifyRowFailureAsync(msg, msg.RetryCount, isTerminal: true,
+                            new InvalidOperationException(msg.Error), cancellationToken).ConfigureAwait(false);
                     }
                     else
                     {
@@ -273,34 +309,7 @@ public sealed class OutboxDispatcherHostedService : BackgroundService
                     // while preserving Error/RetryCount for operators to inspect (dead-letter).
                     msg.ProcessedOnUtc = DateTime.UtcNow;
                 }
-                // v6.5.23 IOutboxRowFailureObserver: notify the optional consumer-
-                // registered observer AFTER we have written the in-memory row state but
-                // BEFORE SaveChangesAsync. The DB state is not yet durable here; the
-                // observer must therefore treat its notification as 'best-effort' (the
-                // commit could still fail and the row would be re-attempted). Observer
-                // exceptions are caught and logged so a misbehaving observer cannot
-                // abort the dispatcher loop.
-                var observerRef = rowFailureObserver;
-                if (observerRef is not null and not NullOutboxRowFailureObserver)
-                {
-                    try
-                    {
-                        await observerRef.OnRowFailedAsync(
-                            msg.Id, msg.EventType, msg.RetryCount, isTerminal, ex, cancellationToken)
-                            .ConfigureAwait(false);
-                    }
-                    catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-                    {
-                        throw;
-                    }
-#pragma warning disable CA1031
-                    catch (Exception observerEx)
-#pragma warning restore CA1031
-                    {
-                        logger?.LogWarning(observerEx,
-                            "IOutboxRowFailureObserver faulted for row {RowId}; dispatcher continued.", msg.Id);
-                    }
-                }
+                await NotifyRowFailureAsync(msg, msg.RetryCount, isTerminal, ex, cancellationToken).ConfigureAwait(false);
             }
             finally
             {

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/OutboxDispatcherHostedService.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/OutboxDispatcherHostedService.cs
@@ -36,6 +36,10 @@ public sealed class OutboxDispatcherHostedService : BackgroundService
     private readonly OutboxTypeMapOptions typeMapOptions;
     private readonly IOutboxWakeSignal wakeSignal;
     private readonly ILogger<OutboxDispatcherHostedService>? logger;
+    // v6.5.23 optional consumer-registered failure observer. Null and
+    // NullOutboxRowFailureObserver are both treated as 'no observer' so the dispatcher
+    // skips the call entirely.
+    private readonly IOutboxRowFailureObserver? rowFailureObserver;
 
     /// <summary>Initializes a new worker.</summary>
     /// <param name="options">Outbox dispatch configuration.</param>
@@ -59,6 +63,11 @@ public sealed class OutboxDispatcherHostedService : BackgroundService
     /// behaviour identical to v6.4 / v6.5.0).
     /// </param>
     /// <param name="logger">Optional logger used to surface startup and per-row diagnostic messages.</param>
+    /// <param name="rowFailureObserver">
+    /// v6.5.23 optional consumer-registered observer notified for EVERY swallowed per-row
+    /// failure (transient + terminal). Defaults to no-op when null or
+    /// <see cref="NullOutboxRowFailureObserver"/> is supplied.
+    /// </param>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="options"/> or <paramref name="scopeFactory"/> is <see langword="null"/>.</exception>
     public OutboxDispatcherHostedService(
         OutboxOptions options,
@@ -67,7 +76,8 @@ public sealed class OutboxDispatcherHostedService : BackgroundService
         OutboxTypeMapRegistry? typeMap = null,
         OutboxTypeMapOptions? typeMapOptions = null,
         ILogger<OutboxDispatcherHostedService>? logger = null,
-        IOutboxWakeSignal? wakeSignal = null)
+        IOutboxWakeSignal? wakeSignal = null,
+        IOutboxRowFailureObserver? rowFailureObserver = null)
     {
         this.options = options ?? throw new ArgumentNullException(nameof(options));
         this.scopeFactory = scopeFactory ?? throw new ArgumentNullException(nameof(scopeFactory));
@@ -76,6 +86,7 @@ public sealed class OutboxDispatcherHostedService : BackgroundService
         this.typeMapOptions = typeMapOptions ?? new OutboxTypeMapOptions();
         this.logger = logger;
         this.wakeSignal = wakeSignal ?? new NullOutboxWakeSignal();
+        this.rowFailureObserver = rowFailureObserver is NullOutboxRowFailureObserver ? null : rowFailureObserver;
     }
 
     /// <inheritdoc />
@@ -255,11 +266,40 @@ public sealed class OutboxDispatcherHostedService : BackgroundService
                 OutboxDispatcherDiagnostics.RecordDispatchError(ex.GetType().Name);
                 msg.RetryCount++;
                 msg.Error = ex.ToString();
-                if (msg.RetryCount >= options.MaxRetries)
+                var isTerminal = msg.RetryCount >= options.MaxRetries;
+                if (isTerminal)
                 {
                     // Why: stamping ProcessedOnUtc removes the row from the unprocessed-rows query
                     // while preserving Error/RetryCount for operators to inspect (dead-letter).
                     msg.ProcessedOnUtc = DateTime.UtcNow;
+                }
+                // v6.5.23 IOutboxRowFailureObserver: notify the optional consumer-
+                // registered observer AFTER we have written the in-memory row state but
+                // BEFORE SaveChangesAsync. The DB state is not yet durable here; the
+                // observer must therefore treat its notification as 'best-effort' (the
+                // commit could still fail and the row would be re-attempted). Observer
+                // exceptions are caught and logged so a misbehaving observer cannot
+                // abort the dispatcher loop.
+                var observerRef = rowFailureObserver;
+                if (observerRef is not null and not NullOutboxRowFailureObserver)
+                {
+                    try
+                    {
+                        await observerRef.OnRowFailedAsync(
+                            msg.Id, msg.EventType, msg.RetryCount, isTerminal, ex, cancellationToken)
+                            .ConfigureAwait(false);
+                    }
+                    catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                    {
+                        throw;
+                    }
+#pragma warning disable CA1031
+                    catch (Exception observerEx)
+#pragma warning restore CA1031
+                    {
+                        logger?.LogWarning(observerEx,
+                            "IOutboxRowFailureObserver faulted for row {RowId}; dispatcher continued.", msg.Id);
+                    }
                 }
             }
             finally

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/ServiceCollectionExtensions.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/ServiceCollectionExtensions.cs
@@ -65,7 +65,11 @@ public static class ServiceCollectionExtensions
                 sp.GetRequiredService<OutboxTypeMapRegistry>(),
                 sp.GetRequiredService<OutboxTypeMapOptions>(),
                 sp.GetService<ILogger<OutboxDispatcherHostedService>>(),
-                sp.GetRequiredService<IOutboxWakeSignal>()));
+                sp.GetRequiredService<IOutboxWakeSignal>(),
+                // v6.5.23: wire the optional row failure observer; GetService returns
+                // null when the consumer has not registered one, which the hosted
+                // service treats as 'no observer' at the call site.
+                sp.GetService<Outbox.IOutboxRowFailureObserver>()));
         }
 
         // Apply fluent customizations (UseDistributedLock / UseOutboxTypeMap / UseOutboxArchival)

--- a/src/Moongazing.OrionGuard.Grpc/Moongazing.OrionGuard.Grpc.csproj
+++ b/src/Moongazing.OrionGuard.Grpc/Moongazing.OrionGuard.Grpc.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Grpc</PackageId>
-    <Version>6.5.22</Version>
+    <Version>6.5.23</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>gRPC integration for OrionGuard validation library. Provides server interceptor for automatic request validation in gRPC services.</Description>
     <PackageTags>guard;validation;grpc;interceptor;protobuf;microservices</PackageTags>

--- a/src/Moongazing.OrionGuard.Locks.Redis/Moongazing.OrionGuard.Locks.Redis.csproj
+++ b/src/Moongazing.OrionGuard.Locks.Redis/Moongazing.OrionGuard.Locks.Redis.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Locks.Redis</PackageId>
-    <Version>6.5.22</Version>
+    <Version>6.5.23</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Redis-backed IDistributedLock for OrionGuard.EntityFrameworkCore's outbox dispatcher. Bridges OrionGuard's IDistributedLock contract to the OrionLock.Redis backend so multi-instance outbox workers can share a Redis-coordinated lease instead of the default SkipLocked DB lock.</Description>
     <PackageTags>guard;outbox;distributed-lock;redis;orionlock;entity-framework-core;efcore</PackageTags>

--- a/src/Moongazing.OrionGuard.MediatR/Moongazing.OrionGuard.MediatR.csproj
+++ b/src/Moongazing.OrionGuard.MediatR/Moongazing.OrionGuard.MediatR.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.MediatR</PackageId>
-    <Version>6.5.22</Version>
+    <Version>6.5.23</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>MediatR integration for OrionGuard validation library. Provides ValidationBehavior pipeline behavior for automatic request validation in CQRS pipelines.</Description>
     <PackageTags>guard;validation;mediatr;cqrs;pipeline;behavior</PackageTags>

--- a/src/Moongazing.OrionGuard.OpenTelemetry/Moongazing.OrionGuard.OpenTelemetry.csproj
+++ b/src/Moongazing.OrionGuard.OpenTelemetry/Moongazing.OrionGuard.OpenTelemetry.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.OpenTelemetry</PackageId>
-    <Version>6.5.22</Version>
+    <Version>6.5.23</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>OpenTelemetry integration for OrionGuard validation library. Provides validation metrics (success/failure rates, latency) and distributed tracing spans.</Description>
     <PackageTags>guard;validation;opentelemetry;metrics;tracing;observability</PackageTags>

--- a/src/Moongazing.OrionGuard.Outbox.Dashboard/Moongazing.OrionGuard.Outbox.Dashboard.csproj
+++ b/src/Moongazing.OrionGuard.Outbox.Dashboard/Moongazing.OrionGuard.Outbox.Dashboard.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904;AD0001</NoWarn>
     <PackageId>OrionGuard.Outbox.Dashboard</PackageId>
-    <Version>6.5.22</Version>
+    <Version>6.5.23</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Outbox operator dashboard for OrionGuard. Maps an authorized listing of failed / poisoned messages from the consumer's DbContext to an ASP.NET Core endpoint group, plus POST /{id}/replay and POST /{id}/discard mutation endpoints (v6.5.5) with an optional OnMutation audit hook.</Description>
     <PackageTags>guard;outbox;dashboard;aspnetcore;poisoned-messages;dead-letter</PackageTags>

--- a/src/Moongazing.OrionGuard.Outbox.PostgresNotify/Moongazing.OrionGuard.Outbox.PostgresNotify.csproj
+++ b/src/Moongazing.OrionGuard.Outbox.PostgresNotify/Moongazing.OrionGuard.Outbox.PostgresNotify.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Outbox.PostgresNotify</PackageId>
-    <Version>6.5.22</Version>
+    <Version>6.5.23</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Postgres LISTEN/NOTIFY backed IOutboxWakeSignal for OrionGuard.EntityFrameworkCore. Replaces the v6.5.1 polling fallback with an event-driven wake on every committed outbox row when the consumer's database is PostgreSQL. Falls back to polling cleanly when the LISTEN connection is unreachable.</Description>
     <PackageTags>guard;outbox;postgres;npgsql;listen;notify;push;dispatch;entity-framework-core;efcore</PackageTags>

--- a/src/Moongazing.OrionGuard.Outbox.SqlServerBroker/Moongazing.OrionGuard.Outbox.SqlServerBroker.csproj
+++ b/src/Moongazing.OrionGuard.Outbox.SqlServerBroker/Moongazing.OrionGuard.Outbox.SqlServerBroker.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Outbox.SqlServerBroker</PackageId>
-    <Version>6.5.22</Version>
+    <Version>6.5.23</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>SQL Server Service Broker backed IOutboxWakeSignal for OrionGuard.EntityFrameworkCore. Sibling to OrionGuard.Outbox.PostgresNotify (v6.5.2) for the SQL Server provider. Replaces the v6.5.1 polling-only fallback with an event-driven wake on every committed outbox row via Service Broker's queueing primitives.</Description>
     <PackageTags>guard;outbox;sqlserver;service-broker;push;dispatch;entity-framework-core;efcore</PackageTags>

--- a/src/Moongazing.OrionGuard.SignalR/Moongazing.OrionGuard.SignalR.csproj
+++ b/src/Moongazing.OrionGuard.SignalR/Moongazing.OrionGuard.SignalR.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.SignalR</PackageId>
-    <Version>6.5.22</Version>
+    <Version>6.5.23</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>SignalR integration for OrionGuard validation library. Provides Hub filter for automatic method parameter validation.</Description>
     <PackageTags>guard;validation;signalr;realtime;hub;filter</PackageTags>

--- a/src/Moongazing.OrionGuard.Swagger/Moongazing.OrionGuard.Swagger.csproj
+++ b/src/Moongazing.OrionGuard.Swagger/Moongazing.OrionGuard.Swagger.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Swagger</PackageId>
-    <Version>6.5.22</Version>
+    <Version>6.5.23</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Swagger/OpenAPI integration for OrionGuard. Auto-generates OpenAPI constraints from OrionGuard validation attributes.</Description>
     <PackageTags>guard;validation;swagger;openapi;swashbuckle</PackageTags>

--- a/src/Moongazing.OrionGuard.Testing/Moongazing.OrionGuard.Testing.csproj
+++ b/src/Moongazing.OrionGuard.Testing/Moongazing.OrionGuard.Testing.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Testing</PackageId>
-    <Version>6.5.22</Version>
+    <Version>6.5.23</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Testing helpers for OrionGuard. Provides DomainEventCapture and InMemoryDomainEventDispatcher with framework-agnostic assertions (no xUnit / NUnit / FluentAssertions dependency). Works with any test runner.</Description>
     <PackageTags>guard;validation;testing;ddd;domain-events;assertions;test-helpers</PackageTags>

--- a/src/Moongazing.OrionGuard/Moongazing.OrionGuard.csproj
+++ b/src/Moongazing.OrionGuard/Moongazing.OrionGuard.csproj
@@ -16,7 +16,7 @@
 		<OutputType>Library</OutputType>
 
 		<PackageId>OrionGuard</PackageId>
-		<Version>6.5.22</Version>
+		<Version>6.5.23</Version>
 		<Authors>Tunahan Ali Ozturk</Authors>
 		<Company>Tunahan Ali Ozturk</Company>
 		<GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/OutboxRowFailureObserverContractTests.cs
+++ b/tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/OutboxRowFailureObserverContractTests.cs
@@ -1,0 +1,62 @@
+namespace Moongazing.OrionGuard.EntityFrameworkCore.Tests.Outbox;
+
+using Moongazing.OrionGuard.EntityFrameworkCore.Outbox;
+using Xunit;
+
+public sealed class OutboxRowFailureObserverContractTests
+{
+    [Fact]
+    public async Task NullOutboxRowFailureObserver_OnRowFailedAsync_completes_without_throwing()
+    {
+        var sut = new NullOutboxRowFailureObserver();
+
+        await sut.OnRowFailedAsync(
+            System.Guid.NewGuid(),
+            "Demo.Event",
+            attempt: 1,
+            isTerminal: false,
+            new System.InvalidOperationException("boom"),
+            System.Threading.CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task Custom_observer_receives_rowId_event_type_attempt_terminal_and_exception()
+    {
+        System.Guid? capturedId = null;
+        string? capturedEventType = null;
+        int capturedAttempt = -1;
+        bool? capturedTerminal = null;
+        System.Exception? capturedEx = null;
+
+        var sut = new CapturingObserver((id, type, attempt, terminal, ex) =>
+        {
+            capturedId = id;
+            capturedEventType = type;
+            capturedAttempt = attempt;
+            capturedTerminal = terminal;
+            capturedEx = ex;
+        });
+
+        var rowId = System.Guid.NewGuid();
+        var ex = new System.TimeoutException("downstream timed out");
+
+        await sut.OnRowFailedAsync(rowId, "Demo.Order.Placed", attempt: 4, isTerminal: true, ex, System.Threading.CancellationToken.None);
+
+        Assert.Equal(rowId, capturedId);
+        Assert.Equal("Demo.Order.Placed", capturedEventType);
+        Assert.Equal(4, capturedAttempt);
+        Assert.True(capturedTerminal);
+        Assert.Same(ex, capturedEx);
+    }
+
+    private sealed class CapturingObserver : IOutboxRowFailureObserver
+    {
+        private readonly System.Action<System.Guid, string, int, bool, System.Exception> capture;
+        public CapturingObserver(System.Action<System.Guid, string, int, bool, System.Exception> capture) => this.capture = capture;
+        public Task OnRowFailedAsync(System.Guid rowId, string eventType, int attempt, bool isTerminal, System.Exception exception, System.Threading.CancellationToken cancellationToken)
+        {
+            capture(rowId, eventType, attempt, isTerminal, exception);
+            return Task.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
Consumer-supplied observer for dispatcher row failures. Optional 8th ctor parameter; legacy wiring unchanged. Fires for transient + terminal failures. 2 facts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an extensibility point to notify on outbox row dispatch failures, allowing custom handling and tracking of failed processing attempts.

* **Chores**
  * Bumped package versions to 6.5.23 across projects.

* **Tests**
  * Added tests validating the new observer contract.

* **Documentation**
  * Updated changelog with 6.5.23 release notes and migration guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->