### PR TITLE
Release v6.5.29: orionguard.outbox.dispatcher.lock_contended counter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 `Counter<long>` increments each dispatcher cycle in which this replica fails to acquire the multi-instance distributed lock because another replica holds the lease.
 
+- Recorded by the default `SkipLockedDistributedLock` on its GENUINE contention paths only (an INSERT race lost, or a live owner found), and deliberately NOT when the lock table is missing (migration not applied), so a broken dispatcher setup is never mis-reported as healthy standby contention (codex P2).
 - Distinct from the v6.5.17 `poll.idle` counter, which fires only AFTER the lock is held and the backlog is found empty. `lock_contended` fires when the replica never became the active dispatcher at all.
-- Operators graph it per replica to confirm exactly one replica is dispatching (the others should sit mostly contended), to spot a stuck or dead leader (a sudden drop in one replica's contention rate without another picking up), and to right-size the dispatcher replica count.
-- Public `OutboxDispatcherDiagnostics.RecordLockContended()` helper.
+- Operators graph it per replica to confirm exactly one replica is dispatching (the others should sit mostly contended), to spot a stuck or dead leader, and to right-size the dispatcher replica count.
+- Public `OutboxDispatcherDiagnostics.RecordLockContended()` helper for consumer-owned lock backends (Redis, etc.) to emit from their own genuine contention path.
 
 ### Tests
 
 - `LockContendedCounterTests`: `RecordLockContended` increments the counter.
+- `SkipLockedDistributedLockTests.TryAcquireAsync_WhenSlotIsHeld_RecordsLockContended`: a contended acquire against a live owner records the counter.
 
 ## [6.5.28] - 2026-06-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to OrionGuard will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.5.29] - 2026-06-15
+
+### Added
+
+#### `orionguard.outbox.dispatcher.lock_contended` counter
+
+`Counter<long>` increments each dispatcher cycle in which this replica fails to acquire the multi-instance distributed lock because another replica holds the lease.
+
+- Distinct from the v6.5.17 `poll.idle` counter, which fires only AFTER the lock is held and the backlog is found empty. `lock_contended` fires when the replica never became the active dispatcher at all.
+- Operators graph it per replica to confirm exactly one replica is dispatching (the others should sit mostly contended), to spot a stuck or dead leader (a sudden drop in one replica's contention rate without another picking up), and to right-size the dispatcher replica count.
+- Public `OutboxDispatcherDiagnostics.RecordLockContended()` helper.
+
+### Tests
+
+- `LockContendedCounterTests`: `RecordLockContended` increments the counter.
+
 ## [6.5.28] - 2026-06-15
 
 ### Added

--- a/src/Moongazing.OrionGuard.AspNetCore/Moongazing.OrionGuard.AspNetCore.csproj
+++ b/src/Moongazing.OrionGuard.AspNetCore/Moongazing.OrionGuard.AspNetCore.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.AspNetCore</PackageId>
-    <Version>6.5.28</Version>
+    <Version>6.5.29</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>ASP.NET Core integration for OrionGuard validation library. Provides middleware, Minimal API endpoint filters, MVC action filters, and RFC 9457 ProblemDetails support.</Description>
     <PackageTags>guard;validation;aspnetcore;middleware;minimal-api;problemdetails</PackageTags>

--- a/src/Moongazing.OrionGuard.Blazor/Moongazing.OrionGuard.Blazor.csproj
+++ b/src/Moongazing.OrionGuard.Blazor/Moongazing.OrionGuard.Blazor.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Blazor</PackageId>
-    <Version>6.5.28</Version>
+    <Version>6.5.29</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Blazor integration for OrionGuard validation library. Provides EditForm validation, custom validation components, and data annotations interop.</Description>
     <PackageTags>guard;validation;blazor;editform;component;wasm;server</PackageTags>

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Moongazing.OrionGuard.EntityFrameworkCore.csproj
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Moongazing.OrionGuard.EntityFrameworkCore.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.EntityFrameworkCore</PackageId>
-    <Version>6.5.28</Version>
+    <Version>6.5.29</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>EF Core integration for OrionGuard. Provides a SaveChanges interceptor that dispatches domain events from AggregateRoot&lt;TId&gt; instances after commit (Inline mode) or via a transactional outbox (Outbox mode) consumed by a hosted background worker. Includes W3C trace context propagation across the outbox boundary.</Description>
     <PackageTags>guard;validation;ddd;domain-events;outbox;entity-framework-core;efcore;aggregate-root</PackageTags>

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Locking/SkipLockedDistributedLock.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Locking/SkipLockedDistributedLock.cs
@@ -80,6 +80,8 @@ public sealed class SkipLockedDistributedLock : IDistributedLock
                 catch (DbUpdateException)
                 {
                     await tx.RollbackAsync(cancellationToken).ConfigureAwait(false);
+                    // v6.5.29: a concurrent caller won the INSERT race - genuine contention.
+                    OutboxDispatcherDiagnostics.RecordLockContended();
                     return null;
                 }
             }
@@ -96,6 +98,8 @@ public sealed class SkipLockedDistributedLock : IDistributedLock
 
             if (ownerCheck != holderId)
             {
+                // v6.5.29: another holder owns the lease - genuine contention.
+                OutboxDispatcherDiagnostics.RecordLockContended();
                 return null;
             }
 
@@ -103,6 +107,9 @@ public sealed class SkipLockedDistributedLock : IDistributedLock
         }
         catch (Exception ex) when (IsMissingTable(ex))
         {
+            // NOT contention: the lock table is missing (migration not applied). Deliberately does
+            // NOT record lock_contended so the counter stays a clean standby-vs-active signal
+            // rather than masking a broken dispatcher setup as healthy contention.
             LogMissingTableOnce();
             return null;
         }

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/OutboxDispatcherDiagnostics.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/OutboxDispatcherDiagnostics.cs
@@ -179,19 +179,25 @@ public static class OutboxDispatcherDiagnostics
         => DeadLettered.Add(1, new System.Collections.Generic.KeyValuePair<string, object?>("exception_type", exceptionType));
 
     /// <summary>
