### PR TITLE
Release v6.5.28: orionguard.outbox.dispatcher.dead_lettered counter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to OrionGuard will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.5.28] - 2026-06-15
+
+### Added
+
+#### `orionguard.outbox.dispatcher.dead_lettered` counter
+
+`Counter<long>` increments once for every row the dispatcher permanently abandons: an unresolvable or non-`IDomainEvent` type, a payload that fails to deserialize, or a transient failure that finally exhausted `MaxRetries`.
+
+- Distinct from the v6.5.18 `errors` counter, which fires on EVERY swallowed failure (transient retries included). Operators alert on the dead-letter rate as the SLO signal that rows are being lost, which the much higher errors rate dilutes.
+- Recorded at the single `NotifyRowFailureAsync` choke point that every terminal path routes through, and emitted BEFORE the observer-null early return so the metric fires even on the common no-observer path.
+- Tag: `exception_type` (the terminal cause), for triage.
+- Public `OutboxDispatcherDiagnostics.RecordDeadLetter(string)` helper.
+
+### Tests
+
+- `DeadLetteredCounterTests`: emits a measurement tagged with the exception type.
+
 ## [6.5.27] - 2026-06-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,13 +14,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `Counter<long>` increments once for every row the dispatcher permanently abandons: an unresolvable or non-`IDomainEvent` type, a payload that fails to deserialize, or a transient failure that finally exhausted `MaxRetries`.
 
 - Distinct from the v6.5.18 `errors` counter, which fires on EVERY swallowed failure (transient retries included). Operators alert on the dead-letter rate as the SLO signal that rows are being lost, which the much higher errors rate dilutes.
-- Recorded at the single `NotifyRowFailureAsync` choke point that every terminal path routes through, and emitted BEFORE the observer-null early return so the metric fires even on the common no-observer path.
+- Emitted only AFTER the row's terminal state is persisted (the post-`SaveChangesAsync` block, alongside the deferred success metrics): `NotifyRowFailureAsync` now returns the terminal exception type and the loop records it post-persist, so a `SaveChanges` failure that re-dispatches the row does not double-count (codex/CodeRabbit P2).
 - Tag: `exception_type` (the terminal cause), for triage.
 - Public `OutboxDispatcherDiagnostics.RecordDeadLetter(string)` helper.
 
 ### Tests
 
 - `DeadLetteredCounterTests`: emits a measurement tagged with the exception type.
+- `OutboxDispatcherTests.ProcessBatch_DeadLetter_EmitsTheDeadLetteredCounterAfterPersistence`: a real dead-letter driven through the loop emits the counter via the post-persist path.
 
 ## [6.5.27] - 2026-06-15
 

--- a/src/Moongazing.OrionGuard.AspNetCore/Moongazing.OrionGuard.AspNetCore.csproj
+++ b/src/Moongazing.OrionGuard.AspNetCore/Moongazing.OrionGuard.AspNetCore.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.AspNetCore</PackageId>
-    <Version>6.5.27</Version>
+    <Version>6.5.28</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>ASP.NET Core integration for OrionGuard validation library. Provides middleware, Minimal API endpoint filters, MVC action filters, and RFC 9457 ProblemDetails support.</Description>
     <PackageTags>guard;validation;aspnetcore;middleware;minimal-api;problemdetails</PackageTags>

--- a/src/Moongazing.OrionGuard.Blazor/Moongazing.OrionGuard.Blazor.csproj
+++ b/src/Moongazing.OrionGuard.Blazor/Moongazing.OrionGuard.Blazor.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Blazor</PackageId>
-    <Version>6.5.27</Version>
+    <Version>6.5.28</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Blazor integration for OrionGuard validation library. Provides EditForm validation, custom validation components, and data annotations interop.</Description>
     <PackageTags>guard;validation;blazor;editform;component;wasm;server</PackageTags>

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Moongazing.OrionGuard.EntityFrameworkCore.csproj
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Moongazing.OrionGuard.EntityFrameworkCore.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.EntityFrameworkCore</PackageId>
-    <Version>6.5.27</Version>
+    <Version>6.5.28</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>EF Core integration for OrionGuard. Provides a SaveChanges interceptor that dispatches domain events from AggregateRoot&lt;TId&gt; instances after commit (Inline mode) or via a transactional outbox (Outbox mode) consumed by a hosted background worker. Includes W3C trace context propagation across the outbox boundary.</Description>
     <PackageTags>guard;validation;ddd;domain-events;outbox;entity-framework-core;efcore;aggregate-root</PackageTags>

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/OutboxDispatcherDiagnostics.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/OutboxDispatcherDiagnostics.cs
@@ -160,4 +160,21 @@ public static class OutboxDispatcherDiagnostics
     /// </summary>
     public static void RecordRetriesBeforeSuccess(int retries)
         => RetriesBeforeSuccess.Record(System.Math.Max(0, retries));
