### PR TITLE
Release v6.5.27: orionguard.outbox.dispatcher.retries_before_success histogram

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to OrionGuard will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.5.27] - 2026-06-15
+
+### Added
+
+#### `orionguard.outbox.dispatcher.retries_before_success` histogram
+
+`Histogram<int>` records the retry count a row had accumulated at the moment it dispatched successfully (its `RetryCount` on the success path: 0 = succeeded on the first attempt). It measures the successful side of the dispatch loop, complementing the v6.5.18 `errors` counter (failures) and the dead-letter path (terminal only), so operators can answer "are retries quietly papering over downstream flakiness?".
+
+- A healthy system sits at p50 = 0; a rising upper percentile means rows are increasingly succeeding only after transient downstream failures.
+- Unlike the batch-size histograms, the zero sample IS recorded: the fraction of first-try successes is exactly the signal, so dropping zeros would erase the healthy baseline.
+- Emitted post-persist (after `SaveChangesAsync`), alongside `queue_lag` (v6.5.16) and `row_size_bytes` (v6.5.19), so a SaveChanges failure that re-dispatches the row does not double-count.
+- Public `OutboxDispatcherDiagnostics.RecordRetriesBeforeSuccess(int)` helper (negatives clamped to 0).
+
+### Tests
+
+- `RetriesBeforeSuccessHistogramTests`: first-try zero is recorded, the retry count is emitted, negatives clamp to 0.
+
 ## [6.5.26] - 2026-06-13
 
 ### Added

--- a/src/Moongazing.OrionGuard.AspNetCore/Moongazing.OrionGuard.AspNetCore.csproj
+++ b/src/Moongazing.OrionGuard.AspNetCore/Moongazing.OrionGuard.AspNetCore.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.AspNetCore</PackageId>
-    <Version>6.5.26</Version>
+    <Version>6.5.27</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>ASP.NET Core integration for OrionGuard validation library. Provides middleware, Minimal API endpoint filters, MVC action filters, and RFC 9457 ProblemDetails support.</Description>
     <PackageTags>guard;validation;aspnetcore;middleware;minimal-api;problemdetails</PackageTags>

--- a/src/Moongazing.OrionGuard.Blazor/Moongazing.OrionGuard.Blazor.csproj
+++ b/src/Moongazing.OrionGuard.Blazor/Moongazing.OrionGuard.Blazor.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Blazor</PackageId>
-    <Version>6.5.26</Version>
+    <Version>6.5.27</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Blazor integration for OrionGuard validation library. Provides EditForm validation, custom validation components, and data annotations interop.</Description>
     <PackageTags>guard;validation;blazor;editform;component;wasm;server</PackageTags>

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Moongazing.OrionGuard.EntityFrameworkCore.csproj
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Moongazing.OrionGuard.EntityFrameworkCore.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.EntityFrameworkCore</PackageId>
-    <Version>6.5.26</Version>
+    <Version>6.5.27</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>EF Core integration for OrionGuard. Provides a SaveChanges interceptor that dispatches domain events from AggregateRoot&lt;TId&gt; instances after commit (Inline mode) or via a transactional outbox (Outbox mode) consumed by a hosted background worker. Includes W3C trace context propagation across the outbox boundary.</Description>
     <PackageTags>guard;validation;ddd;domain-events;outbox;entity-framework-core;efcore;aggregate-root</PackageTags>

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/OutboxDispatcherDiagnostics.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/OutboxDispatcherDiagnostics.cs
@@ -138,4 +138,26 @@ public static class OutboxDispatcherDiagnostics
         }
         DispatcherBatchSize.Record(rowCount);
     }
+
+    /// <summary>
+    /// v6.5.27 distribution of how many retries a row had accumulated at the moment it
+    /// dispatched successfully (its <c>RetryCount</c> on the success path: 0 = succeeded on
+    /// the first attempt). Distinct from the v6.5.18 <c>errors</c> counter (which tallies
+    /// failures) and the dead-letter path (terminal only): this histogram measures the
+    /// successful side, so operators can answer "are retries quietly papering over downstream
+    /// flakiness?". A healthy system sits at p50 = 0; a rising upper percentile means rows are
+    /// increasingly succeeding only after transient downstream failures. Unlike the batch-size
+    /// histograms, the zero sample IS recorded here: the fraction of first-try successes is
+    /// exactly the signal, so dropping zeros would erase the healthy baseline.
+    /// </summary>
+    internal static readonly Histogram<int> RetriesBeforeSuccess = Meter.CreateHistogram<int>(
+        "orionguard.outbox.dispatcher.retries_before_success", unit: "{retries}",
+        description: "Retries a row had accumulated when it dispatched successfully (0 = first-try).");
+
+    /// <summary>
+    /// Record the retry count of a successfully-dispatched row. Negative inputs are clamped to 0.
+    /// Public so consumer-owned dispatchers can emit the same signal.
+    /// </summary>
+    public static void RecordRetriesBeforeSuccess(int retries)
+        => RetriesBeforeSuccess.Record(System.Math.Max(0, retries));
 }

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/OutboxDispatcherHostedService.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/OutboxDispatcherHostedService.cs
@@ -209,6 +209,11 @@ public sealed class OutboxDispatcherHostedService : BackgroundService
             // persistence would double-count on a SaveChanges failure that re-dispatches
             // the row on the next cycle.
             int? pendingRowPayloadBytes = null;