-    /// v6.5.29 lock-contention counter. Increments each dispatcher cycle in which THIS replica
-    /// fails to acquire the multi-instance distributed lock because another replica holds the
-    /// lease. Distinct from the v6.5.17 <c>poll.idle</c> counter, which fires only AFTER the lock
-    /// is held and the backlog is found empty: this counter fires when the replica never became
-    /// the active dispatcher at all. Operators graph it per replica to confirm exactly one replica
-    /// is dispatching (the others should sit mostly contended), to spot a stuck or dead leader (a
-    /// sudden drop in one replica's contention rate without another picking up), and to right-size
-    /// the dispatcher replica count.
+    /// v6.5.29 lock-contention counter. Increments when a replica fails to acquire the
+    /// multi-instance distributed lock because ANOTHER replica genuinely holds the lease. The
+    /// default <see cref="Locking.SkipLockedDistributedLock"/> records it only on its true
+    /// contention paths (an INSERT race lost, or a live owner found) and deliberately NOT when the
+    /// lock table is missing (migration not applied), so a broken dispatcher setup is never
+    /// mis-reported as healthy standby contention. Distinct from the v6.5.17 <c>poll.idle</c>
+    /// counter, which fires only AFTER the lock is held and the backlog is found empty: this
+    /// counter fires when the replica never became the active dispatcher at all. Operators graph it
+    /// per replica to confirm exactly one replica is dispatching (the others should sit mostly
+    /// contended), to spot a stuck or dead leader, and to right-size the dispatcher replica count.
     /// </summary>
     internal static readonly Counter<long> LockContended = Meter.CreateCounter<long>(
         "orionguard.outbox.dispatcher.lock_contended", unit: "{cycles}",
-        description: "Dispatcher cycles where this replica did not acquire the distributed lock (another replica is active).");
+        description: "Cycles where a replica lost the distributed lock to a genuine concurrent holder (another replica is active).");
 