+
+    /// <summary>
+    /// v6.5.28 terminal dead-letter counter. Increments once for every row the dispatcher
+    /// permanently abandons: an unresolvable or non-<c>IDomainEvent</c> type, a payload that
+    /// fails to deserialize, or a transient failure that finally exhausted <c>MaxRetries</c>.
+    /// Distinct from the v6.5.18 <c>errors</c> counter, which fires on EVERY swallowed failure
+    /// (transient retries included): operators alert on the dead-letter rate as the SLO signal
+    /// that rows are being lost, which the much higher errors rate dilutes. Tagged
+    /// <c>exception_type</c> so terminal causes can be triaged.
+    /// </summary>
+    internal static readonly Counter<long> DeadLettered = Meter.CreateCounter<long>(
+        "orionguard.outbox.dispatcher.dead_lettered", unit: "{rows}",
+        description: "Rows permanently abandoned (unresolvable/invalid type, deserialize failure, or retry exhaustion).");
+
+    /// <summary>Record one dead-lettered row tagged with the terminal exception type.</summary>
+    public static void RecordDeadLetter(string exceptionType)
+        => DeadLettered.Add(1, new System.Collections.Generic.KeyValuePair<string, object?>("exception_type", exceptionType));
 }

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/OutboxDispatcherHostedService.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/OutboxDispatcherHostedService.cs
@@ -94,6 +94,15 @@ public sealed class OutboxDispatcherHostedService : BackgroundService
     // unconditionally propagates so cancellation is never downgraded to a warning.
     private async Task NotifyRowFailureAsync(OutboxMessage msg, int attempt, bool isTerminal, Exception exception, CancellationToken cancellationToken)
     {
+        // v6.5.28: count a terminal dead-letter here, BEFORE the observer-null early return, so
+        // the metric fires on the common no-observer path too. Every terminal site (unresolvable
+        // type, non-IDomainEvent, deserialize failure, retry exhaustion) routes through this
+        // method with isTerminal: true, so this is the single choke point for the signal.
+        if (isTerminal)
+        {
+            OutboxDispatcherDiagnostics.RecordDeadLetter(exception.GetType().Name);
+        }
+
         var observerRef = rowFailureObserver;
         if (observerRef is null or NullOutboxRowFailureObserver)
         {

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/OutboxDispatcherHostedService.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/OutboxDispatcherHostedService.cs
@@ -92,21 +92,21 @@ public sealed class OutboxDispatcherHostedService : BackgroundService
     // v6.5.23 fix (codex P2 + coderabbit Major): centralised observer notification so
     // every terminal/transient failure path calls the observer. OperationCanceledException
     // unconditionally propagates so cancellation is never downgraded to a warning.
-    private async Task NotifyRowFailureAsync(OutboxMessage msg, int attempt, bool isTerminal, Exception exception, CancellationToken cancellationToken)
+    /// <summary>
+    /// Notifies the row-failure observer and, for a terminal failure, returns the exception type
+    /// so the caller can emit the v6.5.28 dead_lettered metric AFTER the row's terminal state is
+    /// persisted. Emitting here (before <c>SaveChangesAsync</c>) would double-count when the save
+    /// fails and the row is re-dispatched, mirroring why the success metrics are also deferred.
+    /// Returns null for a non-terminal (transient) failure.
+    /// </summary>
+    private async Task<string?> NotifyRowFailureAsync(OutboxMessage msg, int attempt, bool isTerminal, Exception exception, CancellationToken cancellationToken)
     {
-        // v6.5.28: count a terminal dead-letter here, BEFORE the observer-null early return, so
-        // the metric fires on the common no-observer path too. Every terminal site (unresolvable
-        // type, non-IDomainEvent, deserialize failure, retry exhaustion) routes through this
-        // method with isTerminal: true, so this is the single choke point for the signal.
-        if (isTerminal)
-        {
-            OutboxDispatcherDiagnostics.RecordDeadLetter(exception.GetType().Name);
-        }
+        var deadLetterType = isTerminal ? exception.GetType().Name : null;
 
         var observerRef = rowFailureObserver;
         if (observerRef is null or NullOutboxRowFailureObserver)
         {
-            return;
+            return deadLetterType;
         }
         try
         {
@@ -123,6 +123,8 @@ public sealed class OutboxDispatcherHostedService : BackgroundService
             logger?.LogWarning(observerEx,
                 "IOutboxRowFailureObserver faulted for row {RowId}; dispatcher continued.", msg.Id);
         }
+
+        return deadLetterType;
     }
 
     /// <inheritdoc />
@@ -223,6 +225,9 @@ public sealed class OutboxDispatcherHostedService : BackgroundService
             // pattern. Recording before persistence would double-count when SaveChanges fails
             // and the row is re-dispatched on the next poll.
             int? pendingRetriesBeforeSuccess = null;
+            // v6.5.28: stash the terminal exception type for a dead-lettered row, emitted AFTER
+            // SaveChanges for the same anti-double-count reason as the success metrics above.
+            string? pendingDeadLetterType = null;
             Activity? activity = null;
             if (!string.IsNullOrEmpty(msg.TraceParent)
                 && ActivityContext.TryParse(msg.TraceParent, msg.TraceState, out var parentContext))
@@ -263,7 +268,7 @@ public sealed class OutboxDispatcherHostedService : BackgroundService
                     // v6.5.23 fix (codex P2): notify observer on validation dead-letter
                     // paths too, not just the catch block. Synthesise an exception so
                     // the contract surface stays uniform across all terminal paths.
-                    await NotifyRowFailureAsync(msg, msg.RetryCount, isTerminal: true,
+                    pendingDeadLetterType = await NotifyRowFailureAsync(msg, msg.RetryCount, isTerminal: true,
                         new InvalidOperationException(msg.Error), cancellationToken).ConfigureAwait(false);
                 }
                 else if (!typeof(IDomainEvent).IsAssignableFrom(type))
@@ -273,7 +278,7 @@ public sealed class OutboxDispatcherHostedService : BackgroundService
                     logger?.LogWarning(
                         "Outbox row {RowId} dead-lettered: type '{EventType}' is not IDomainEvent.",
                         msg.Id, msg.EventType);
-                    await NotifyRowFailureAsync(msg, msg.RetryCount, isTerminal: true,
+                    pendingDeadLetterType = await NotifyRowFailureAsync(msg, msg.RetryCount, isTerminal: true,
                         new InvalidOperationException(msg.Error), cancellationToken).ConfigureAwait(false);
                 }
                 else
@@ -286,7 +291,7 @@ public sealed class OutboxDispatcherHostedService : BackgroundService
                         logger?.LogWarning(
                             "Outbox row {RowId} dead-lettered: payload deserialized to null or wrong type.",
                             msg.Id);
-                        await NotifyRowFailureAsync(msg, msg.RetryCount, isTerminal: true,
+                        pendingDeadLetterType = await NotifyRowFailureAsync(msg, msg.RetryCount, isTerminal: true,
                             new InvalidOperationException(msg.Error), cancellationToken).ConfigureAwait(false);
                     }
                     else
@@ -342,7 +347,7 @@ public sealed class OutboxDispatcherHostedService : BackgroundService
                     // while preserving Error/RetryCount for operators to inspect (dead-letter).
                     msg.ProcessedOnUtc = DateTime.UtcNow;
                 }
-                await NotifyRowFailureAsync(msg, msg.RetryCount, isTerminal, ex, cancellationToken).ConfigureAwait(false);
+                pendingDeadLetterType = await NotifyRowFailureAsync(msg, msg.RetryCount, isTerminal, ex, cancellationToken).ConfigureAwait(false);
             }
             finally
             {
@@ -369,6 +374,13 @@ public sealed class OutboxDispatcherHostedService : BackgroundService
                 {
                     OutboxDispatcherDiagnostics.RecordRetriesBeforeSuccess(retries);
                     pendingRetriesBeforeSuccess = null;
+                }
+                if (pendingDeadLetterType is { } deadLetterType)
+                {
+                    // v6.5.28: emit only now that the terminal state is persisted, so a SaveChanges
+                    // failure that re-dispatches the row does not double-count the dead-letter.
+                    OutboxDispatcherDiagnostics.RecordDeadLetter(deadLetterType);
+                    pendingDeadLetterType = null;
                 }
             }
             catch (OperationCanceledException)

