### PR TITLE
Fix distorted README logo aspect ratio

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
- <img width="150" height="831" alt="Moongazing-04" src="https://github.com/user-attachments/assets/eddd78ec-7398-4a91-81ec-bdba629e81d3" />
+ <img width="150" height="150" alt="OrionGuard logo" src="https://github.com/user-attachments/assets/eddd78ec-7398-4a91-81ec-bdba629e81d3" />
 
 </p>
 


### PR DESCRIPTION
## Problem
The README header logo renders as a thin vertical sliver. The source image is a perfect **831×831 square**, but the `<img>` tag pinned it to `width="150" height="831"`, forcing the square into a 150-wide × 831-tall box. (This distortion was introduced in #51.)

## Fix
- Set the logo to `width="150" height="150"`, restoring the square aspect ratio at the originally intended 150px display width.
- Improved the `alt` text from the upload artifact name `Moongazing-04` to `OrionGuard logo` for accessibility.

No other content changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the logo in the README with adjusted sizing and improved accessibility descriptors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->