+            // v6.5.27: stash the row's retry count captured on the success path and emit it
+            // AFTER SaveChangesAsync confirms persistence, matching the v6.5.16 queue_lag
+            // pattern. Recording before persistence would double-count when SaveChanges fails
+            // and the row is re-dispatched on the next poll.
+            int? pendingRetriesBeforeSuccess = null;
             Activity? activity = null;
             if (!string.IsNullOrEmpty(msg.TraceParent)
                 && ActivityContext.TryParse(msg.TraceParent, msg.TraceState, out var parentContext))
@@ -301,6 +306,10 @@ public sealed class OutboxDispatcherHostedService : BackgroundService
                         // v6.5.19: stash for post-SaveChanges emit so a SaveChanges
                         // failure does NOT cause a double count on re-dispatch.
                         pendingRowPayloadBytes = msg.Payload?.Length;
+                        // v6.5.27: capture the retry count this successful row carried so the
+                        // retries_before_success histogram is emitted post-persist alongside
+                        // queue_lag and row_size. A first-try success records 0.
+                        pendingRetriesBeforeSuccess = msg.RetryCount;
                     }
                 }
             }
@@ -346,6 +355,11 @@ public sealed class OutboxDispatcherHostedService : BackgroundService
                 {
                     OutboxDispatcherDiagnostics.RecordRowPayloadSize(bytes);
                     pendingRowPayloadBytes = null;
+                }
+                if (pendingRetriesBeforeSuccess is { } retries)
+                {
+                    OutboxDispatcherDiagnostics.RecordRetriesBeforeSuccess(retries);
+                    pendingRetriesBeforeSuccess = null;
                 }
             }
             catch (OperationCanceledException)

--- a/src/Moongazing.OrionGuard.Grpc/Moongazing.OrionGuard.Grpc.csproj
+++ b/src/Moongazing.OrionGuard.Grpc/Moongazing.OrionGuard.Grpc.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Grpc</PackageId>
-    <Version>6.5.26</Version>
+    <Version>6.5.27</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>gRPC integration for OrionGuard validation library. Provides server interceptor for automatic request validation in gRPC services.</Description>
     <PackageTags>guard;validation;grpc;interceptor;protobuf;microservices</PackageTags>

--- a/src/Moongazing.OrionGuard.Locks.Redis/Moongazing.OrionGuard.Locks.Redis.csproj
+++ b/src/Moongazing.OrionGuard.Locks.Redis/Moongazing.OrionGuard.Locks.Redis.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Locks.Redis</PackageId>
-    <Version>6.5.26</Version>
+    <Version>6.5.27</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Redis-backed IDistributedLock for OrionGuard.EntityFrameworkCore's outbox dispatcher. Bridges OrionGuard's IDistributedLock contract to the OrionLock.Redis backend so multi-instance outbox workers can share a Redis-coordinated lease instead of the default SkipLocked DB lock.</Description>
     <PackageTags>guard;outbox;distributed-lock;redis;orionlock;entity-framework-core;efcore</PackageTags>

--- a/src/Moongazing.OrionGuard.MediatR/Moongazing.OrionGuard.MediatR.csproj
+++ b/src/Moongazing.OrionGuard.MediatR/Moongazing.OrionGuard.MediatR.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.MediatR</PackageId>
-    <Version>6.5.26</Version>
+    <Version>6.5.27</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>MediatR integration for OrionGuard validation library. Provides ValidationBehavior pipeline behavior for automatic request validation in CQRS pipelines.</Description>
     <PackageTags>guard;validation;mediatr;cqrs;pipeline;behavior</PackageTags>