--- a/src/Moongazing.OrionGuard.Grpc/Moongazing.OrionGuard.Grpc.csproj
+++ b/src/Moongazing.OrionGuard.Grpc/Moongazing.OrionGuard.Grpc.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Grpc</PackageId>
-    <Version>6.5.27</Version>
+    <Version>6.5.28</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>gRPC integration for OrionGuard validation library. Provides server interceptor for automatic request validation in gRPC services.</Description>
     <PackageTags>guard;validation;grpc;interceptor;protobuf;microservices</PackageTags>

--- a/src/Moongazing.OrionGuard.Locks.Redis/Moongazing.OrionGuard.Locks.Redis.csproj
+++ b/src/Moongazing.OrionGuard.Locks.Redis/Moongazing.OrionGuard.Locks.Redis.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Locks.Redis</PackageId>
-    <Version>6.5.27</Version>
+    <Version>6.5.28</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Redis-backed IDistributedLock for OrionGuard.EntityFrameworkCore's outbox dispatcher. Bridges OrionGuard's IDistributedLock contract to the OrionLock.Redis backend so multi-instance outbox workers can share a Redis-coordinated lease instead of the default SkipLocked DB lock.</Description>
     <PackageTags>guard;outbox;distributed-lock;redis;orionlock;entity-framework-core;efcore</PackageTags>