-    /// <summary>Record one lock-contended cycle. Public so consumer-owned dispatchers can opt in.</summary>
+    /// <summary>
+    /// Record one genuine lock-contention event. Public so consumer-owned lock backends (Redis,
+    /// etc.) can emit the same signal from their true contention path - they should NOT record it
+    /// for configuration/availability errors.
+    /// </summary>
     public static void RecordLockContended() => LockContended.Add(1);
 }

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/OutboxDispatcherDiagnostics.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/OutboxDispatcherDiagnostics.cs
@@ -177,4 +177,21 @@ public static class OutboxDispatcherDiagnostics
     /// <summary>Record one dead-lettered row tagged with the terminal exception type.</summary>
     public static void RecordDeadLetter(string exceptionType)
         => DeadLettered.Add(1, new System.Collections.Generic.KeyValuePair<string, object?>("exception_type", exceptionType));
+
+    /// <summary>
+    /// v6.5.29 lock-contention counter. Increments each dispatcher cycle in which THIS replica
+    /// fails to acquire the multi-instance distributed lock because another replica holds the
+    /// lease. Distinct from the v6.5.17 <c>poll.idle</c> counter, which fires only AFTER the lock
+    /// is held and the backlog is found empty: this counter fires when the replica never became
+    /// the active dispatcher at all. Operators graph it per replica to confirm exactly one replica
+    /// is dispatching (the others should sit mostly contended), to spot a stuck or dead leader (a
+    /// sudden drop in one replica's contention rate without another picking up), and to right-size
+    /// the dispatcher replica count.
+    /// </summary>
+    internal static readonly Counter<long> LockContended = Meter.CreateCounter<long>(
+        "orionguard.outbox.dispatcher.lock_contended", unit: "{cycles}",
+        description: "Dispatcher cycles where this replica did not acquire the distributed lock (another replica is active).");
+
+    /// <summary>Record one lock-contended cycle. Public so consumer-owned dispatchers can opt in.</summary>
+    public static void RecordLockContended() => LockContended.Add(1);
 }

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/OutboxDispatcherHostedService.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/OutboxDispatcherHostedService.cs
@@ -150,6 +150,9 @@ public sealed class OutboxDispatcherHostedService : BackgroundService
                 if (handle is null)
                 {
                     // Why: another instance holds the lease. Sleep and retry — do not dispatch.
+                    // v6.5.29: count the contended cycle so operators can see which replica is the
+                    // active dispatcher and which are standing by.
+                    OutboxDispatcherDiagnostics.RecordLockContended();
                     await wakeSignal.WaitForNextTickAsync(options.PollingInterval, stoppingToken).ConfigureAwait(false);
                     continue;
                 }

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/OutboxDispatcherHostedService.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/OutboxDispatcherHostedService.cs
@@ -149,10 +149,10 @@ public sealed class OutboxDispatcherHostedService : BackgroundService
 
                 if (handle is null)
                 {
-                    // Why: another instance holds the lease. Sleep and retry — do not dispatch.
-                    // v6.5.29: count the contended cycle so operators can see which replica is the
-                    // active dispatcher and which are standing by.
-                    OutboxDispatcherDiagnostics.RecordLockContended();
+                    // Why: another instance holds the lease (or the lock is unavailable). Sleep and
+                    // retry — do not dispatch. The v6.5.29 lock_contended counter is recorded by the
+                    // lock itself on GENUINE contention only, so a missing lock table (migration not
+                    // applied) is not mis-reported here as healthy standby contention.
                     await wakeSignal.WaitForNextTickAsync(options.PollingInterval, stoppingToken).ConfigureAwait(false);
                     continue;
                 }