--- a/src/Moongazing.OrionGuard.OpenTelemetry/Moongazing.OrionGuard.OpenTelemetry.csproj
+++ b/src/Moongazing.OrionGuard.OpenTelemetry/Moongazing.OrionGuard.OpenTelemetry.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.OpenTelemetry</PackageId>
-    <Version>6.5.26</Version>
+    <Version>6.5.27</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>OpenTelemetry integration for OrionGuard validation library. Provides validation metrics (success/failure rates, latency) and distributed tracing spans.</Description>
     <PackageTags>guard;validation;opentelemetry;metrics;tracing;observability</PackageTags>

--- a/src/Moongazing.OrionGuard.Outbox.Dashboard/Moongazing.OrionGuard.Outbox.Dashboard.csproj
+++ b/src/Moongazing.OrionGuard.Outbox.Dashboard/Moongazing.OrionGuard.Outbox.Dashboard.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904;AD0001</NoWarn>
     <PackageId>OrionGuard.Outbox.Dashboard</PackageId>
-    <Version>6.5.26</Version>
+    <Version>6.5.27</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Outbox operator dashboard for OrionGuard. Maps an authorized listing of failed / poisoned messages from the consumer's DbContext to an ASP.NET Core endpoint group, plus POST /{id}/replay and POST /{id}/discard mutation endpoints (v6.5.5) with an optional OnMutation audit hook.</Description>
     <PackageTags>guard;outbox;dashboard;aspnetcore;poisoned-messages;dead-letter</PackageTags>

--- a/src/Moongazing.OrionGuard.Outbox.PostgresNotify/Moongazing.OrionGuard.Outbox.PostgresNotify.csproj
+++ b/src/Moongazing.OrionGuard.Outbox.PostgresNotify/Moongazing.OrionGuard.Outbox.PostgresNotify.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Outbox.PostgresNotify</PackageId>
-    <Version>6.5.26</Version>
+    <Version>6.5.27</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Postgres LISTEN/NOTIFY backed IOutboxWakeSignal for OrionGuard.EntityFrameworkCore. Replaces the v6.5.1 polling fallback with an event-driven wake on every committed outbox row when the consumer's database is PostgreSQL. Falls back to polling cleanly when the LISTEN connection is unreachable.</Description>
     <PackageTags>guard;outbox;postgres;npgsql;listen;notify;push;dispatch;entity-framework-core;efcore</PackageTags>

--- a/src/Moongazing.OrionGuard.Outbox.SqlServerBroker/Moongazing.OrionGuard.Outbox.SqlServerBroker.csproj
+++ b/src/Moongazing.OrionGuard.Outbox.SqlServerBroker/Moongazing.OrionGuard.Outbox.SqlServerBroker.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Outbox.SqlServerBroker</PackageId>
-    <Version>6.5.26</Version>
+    <Version>6.5.27</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>SQL Server Service Broker backed IOutboxWakeSignal for OrionGuard.EntityFrameworkCore. Sibling to OrionGuard.Outbox.PostgresNotify (v6.5.2) for the SQL Server provider. Replaces the v6.5.1 polling-only fallback with an event-driven wake on every committed outbox row via Service Broker's queueing primitives.</Description>
     <PackageTags>guard;outbox;sqlserver;service-broker;push;dispatch;entity-framework-core;efcore</PackageTags>

--- a/src/Moongazing.OrionGuard.SignalR/Moongazing.OrionGuard.SignalR.csproj
+++ b/src/Moongazing.OrionGuard.SignalR/Moongazing.OrionGuard.SignalR.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.SignalR</PackageId>
-    <Version>6.5.26</Version>
+    <Version>6.5.27</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>SignalR integration for OrionGuard validation library. Provides Hub filter for automatic method parameter validation.</Description>
     <PackageTags>guard;validation;signalr;realtime;hub;filter</PackageTags>

--- a/src/Moongazing.OrionGuard.Swagger/Moongazing.OrionGuard.Swagger.csproj
+++ b/src/Moongazing.OrionGuard.Swagger/Moongazing.OrionGuard.Swagger.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Swagger</PackageId>
-    <Version>6.5.26</Version>
+    <Version>6.5.27</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Swagger/OpenAPI integration for OrionGuard. Auto-generates OpenAPI constraints from OrionGuard validation attributes.</Description>
     <PackageTags>guard;validation;swagger;openapi;swashbuckle</PackageTags>

--- a/src/Moongazing.OrionGuard.Testing/Moongazing.OrionGuard.Testing.csproj
+++ b/src/Moongazing.OrionGuard.Testing/Moongazing.OrionGuard.Testing.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Testing</PackageId>
-    <Version>6.5.26</Version>
+    <Version>6.5.27</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Testing helpers for OrionGuard. Provides DomainEventCapture and InMemoryDomainEventDispatcher with framework-agnostic assertions (no xUnit / NUnit / FluentAssertions dependency). Works with any test runner.</Description>
     <PackageTags>guard;validation;testing;ddd;domain-events;assertions;test-helpers</PackageTags>