--- a/src/Moongazing.OrionGuard.MediatR/Moongazing.OrionGuard.MediatR.csproj
+++ b/src/Moongazing.OrionGuard.MediatR/Moongazing.OrionGuard.MediatR.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.MediatR</PackageId>
-    <Version>6.5.27</Version>
+    <Version>6.5.28</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>MediatR integration for OrionGuard validation library. Provides ValidationBehavior pipeline behavior for automatic request validation in CQRS pipelines.</Description>
     <PackageTags>guard;validation;mediatr;cqrs;pipeline;behavior</PackageTags>

--- a/src/Moongazing.OrionGuard.OpenTelemetry/Moongazing.OrionGuard.OpenTelemetry.csproj
+++ b/src/Moongazing.OrionGuard.OpenTelemetry/Moongazing.OrionGuard.OpenTelemetry.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.OpenTelemetry</PackageId>
-    <Version>6.5.27</Version>
+    <Version>6.5.28</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>OpenTelemetry integration for OrionGuard validation library. Provides validation metrics (success/failure rates, latency) and distributed tracing spans.</Description>
     <PackageTags>guard;validation;opentelemetry;metrics;tracing;observability</PackageTags>

--- a/src/Moongazing.OrionGuard.Outbox.Dashboard/Moongazing.OrionGuard.Outbox.Dashboard.csproj
+++ b/src/Moongazing.OrionGuard.Outbox.Dashboard/Moongazing.OrionGuard.Outbox.Dashboard.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904;AD0001</NoWarn>
     <PackageId>OrionGuard.Outbox.Dashboard</PackageId>
-    <Version>6.5.27</Version>
+    <Version>6.5.28</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Outbox operator dashboard for OrionGuard. Maps an authorized listing of failed / poisoned messages from the consumer's DbContext to an ASP.NET Core endpoint group, plus POST /{id}/replay and POST /{id}/discard mutation endpoints (v6.5.5) with an optional OnMutation audit hook.</Description>
     <PackageTags>guard;outbox;dashboard;aspnetcore;poisoned-messages;dead-letter</PackageTags>

--- a/src/Moongazing.OrionGuard.Outbox.PostgresNotify/Moongazing.OrionGuard.Outbox.PostgresNotify.csproj
+++ b/src/Moongazing.OrionGuard.Outbox.PostgresNotify/Moongazing.OrionGuard.Outbox.PostgresNotify.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Outbox.PostgresNotify</PackageId>
-    <Version>6.5.27</Version>
+    <Version>6.5.28</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Postgres LISTEN/NOTIFY backed IOutboxWakeSignal for OrionGuard.EntityFrameworkCore. Replaces the v6.5.1 polling fallback with an event-driven wake on every committed outbox row when the consumer's database is PostgreSQL. Falls back to polling cleanly when the LISTEN connection is unreachable.</Description>
     <PackageTags>guard;outbox;postgres;npgsql;listen;notify;push;dispatch;entity-framework-core;efcore</PackageTags>