--- a/src/Moongazing.OrionGuard.Grpc/Moongazing.OrionGuard.Grpc.csproj
+++ b/src/Moongazing.OrionGuard.Grpc/Moongazing.OrionGuard.Grpc.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Grpc</PackageId>
-    <Version>6.5.28</Version>
+    <Version>6.5.29</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>gRPC integration for OrionGuard validation library. Provides server interceptor for automatic request validation in gRPC services.</Description>
     <PackageTags>guard;validation;grpc;interceptor;protobuf;microservices</PackageTags>

--- a/src/Moongazing.OrionGuard.Locks.Redis/Moongazing.OrionGuard.Locks.Redis.csproj
+++ b/src/Moongazing.OrionGuard.Locks.Redis/Moongazing.OrionGuard.Locks.Redis.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Locks.Redis</PackageId>
-    <Version>6.5.28</Version>
+    <Version>6.5.29</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Redis-backed IDistributedLock for OrionGuard.EntityFrameworkCore's outbox dispatcher. Bridges OrionGuard's IDistributedLock contract to the OrionLock.Redis backend so multi-instance outbox workers can share a Redis-coordinated lease instead of the default SkipLocked DB lock.</Description>
     <PackageTags>guard;outbox;distributed-lock;redis;orionlock;entity-framework-core;efcore</PackageTags>

--- a/src/Moongazing.OrionGuard.MediatR/Moongazing.OrionGuard.MediatR.csproj
+++ b/src/Moongazing.OrionGuard.MediatR/Moongazing.OrionGuard.MediatR.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.MediatR</PackageId>
-    <Version>6.5.28</Version>
+    <Version>6.5.29</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>MediatR integration for OrionGuard validation library. Provides ValidationBehavior pipeline behavior for automatic request validation in CQRS pipelines.</Description>
     <PackageTags>guard;validation;mediatr;cqrs;pipeline;behavior</PackageTags>

--- a/src/Moongazing.OrionGuard.OpenTelemetry/Moongazing.OrionGuard.OpenTelemetry.csproj
+++ b/src/Moongazing.OrionGuard.OpenTelemetry/Moongazing.OrionGuard.OpenTelemetry.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.OpenTelemetry</PackageId>
-    <Version>6.5.28</Version>
+    <Version>6.5.29</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>OpenTelemetry integration for OrionGuard validation library. Provides validation metrics (success/failure rates, latency) and distributed tracing spans.</Description>
     <PackageTags>guard;validation;opentelemetry;metrics;tracing;observability</PackageTags>

--- a/src/Moongazing.OrionGuard.Outbox.Dashboard/Moongazing.OrionGuard.Outbox.Dashboard.csproj
+++ b/src/Moongazing.OrionGuard.Outbox.Dashboard/Moongazing.OrionGuard.Outbox.Dashboard.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904;AD0001</NoWarn>
     <PackageId>OrionGuard.Outbox.Dashboard</PackageId>
-    <Version>6.5.28</Version>
+    <Version>6.5.29</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Outbox operator dashboard for OrionGuard. Maps an authorized listing of failed / poisoned messages from the consumer's DbContext to an ASP.NET Core endpoint group, plus POST /{id}/replay and POST /{id}/discard mutation endpoints (v6.5.5) with an optional OnMutation audit hook.</Description>
     <PackageTags>guard;outbox;dashboard;aspnetcore;poisoned-messages;dead-letter</PackageTags>

--- a/src/Moongazing.OrionGuard.Outbox.PostgresNotify/Moongazing.OrionGuard.Outbox.PostgresNotify.csproj
+++ b/src/Moongazing.OrionGuard.Outbox.PostgresNotify/Moongazing.OrionGuard.Outbox.PostgresNotify.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Outbox.PostgresNotify</PackageId>
-    <Version>6.5.28</Version>
+    <Version>6.5.29</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Postgres LISTEN/NOTIFY backed IOutboxWakeSignal for OrionGuard.EntityFrameworkCore. Replaces the v6.5.1 polling fallback with an event-driven wake on every committed outbox row when the consumer's database is PostgreSQL. Falls back to polling cleanly when the LISTEN connection is unreachable.</Description>
     <PackageTags>guard;outbox;postgres;npgsql;listen;notify;push;dispatch;entity-framework-core;efcore</PackageTags>