--- a/src/Moongazing.OrionGuard/Moongazing.OrionGuard.csproj
+++ b/src/Moongazing.OrionGuard/Moongazing.OrionGuard.csproj
@@ -16,7 +16,7 @@
 		<OutputType>Library</OutputType>
 
 		<PackageId>OrionGuard</PackageId>
-		<Version>6.5.26</Version>
+		<Version>6.5.27</Version>
 		<Authors>Tunahan Ali Ozturk</Authors>
 		<Company>Tunahan Ali Ozturk</Company>
 		<GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/RetriesBeforeSuccessHistogramTests.cs
+++ b/tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/RetriesBeforeSuccessHistogramTests.cs
@@ -1,0 +1,56 @@
+namespace Moongazing.OrionGuard.EntityFrameworkCore.Tests.Outbox;
+
+using System.Diagnostics.Metrics;
+using Moongazing.OrionGuard.EntityFrameworkCore.Outbox;
+using Xunit;
+
+public sealed class RetriesBeforeSuccessHistogramTests
+{
+    private const string InstrumentName = "orionguard.outbox.dispatcher.retries_before_success";
+
+    private static System.Collections.Generic.List<int> Capture(System.Action act)
+    {
+        var samples = new System.Collections.Generic.List<int>();
+        using var listener = new MeterListener();
+        listener.InstrumentPublished = (instrument, l) =>
+        {
+            if (instrument.Meter.Name == OutboxDispatcherDiagnostics.MeterName
+                && instrument.Name == InstrumentName)
+            {
+                l.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<int>((_, val, _, _) =>
+        {
+            lock (samples) { samples.Add(val); }
+        });
+        listener.Start();
+
+        act();
+
+        lock (samples) { return new System.Collections.Generic.List<int>(samples); }
+    }
+
+    [Fact]
+    public void RecordRetriesBeforeSuccess_emits_a_first_try_zero()
+    {
+        // A first-try success (RetryCount 0) IS recorded: the fraction of zeros is the signal.
+        var samples = Capture(() => OutboxDispatcherDiagnostics.RecordRetriesBeforeSuccess(0));
+        Assert.Contains(0, samples);
+    }
+
+    [Fact]
+    public void RecordRetriesBeforeSuccess_emits_the_retry_count()
+    {
+        var samples = Capture(() => OutboxDispatcherDiagnostics.RecordRetriesBeforeSuccess(3));
+        Assert.Contains(3, samples);
+    }
+
+    [Fact]
+    public void RecordRetriesBeforeSuccess_clamps_negative_to_zero()
+    {
+        var samples = Capture(() => OutboxDispatcherDiagnostics.RecordRetriesBeforeSuccess(-2));
+        Assert.Contains(0, samples);
+        Assert.DoesNotContain(-2, samples);
+    }
+}


### PR DESCRIPTION
## Summary

Adds `orionguard.outbox.dispatcher.retries_before_success` (`Histogram<int>`), recording the retry count a row had accumulated at the moment it dispatched successfully (its `RetryCount` on the success path: 0 = succeeded on the first attempt).

It measures the **successful** side of the dispatch loop, complementing the v6.5.18 `errors` counter (failures) and the dead-letter path (terminal only), so operators can answer: *are retries quietly papering over downstream flakiness?*

- Healthy system sits at p50 = 0; a rising upper percentile means rows are increasingly succeeding only after transient downstream failures.
- Unlike the batch-size histograms, the **zero sample IS recorded** here: the fraction of first-try successes is exactly the signal, so dropping zeros would erase the healthy baseline.
- Emitted **post-persist** (after `SaveChangesAsync`), alongside `queue_lag` (v6.5.16) and `row_size_bytes` (v6.5.19), so a SaveChanges failure that re-dispatches the row does not double-count.
- Public `OutboxDispatcherDiagnostics.RecordRetriesBeforeSuccess(int)` helper (negatives clamp to 0).

## Tests

- `RetriesBeforeSuccessHistogramTests` (3): first-try zero recorded, retry count emitted, negative clamps to 0.
- Full Outbox suite green (114/114). EFCore project builds clean under `-warnaserror`.

## Version

6.5.26 -> 6.5.27 across all 14 packages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new observability metric to track outbox dispatcher retry behavior, capturing retry counts at successful dispatch time including zero for first-attempt success.
  * Introduced a public diagnostics helper for recording retry metrics with automatic negative value handling.

* **Tests**
  * Added test coverage for retry behavior metric recording and negative value clamping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->