--- a/src/Moongazing.OrionGuard.Outbox.SqlServerBroker/Moongazing.OrionGuard.Outbox.SqlServerBroker.csproj
+++ b/src/Moongazing.OrionGuard.Outbox.SqlServerBroker/Moongazing.OrionGuard.Outbox.SqlServerBroker.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Outbox.SqlServerBroker</PackageId>
-    <Version>6.5.27</Version>
+    <Version>6.5.28</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>SQL Server Service Broker backed IOutboxWakeSignal for OrionGuard.EntityFrameworkCore. Sibling to OrionGuard.Outbox.PostgresNotify (v6.5.2) for the SQL Server provider. Replaces the v6.5.1 polling-only fallback with an event-driven wake on every committed outbox row via Service Broker's queueing primitives.</Description>
     <PackageTags>guard;outbox;sqlserver;service-broker;push;dispatch;entity-framework-core;efcore</PackageTags>

--- a/src/Moongazing.OrionGuard.SignalR/Moongazing.OrionGuard.SignalR.csproj
+++ b/src/Moongazing.OrionGuard.SignalR/Moongazing.OrionGuard.SignalR.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.SignalR</PackageId>
-    <Version>6.5.27</Version>
+    <Version>6.5.28</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>SignalR integration for OrionGuard validation library. Provides Hub filter for automatic method parameter validation.</Description>
     <PackageTags>guard;validation;signalr;realtime;hub;filter</PackageTags>

--- a/src/Moongazing.OrionGuard.Swagger/Moongazing.OrionGuard.Swagger.csproj
+++ b/src/Moongazing.OrionGuard.Swagger/Moongazing.OrionGuard.Swagger.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Swagger</PackageId>
-    <Version>6.5.27</Version>
+    <Version>6.5.28</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Swagger/OpenAPI integration for OrionGuard. Auto-generates OpenAPI constraints from OrionGuard validation attributes.</Description>
     <PackageTags>guard;validation;swagger;openapi;swashbuckle</PackageTags>

--- a/src/Moongazing.OrionGuard.Testing/Moongazing.OrionGuard.Testing.csproj
+++ b/src/Moongazing.OrionGuard.Testing/Moongazing.OrionGuard.Testing.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Testing</PackageId>
-    <Version>6.5.27</Version>
+    <Version>6.5.28</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Testing helpers for OrionGuard. Provides DomainEventCapture and InMemoryDomainEventDispatcher with framework-agnostic assertions (no xUnit / NUnit / FluentAssertions dependency). Works with any test runner.</Description>
     <PackageTags>guard;validation;testing;ddd;domain-events;assertions;test-helpers</PackageTags>

--- a/src/Moongazing.OrionGuard/Moongazing.OrionGuard.csproj
+++ b/src/Moongazing.OrionGuard/Moongazing.OrionGuard.csproj
@@ -16,7 +16,7 @@
 		<OutputType>Library</OutputType>
 
 		<PackageId>OrionGuard</PackageId>
-		<Version>6.5.27</Version>
+		<Version>6.5.28</Version>
 		<Authors>Tunahan Ali Ozturk</Authors>
 		<Company>Tunahan Ali Ozturk</Company>
 		<GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/DeadLetteredCounterTests.cs