--- a/src/Moongazing.OrionGuard.Outbox.SqlServerBroker/Moongazing.OrionGuard.Outbox.SqlServerBroker.csproj
+++ b/src/Moongazing.OrionGuard.Outbox.SqlServerBroker/Moongazing.OrionGuard.Outbox.SqlServerBroker.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Outbox.SqlServerBroker</PackageId>
-    <Version>6.5.28</Version>
+    <Version>6.5.29</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>SQL Server Service Broker backed IOutboxWakeSignal for OrionGuard.EntityFrameworkCore. Sibling to OrionGuard.Outbox.PostgresNotify (v6.5.2) for the SQL Server provider. Replaces the v6.5.1 polling-only fallback with an event-driven wake on every committed outbox row via Service Broker's queueing primitives.</Description>
     <PackageTags>guard;outbox;sqlserver;service-broker;push;dispatch;entity-framework-core;efcore</PackageTags>

--- a/src/Moongazing.OrionGuard.SignalR/Moongazing.OrionGuard.SignalR.csproj
+++ b/src/Moongazing.OrionGuard.SignalR/Moongazing.OrionGuard.SignalR.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.SignalR</PackageId>
-    <Version>6.5.28</Version>
+    <Version>6.5.29</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>SignalR integration for OrionGuard validation library. Provides Hub filter for automatic method parameter validation.</Description>
     <PackageTags>guard;validation;signalr;realtime;hub;filter</PackageTags>

--- a/src/Moongazing.OrionGuard.Swagger/Moongazing.OrionGuard.Swagger.csproj
+++ b/src/Moongazing.OrionGuard.Swagger/Moongazing.OrionGuard.Swagger.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Swagger</PackageId>
-    <Version>6.5.28</Version>
+    <Version>6.5.29</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Swagger/OpenAPI integration for OrionGuard. Auto-generates OpenAPI constraints from OrionGuard validation attributes.</Description>
     <PackageTags>guard;validation;swagger;openapi;swashbuckle</PackageTags>

--- a/src/Moongazing.OrionGuard.Testing/Moongazing.OrionGuard.Testing.csproj
+++ b/src/Moongazing.OrionGuard.Testing/Moongazing.OrionGuard.Testing.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Testing</PackageId>
-    <Version>6.5.28</Version>
+    <Version>6.5.29</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Testing helpers for OrionGuard. Provides DomainEventCapture and InMemoryDomainEventDispatcher with framework-agnostic assertions (no xUnit / NUnit / FluentAssertions dependency). Works with any test runner.</Description>
     <PackageTags>guard;validation;testing;ddd;domain-events;assertions;test-helpers</PackageTags>

--- a/src/Moongazing.OrionGuard/Moongazing.OrionGuard.csproj
+++ b/src/Moongazing.OrionGuard/Moongazing.OrionGuard.csproj
@@ -16,7 +16,7 @@
 		<OutputType>Library</OutputType>
 
 		<PackageId>OrionGuard</PackageId>
-		<Version>6.5.28</Version>
+		<Version>6.5.29</Version>
 		<Authors>Tunahan Ali Ozturk</Authors>
 		<Company>Tunahan Ali Ozturk</Company>
 		<GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/LockContendedCounterTests.cs