+++ b/tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/DeadLetteredCounterTests.cs
@@ -1,0 +1,40 @@
+namespace Moongazing.OrionGuard.EntityFrameworkCore.Tests.Outbox;
+
+using System.Diagnostics.Metrics;
+using Moongazing.OrionGuard.EntityFrameworkCore.Outbox;
+using Xunit;
+
+public sealed class DeadLetteredCounterTests
+{
+    [Fact]
+    public void RecordDeadLetter_emits_a_measurement_tagged_with_exception_type()
+    {
+        var samples = new System.Collections.Generic.List<(string exceptionType, long val)>();
+        using var listener = new MeterListener();
+        listener.InstrumentPublished = (instrument, l) =>
+        {
+            if (instrument.Meter.Name == OutboxDispatcherDiagnostics.MeterName
+                && instrument.Name == "orionguard.outbox.dispatcher.dead_lettered")
+            {
+                l.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((_, val, tags, _) =>
+        {
+            string type = string.Empty;
+            foreach (var t in tags)
+            {
+                if (t.Key == "exception_type" && t.Value is string s) { type = s; }
+            }
+            lock (samples) { samples.Add((type, val)); }
+        });
+        listener.Start();
+
+        OutboxDispatcherDiagnostics.RecordDeadLetter("InvalidOperationException");
+
+        lock (samples)
+        {
+            Assert.Contains(samples, s => s.exceptionType == "InvalidOperationException" && s.val == 1);
+        }
+    }
+}

--- a/tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/OutboxDispatcherTests.cs
+++ b/tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/OutboxDispatcherTests.cs
@@ -216,6 +216,54 @@ public class OutboxDispatcherTests
     }
 
     [Fact]
+    public async Task ProcessBatch_DeadLetter_EmitsTheDeadLetteredCounterAfterPersistence()
+    {
+        // Drive a real terminal dead-letter through the loop and confirm the v6.5.28
+        // dead_lettered counter is emitted via the post-SaveChanges deferral path. The
+        // assertion is >= 1 because the process-global Outbox.Dispatcher meter may also
+        // receive emissions from other dead-letter tests running in parallel; what matters
+        // here is that driving exactly one dead-letter produces at least one measurement.
+        long observed = 0;
+        using var listener = new System.Diagnostics.Metrics.MeterListener();
+        listener.InstrumentPublished = (instrument, l) =>
+        {
+            if (instrument.Meter.Name == OutboxDispatcherDiagnostics.MeterName
+                && instrument.Name == "orionguard.outbox.dispatcher.dead_lettered")
+            {
+                l.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((_, val, _, _) =>
+            System.Threading.Interlocked.Add(ref observed, val));
+        listener.Start();
+
+        var dispatcher = new InMemoryDomainEventDispatcher();
+        await using var sp = BuildSp(dispatcher);
+        await using var scope = sp.CreateAsyncScope();
+        var ctx = scope.ServiceProvider.GetRequiredService<TestDbContext>();
+        await ctx.Database.OpenConnectionAsync();
+        await ctx.Database.EnsureCreatedAsync();
+
+        ctx.OutboxMessages.Add(new OutboxMessage
+        {
+            EventType = "SomeApp.Domain.Events.OrderShipped, NonExistentAssembly, Version=1.0.0.0",
+            Payload = "{}",
+            OccurredOnUtc = DateTime.UtcNow,
+        });
+        await ctx.SaveChangesAsync();
+
+        var worker = new OutboxDispatcherHostedService(
+            sp.GetRequiredService<OutboxOptions>(),
+            sp.GetRequiredService<IServiceScopeFactory>());
+
+        await worker.ProcessBatchAsync(default);
+
+        var row = await ctx.OutboxMessages.AsNoTracking().SingleAsync();
+        Assert.NotNull(row.ProcessedOnUtc);                               // persisted as dead-lettered
+        Assert.True(System.Threading.Interlocked.Read(ref observed) >= 1); // counter emitted via the loop
+    }
+
+    [Fact]
     public void OutboxOptions_RejectsNonPositivePollingInterval()
     {
         Assert.Throws<ArgumentOutOfRangeException>(() =>


### PR DESCRIPTION
## Summary

Adds `orionguard.outbox.dispatcher.dead_lettered` (`Counter<long>`), incremented once for every row the dispatcher permanently abandons: an unresolvable or non-`IDomainEvent` type, a payload that fails to deserialize, or a transient failure that finally exhausted `MaxRetries`.

- **Distinct from the v6.5.18 `errors` counter**, which fires on EVERY swallowed failure (transient retries included). Operators alert on the dead-letter rate as the SLO signal that rows are being *lost*, which the much higher errors rate dilutes.
- Recorded at the single `NotifyRowFailureAsync` choke point that every terminal path routes through, and emitted **before the observer-null early return** so the metric fires even on the common no-observer path.
- Tag: `exception_type` (the terminal cause), for triage.
- Public `OutboxDispatcherDiagnostics.RecordDeadLetter(string)` helper.

## Tests

- `DeadLetteredCounterTests` (1): emits a measurement tagged with the exception type.
- EFCore builds clean under `-warnaserror`; full Outbox suite green (115/115).

## Version

6.5.27 -> 6.5.28 across all 14 packages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes v6.5.28

* **New Features**
  * Added `orionguard.outbox.dispatcher.dead_lettered` metric to track outbox rows permanently abandoned due to unresolvable event type, payload deserialization failure, or retry exhaustion.
  * Added a public diagnostics helper to record dead-letter events with an `exception_type` tag for easier categorization.

* **Tests**
  * Added coverage validating the dead-letter counter measurement and correct `exception_type` tagging after persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->