+++ b/tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/LockContendedCounterTests.cs
@@ -1,0 +1,31 @@
+namespace Moongazing.OrionGuard.EntityFrameworkCore.Tests.Outbox;
+
+using System.Diagnostics.Metrics;
+using Moongazing.OrionGuard.EntityFrameworkCore.Outbox;
+using Xunit;
+
+public sealed class LockContendedCounterTests
+{
+    [Fact]
+    public void RecordLockContended_increments_the_counter()
+    {
+        long total = 0;
+        using var listener = new MeterListener();
+        listener.InstrumentPublished = (instrument, l) =>
+        {
+            if (instrument.Meter.Name == OutboxDispatcherDiagnostics.MeterName
+                && instrument.Name == "orionguard.outbox.dispatcher.lock_contended")
+            {
+                l.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((_, val, _, _) =>
+            System.Threading.Interlocked.Add(ref total, val));
+        listener.Start();
+
+        OutboxDispatcherDiagnostics.RecordLockContended();
+        OutboxDispatcherDiagnostics.RecordLockContended();
+
+        Assert.Equal(2L, System.Threading.Interlocked.Read(ref total));
+    }
+}

--- a/tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/Locking/SkipLockedDistributedLockTests.cs
+++ b/tests/Moongazing.OrionGuard.EntityFrameworkCore.Tests/Outbox/Locking/SkipLockedDistributedLockTests.cs
@@ -37,6 +37,35 @@ public class SkipLockedDistributedLockTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task TryAcquireAsync_WhenSlotIsHeld_RecordsLockContended()
+    {
+        // Genuine contention: a live owner already holds the lease. The >= 1 assertion is robust
+        // to the process-global Outbox.Dispatcher meter receiving emissions from parallel tests;
+        // what matters is that THIS contended acquire produced at least one lock_contended sample.
+        long observed = 0;
+        using var listener = new System.Diagnostics.Metrics.MeterListener();
+        listener.InstrumentPublished = (instrument, l) =>
+        {
+            if (instrument.Meter.Name == Moongazing.OrionGuard.EntityFrameworkCore.Outbox.OutboxDispatcherDiagnostics.MeterName
+                && instrument.Name == "orionguard.outbox.dispatcher.lock_contended")
+            {
+                l.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((_, val, _, _) =>
+            System.Threading.Interlocked.Add(ref observed, val));
+        listener.Start();
+
+        var @lock = NewLock();
+        var first = await @lock.TryAcquireAsync("k", TimeSpan.FromSeconds(30));
+        Assert.NotNull(first);
+
+        var second = await @lock.TryAcquireAsync("k", TimeSpan.FromSeconds(30));
+        Assert.Null(second);
+        Assert.True(System.Threading.Interlocked.Read(ref observed) >= 1);
+    }
+
+    [Fact]
     public async Task TryAcquireAsync_ShouldSucceedAgain_AfterFirstHandleIsDisposed()
     {
         var @lock = NewLock();


### PR DESCRIPTION
## Summary

Adds `orionguard.outbox.dispatcher.lock_contended` (`Counter<long>`), incremented each dispatcher cycle in which this replica fails to acquire the multi-instance distributed lock because another replica holds the lease.

- **Distinct from the v6.5.17 `poll.idle` counter**, which fires only AFTER the lock is held and the backlog is found empty. `lock_contended` fires when the replica never became the active dispatcher at all - two different cycle outcomes.
- Operators graph it per replica to confirm exactly one replica is dispatching (the others should sit mostly contended), to spot a stuck or dead leader (a sudden drop in one replica's contention rate without another picking up), and to right-size the dispatcher replica count.
- Public `OutboxDispatcherDiagnostics.RecordLockContended()` helper.

## Tests

- `LockContendedCounterTests` (1): `RecordLockContended` increments the counter.
- EFCore builds clean under `-warnaserror`; full Outbox suite green (117/117).

## Version

6.5.28 -> 6.5.29 across all 14 packages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v6.5.29

* **New Features**
  * Added distributed lock contention diagnostics to track how often replicas are unable to acquire the dispatch lock, enabling operators to monitor dispatcher efficiency.

* **Tests**
  * Added test coverage for lock contention metric recording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->