### PR TITLE
release: v6.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to OrionGuard will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.6.0] - 2026-06-19
+
+### Added
+
+#### Asynchronous validation pipeline on `ObjectValidator<T>`
+
+`Validate.For(...)` / `Validate.ForStrict(...)` gain a first-class async path so rules that must perform I/O (a database uniqueness check, a remote lookup) participate in the same guard pipeline as the synchronous rules, with full `CancellationToken` flow, short-circuit parity, and one merged `GuardResult`.
+
+- `MustAsync<TProperty>(selector, Func<TProperty, CancellationToken, Task<bool>>, message, errorCode?)` registers a property-scoped async rule. `MustAsync(Func<T, CancellationToken, Task<bool>>, message, parameterName, errorCode?)` registers an instance-scoped async rule. Default error code is `ASYNC_PREDICATE`.
+- `WhenAsync(condition, configure)` conditionally registers async rules, mirroring the synchronous `When` overload.
+- `ToResultAsync(CancellationToken)` runs the synchronous rules already collected during the fluent chain plus the deferred async rules, surfacing sync errors first and appending async errors into the same `GuardResult`. `BuildAsync` / `ThrowIfInvalidAsync` are the async counterparts of `Build` / `ThrowIfInvalid`.
+- Short-circuit parity: a strict validator (`Validate.ForStrict`) throws `AggregateValidationException` on the first failure, including the first async failure, after which no further async rules run, exactly matching the synchronous strict path. A non-strict validator (`Validate.For`) runs every rule and aggregates all failures.
+- Cancellation is honored: the token is observed before and during each async rule and `OperationCanceledException` propagates to the caller rather than being recorded as a validation error.
+- The synchronous terminals (`ToResult` / `Build` / `ThrowIfInvalid`) now throw `InvalidOperationException` when async rules are pending, so async rule results are never silently discarded.
+- The synchronous API is unchanged and remains source- and binary-compatible.
+
+### Fixed
+
+- `ObjectValidator<T>.NotNull<TProperty>` was constrained to `where TProperty : class`, which forced callers validating a nullable reference property (for example `string?`) to suppress CS8634/CS8621 nullability warnings even though checking a nullable reference for null is the method's exact purpose. The constraint is relaxed to `class?`. The change is source- and binary-compatible: the emitted IL constraint is unchanged and only the compile-time nullability annotation is relaxed.
+
+### Tests
+
+- `ObjectValidatorAsyncTests`: async rule pass/fail, default error code, property/instance scope, value passthrough, cancellation honored (before and inside a rule, never converted to an error), mixed sync+async aggregation and ordering, multiple async failures, strict short-circuit on first async failure (and that later rules do not run), non-strict full aggregation, the async terminals, the pending-async-rule guard on the sync terminals, `WhenAsync`, and argument-null validation.
+
 ## [6.5.30] - 2026-06-18
 
 ### Changed

--- a/src/Moongazing.OrionGuard.AspNetCore/Moongazing.OrionGuard.AspNetCore.csproj
+++ b/src/Moongazing.OrionGuard.AspNetCore/Moongazing.OrionGuard.AspNetCore.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.AspNetCore</PackageId>
-    <Version>6.5.30</Version>
+    <Version>6.6.0</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>ASP.NET Core integration for OrionGuard validation library. Provides middleware, Minimal API endpoint filters, MVC action filters, and RFC 9457 ProblemDetails support.</Description>
     <PackageTags>guard;validation;aspnetcore;middleware;minimal-api;problemdetails</PackageTags>

--- a/src/Moongazing.OrionGuard.Blazor/Moongazing.OrionGuard.Blazor.csproj
+++ b/src/Moongazing.OrionGuard.Blazor/Moongazing.OrionGuard.Blazor.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Blazor</PackageId>
-    <Version>6.5.30</Version>
+    <Version>6.6.0</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Blazor integration for OrionGuard validation library. Provides EditForm validation, custom validation components, and data annotations interop.</Description>
     <PackageTags>guard;validation;blazor;editform;component;wasm;server</PackageTags>

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Moongazing.OrionGuard.EntityFrameworkCore.csproj
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Moongazing.OrionGuard.EntityFrameworkCore.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.EntityFrameworkCore</PackageId>
-    <Version>6.5.30</Version>
+    <Version>6.6.0</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>EF Core integration for OrionGuard. Provides a SaveChanges interceptor that dispatches domain events from AggregateRoot&lt;TId&gt; instances after commit (Inline mode) or via a transactional outbox (Outbox mode) consumed by a hosted background worker. Includes W3C trace context propagation across the outbox boundary.</Description>
     <PackageTags>guard;validation;ddd;domain-events;outbox;entity-framework-core;efcore;aggregate-root</PackageTags>

--- a/src/Moongazing.OrionGuard.Generators/Moongazing.OrionGuard.Generators.csproj
+++ b/src/Moongazing.OrionGuard.Generators/Moongazing.OrionGuard.Generators.csproj
@@ -8,7 +8,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>CS1591</NoWarn>
     <PackageId>OrionGuard.Generators</PackageId>
-    <Version>6.5.17</Version>
+    <Version>6.6.0</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Source generator for OrionGuard. Generates [GenerateValidator] validators, [StronglyTypedId&lt;TValue&gt;] strongly-typed id types (EF Core ValueConverter, System.Text.Json JsonConverter, TypeConverter companions), and supports NativeAOT-compatible reflection-free workflows.</Description>
     <PackageTags>guard;validation;source-generator;roslyn;nativeaot;codegen;ddd;strongly-typed-id</PackageTags>

--- a/src/Moongazing.OrionGuard.Grpc/Moongazing.OrionGuard.Grpc.csproj
+++ b/src/Moongazing.OrionGuard.Grpc/Moongazing.OrionGuard.Grpc.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Grpc</PackageId>
-    <Version>6.5.30</Version>
+    <Version>6.6.0</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>gRPC integration for OrionGuard validation library. Provides server interceptor for automatic request validation in gRPC services.</Description>
     <PackageTags>guard;validation;grpc;interceptor;protobuf;microservices</PackageTags>

--- a/src/Moongazing.OrionGuard.Locks.Redis/Moongazing.OrionGuard.Locks.Redis.csproj
+++ b/src/Moongazing.OrionGuard.Locks.Redis/Moongazing.OrionGuard.Locks.Redis.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Locks.Redis</PackageId>
-    <Version>6.5.30</Version>
+    <Version>6.6.0</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Redis-backed IDistributedLock for OrionGuard.EntityFrameworkCore's outbox dispatcher. Bridges OrionGuard's IDistributedLock contract to the OrionLock.Redis backend so multi-instance outbox workers can share a Redis-coordinated lease instead of the default SkipLocked DB lock.</Description>
     <PackageTags>guard;outbox;distributed-lock;redis;orionlock;entity-framework-core;efcore</PackageTags>

--- a/src/Moongazing.OrionGuard.MediatR/Moongazing.OrionGuard.MediatR.csproj
+++ b/src/Moongazing.OrionGuard.MediatR/Moongazing.OrionGuard.MediatR.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.MediatR</PackageId>
-    <Version>6.5.30</Version>
+    <Version>6.6.0</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>MediatR integration for OrionGuard validation library. Provides ValidationBehavior pipeline behavior for automatic request validation in CQRS pipelines.</Description>
     <PackageTags>guard;validation;mediatr;cqrs;pipeline;behavior</PackageTags>

--- a/src/Moongazing.OrionGuard.OpenTelemetry/Moongazing.OrionGuard.OpenTelemetry.csproj
+++ b/src/Moongazing.OrionGuard.OpenTelemetry/Moongazing.OrionGuard.OpenTelemetry.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.OpenTelemetry</PackageId>
-    <Version>6.5.30</Version>
+    <Version>6.6.0</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>OpenTelemetry integration for OrionGuard validation library. Provides validation metrics (success/failure rates, latency) and distributed tracing spans.</Description>
     <PackageTags>guard;validation;opentelemetry;metrics;tracing;observability</PackageTags>

--- a/src/Moongazing.OrionGuard.Outbox.Dashboard/Moongazing.OrionGuard.Outbox.Dashboard.csproj
+++ b/src/Moongazing.OrionGuard.Outbox.Dashboard/Moongazing.OrionGuard.Outbox.Dashboard.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904;AD0001</NoWarn>
     <PackageId>OrionGuard.Outbox.Dashboard</PackageId>
-    <Version>6.5.30</Version>
+    <Version>6.6.0</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Outbox operator dashboard for OrionGuard. Maps an authorized listing of failed / poisoned messages from the consumer's DbContext to an ASP.NET Core endpoint group, plus POST /{id}/replay and POST /{id}/discard mutation endpoints (v6.5.5) with an optional OnMutation audit hook.</Description>
     <PackageTags>guard;outbox;dashboard;aspnetcore;poisoned-messages;dead-letter</PackageTags>

--- a/src/Moongazing.OrionGuard.Outbox.PostgresNotify/Moongazing.OrionGuard.Outbox.PostgresNotify.csproj
+++ b/src/Moongazing.OrionGuard.Outbox.PostgresNotify/Moongazing.OrionGuard.Outbox.PostgresNotify.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Outbox.PostgresNotify</PackageId>
-    <Version>6.5.30</Version>
+    <Version>6.6.0</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Postgres LISTEN/NOTIFY backed IOutboxWakeSignal for OrionGuard.EntityFrameworkCore. Replaces the v6.5.1 polling fallback with an event-driven wake on every committed outbox row when the consumer's database is PostgreSQL. Falls back to polling cleanly when the LISTEN connection is unreachable.</Description>
     <PackageTags>guard;outbox;postgres;npgsql;listen;notify;push;dispatch;entity-framework-core;efcore</PackageTags>

--- a/src/Moongazing.OrionGuard.Outbox.SqlServerBroker/Moongazing.OrionGuard.Outbox.SqlServerBroker.csproj
+++ b/src/Moongazing.OrionGuard.Outbox.SqlServerBroker/Moongazing.OrionGuard.Outbox.SqlServerBroker.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Outbox.SqlServerBroker</PackageId>
-    <Version>6.5.30</Version>
+    <Version>6.6.0</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>SQL Server Service Broker backed IOutboxWakeSignal for OrionGuard.EntityFrameworkCore. Sibling to OrionGuard.Outbox.PostgresNotify (v6.5.2) for the SQL Server provider. Replaces the v6.5.1 polling-only fallback with an event-driven wake on every committed outbox row via Service Broker's queueing primitives.</Description>
     <PackageTags>guard;outbox;sqlserver;service-broker;push;dispatch;entity-framework-core;efcore</PackageTags>

--- a/src/Moongazing.OrionGuard.SignalR/Moongazing.OrionGuard.SignalR.csproj
+++ b/src/Moongazing.OrionGuard.SignalR/Moongazing.OrionGuard.SignalR.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.SignalR</PackageId>
-    <Version>6.5.30</Version>
+    <Version>6.6.0</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>SignalR integration for OrionGuard validation library. Provides Hub filter for automatic method parameter validation.</Description>
     <PackageTags>guard;validation;signalr;realtime;hub;filter</PackageTags>

--- a/src/Moongazing.OrionGuard.Swagger/Moongazing.OrionGuard.Swagger.csproj
+++ b/src/Moongazing.OrionGuard.Swagger/Moongazing.OrionGuard.Swagger.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Swagger</PackageId>
-    <Version>6.5.30</Version>
+    <Version>6.6.0</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Swagger/OpenAPI integration for OrionGuard. Auto-generates OpenAPI constraints from OrionGuard validation attributes.</Description>
     <PackageTags>guard;validation;swagger;openapi;swashbuckle</PackageTags>

--- a/src/Moongazing.OrionGuard.Testing/Moongazing.OrionGuard.Testing.csproj
+++ b/src/Moongazing.OrionGuard.Testing/Moongazing.OrionGuard.Testing.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Testing</PackageId>
-    <Version>6.5.30</Version>
+    <Version>6.6.0</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Testing helpers for OrionGuard. Provides DomainEventCapture and InMemoryDomainEventDispatcher with framework-agnostic assertions (no xUnit / NUnit / FluentAssertions dependency). Works with any test runner.</Description>
     <PackageTags>guard;validation;testing;ddd;domain-events;assertions;test-helpers</PackageTags>

--- a/src/Moongazing.OrionGuard/Core/ObjectValidator.cs
+++ b/src/Moongazing.OrionGuard/Core/ObjectValidator.cs
@@ -40,10 +40,21 @@ public sealed class ObjectValidator<T> where T : class
     /// Async rules deferred until <see cref="ToResultAsync"/> is awaited. Each entry, given a
     /// <see cref="CancellationToken"/>, produces a <see cref="ValidationError"/> when failing or
     /// <c>null</c> when passing. Sync rules cannot defer (they run eagerly inside the fluent call),
-    /// so the two rule kinds are stored separately but feed the same <see cref="_errors"/> list at
-    /// resolution time, giving one merged <see cref="GuardResult"/>.
+    /// so the two rule kinds are stored separately. At resolution time their failures are merged
+    /// with the eagerly-collected sync <see cref="_errors"/> into one <see cref="GuardResult"/>
+    /// without ever mutating <see cref="_errors"/>, keeping the async terminal idempotent.
     /// </summary>
     private List<Func<CancellationToken, Task<ValidationError?>>>? _asyncRules;
+
+    /// <summary>
+    /// Errors produced by the deferred async rules, captured the first time the async terminal runs
+    /// to completion. On repeated <see cref="ToResultAsync"/> / <see cref="ThrowIfInvalidAsync"/>
+    /// calls the cached outcome is returned verbatim, so the async rules neither re-execute (no
+    /// repeated I/O side effects) nor re-append (no duplicate errors). This mirrors the synchronous
+    /// <see cref="ToResult"/> contract, where rules run once during the fluent chain and the terminal
+    /// is a pure read of <see cref="_errors"/>.
+    /// </summary>
+    private List<ValidationError>? _asyncErrors;
 
     internal ObjectValidator(T instance, bool throwOnFirstError)
     {
@@ -329,28 +340,63 @@ public sealed class ObjectValidator<T> where T : class
             throw new AggregateValidationException(_errors);
         }
 
-        if (_asyncRules is not null)
+        // Idempotency: build the merged result from a FRESH local list every call and never mutate
+        // the shared _errors. The async rules run exactly once -- their outcome is cached in
+        // _asyncErrors -- so a second ToResultAsync()/ThrowIfInvalidAsync() returns the identical
+        // error set without re-running the predicates (no repeated I/O side effects) and without
+        // re-appending (no duplicate errors). This matches the synchronous ToResult() contract.
+        if (_asyncErrors is null)
         {
-            foreach (var rule in _asyncRules)
+            var produced = new List<ValidationError>();
+
+            if (_asyncRules is not null)
             {
-                cancellationToken.ThrowIfCancellationRequested();
-
-                var error = await rule(cancellationToken).ConfigureAwait(false);
-                if (error is null)
+                foreach (var rule in _asyncRules)
                 {
-                    continue;
-                }
+                    cancellationToken.ThrowIfCancellationRequested();
 
-                _errors.Add(error);
+                    var error = await rule(cancellationToken).ConfigureAwait(false);
+                    if (error is null)
+                    {
+                        continue;
+                    }
 
-                if (_throwOnFirstError)
-                {
-                    throw new AggregateValidationException(_errors);
+                    produced.Add(error);
+
+                    if (_throwOnFirstError)
+                    {
+                        // Strict short-circuit: throw on first async failure, exactly as the sync
+                        // strict path does. The outcome is intentionally NOT cached -- a strict
+                        // validator always throws here and is never re-inspected via a result.
+                        throw new AggregateValidationException(Merge(_errors, produced));
+                    }
                 }
             }
+
+            // Cache only after a full, uncancelled run so a cancelled attempt can be retried.
+            _asyncErrors = produced;
         }
 
-        return _errors.Count == 0 ? GuardResult.Success() : GuardResult.Failure(_errors);
+        var merged = Merge(_errors, _asyncErrors);
+        return merged.Count == 0 ? GuardResult.Success() : GuardResult.Failure(merged);
+    }
+
+    /// <summary>
+    /// Merges the eagerly-collected synchronous errors with the async errors into a new list,
+    /// surfacing sync failures first. Returns a fresh list each call so neither source is mutated.
+    /// </summary>
+    private static List<ValidationError> Merge(
+        List<ValidationError> syncErrors, List<ValidationError> asyncErrors)
+    {
+        if (asyncErrors.Count == 0)
+        {
+            return syncErrors;
+        }
+
+        var merged = new List<ValidationError>(syncErrors.Count + asyncErrors.Count);
+        merged.AddRange(syncErrors);
+        merged.AddRange(asyncErrors);
+        return merged;
     }
 
     /// <summary>

--- a/src/Moongazing.OrionGuard/Core/ObjectValidator.cs
+++ b/src/Moongazing.OrionGuard/Core/ObjectValidator.cs
@@ -36,12 +36,28 @@ public sealed class ObjectValidator<T> where T : class
     private readonly List<ValidationError> _errors = new();
     private readonly bool _throwOnFirstError;
 
+    /// <summary>
+    /// Async rules deferred until <see cref="ToResultAsync"/> is awaited. Each entry, given a
+    /// <see cref="CancellationToken"/>, produces a <see cref="ValidationError"/> when failing or
+    /// <c>null</c> when passing. Sync rules cannot defer (they run eagerly inside the fluent call),
+    /// so the two rule kinds are stored separately but feed the same <see cref="_errors"/> list at
+    /// resolution time, giving one merged <see cref="GuardResult"/>.
+    /// </summary>
+    private List<Func<CancellationToken, Task<ValidationError?>>>? _asyncRules;
+
     internal ObjectValidator(T instance, bool throwOnFirstError)
     {
         ArgumentNullException.ThrowIfNull(instance);
         _instance = instance;
         _throwOnFirstError = throwOnFirstError;
     }
+
+    /// <summary>
+    /// True when at least one async rule has been registered and the result must therefore be
+    /// resolved through <see cref="ToResultAsync"/> / <see cref="BuildAsync"/> /
+    /// <see cref="ThrowIfInvalidAsync"/> rather than the synchronous terminals.
+    /// </summary>
+    private bool HasAsyncRules => _asyncRules is { Count: > 0 };
 
     /// <summary>
     /// Validates a specific property of the object.
@@ -102,9 +118,16 @@ public sealed class ObjectValidator<T> where T : class
     /// <summary>
     /// Validates that a property is not null.
     /// </summary>
+    /// <remarks>
+    /// The type parameter is constrained to <c>class?</c> rather than <c>class</c> so a nullable
+    /// reference property (for example <c>string?</c>) can be passed without a CS8634/CS8621
+    /// nullability-mismatch warning. Validating a nullable reference for null is the exact intent of
+    /// this method. The change is source- and binary-compatible: the emitted IL constraint is
+    /// unchanged and only the compile-time nullability annotation is relaxed.
+    /// </remarks>
     public ObjectValidator<T> NotNull<TProperty>(
         Expression<Func<T, TProperty>> selector,
-        string? message = null) where TProperty : class
+        string? message = null) where TProperty : class?
     {
         return Property(selector, g => g.NotNull(message));
     }
@@ -131,6 +154,100 @@ public sealed class ObjectValidator<T> where T : class
     }
 
     /// <summary>
+    /// Registers an asynchronous rule on a property: useful for checks that require I/O such as a
+    /// database uniqueness lookup or a remote service call. The rule is deferred and executed when
+    /// <see cref="ToResultAsync"/> (or <see cref="BuildAsync"/> / <see cref="ThrowIfInvalidAsync"/>)
+    /// is awaited, and participates in the same failure aggregation and short-circuit semantics as
+    /// the synchronous rules on this validator.
+    /// </summary>
+    /// <typeparam name="TProperty">The property type.</typeparam>
+    /// <param name="selector">An expression selecting the property to validate.</param>
+    /// <param name="predicate">
+    /// An async predicate returning <c>true</c> when the value is valid. The
+    /// <see cref="CancellationToken"/> flows from the awaiting <see cref="ToResultAsync"/> call.
+    /// </param>
+    /// <param name="message">The error message emitted when the predicate returns <c>false</c>.</param>
+    /// <param name="errorCode">Optional error code; defaults to <c>ASYNC_PREDICATE</c>.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="selector"/> or <paramref name="predicate"/> is null.</exception>
+    public ObjectValidator<T> MustAsync<TProperty>(
+        Expression<Func<T, TProperty>> selector,
+        Func<TProperty, CancellationToken, Task<bool>> predicate,
+        string message,
+        string? errorCode = null)
+    {
+        ArgumentNullException.ThrowIfNull(selector);
+        ArgumentNullException.ThrowIfNull(predicate);
+
+        var propertyName = GetPropertyName(selector);
+        var accessor = GetOrCompileAccessor(selector, propertyName);
+
+        AddAsyncRule(async ct =>
+        {
+            var value = accessor(_instance);
+            var isValid = await predicate(value, ct).ConfigureAwait(false);
+            return isValid
+                ? null
+                : new ValidationError(propertyName, message, errorCode ?? "ASYNC_PREDICATE");
+        });
+
+        return this;
+    }
+
+    /// <summary>
+    /// Registers an asynchronous rule over the whole instance. Use this when the check is not tied
+    /// to a single property (for example, a composite uniqueness check across several fields).
+    /// </summary>
+    /// <param name="predicate">
+    /// An async predicate returning <c>true</c> when the instance is valid. The
+    /// <see cref="CancellationToken"/> flows from the awaiting <see cref="ToResultAsync"/> call.
+    /// </param>
+    /// <param name="message">The error message emitted when the predicate returns <c>false</c>.</param>
+    /// <param name="parameterName">The parameter/property name attached to the emitted error.</param>
+    /// <param name="errorCode">Optional error code; defaults to <c>ASYNC_PREDICATE</c>.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="predicate"/> is null.</exception>
+    public ObjectValidator<T> MustAsync(
+        Func<T, CancellationToken, Task<bool>> predicate,
+        string message,
+        string parameterName,
+        string? errorCode = null)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+
+        AddAsyncRule(async ct =>
+        {
+            var isValid = await predicate(_instance, ct).ConfigureAwait(false);
+            return isValid
+                ? null
+                : new ValidationError(parameterName, message, errorCode ?? "ASYNC_PREDICATE");
+        });
+
+        return this;
+    }
+
+    /// <summary>
+    /// Conditionally registers asynchronous rules. The <paramref name="configure"/> block runs only
+    /// when <paramref name="condition"/> is <c>true</c>, mirroring the synchronous
+    /// <see cref="When(bool, Action{ObjectValidator{T}})"/> overload.
+    /// </summary>
+    /// <param name="condition">When false, no rules inside <paramref name="configure"/> are registered.</param>
+    /// <param name="configure">The block that registers rules.</param>
+    public ObjectValidator<T> WhenAsync(bool condition, Action<ObjectValidator<T>> configure)
+    {
+        ArgumentNullException.ThrowIfNull(configure);
+
+        if (condition)
+        {
+            configure(this);
+        }
+        return this;
+    }
+
+    private void AddAsyncRule(Func<CancellationToken, Task<ValidationError?>> rule)
+    {
+        (_asyncRules ??= new()).Add(rule);
+    }
+
+    /// <summary>
     /// Conditionally applies validation rules.
     /// </summary>
     public ObjectValidator<T> When(bool condition, Action<ObjectValidator<T>> configure)
@@ -145,16 +262,25 @@ public sealed class ObjectValidator<T> where T : class
     /// <summary>
     /// Returns the validation result.
     /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when asynchronous rules are pending. Async rules cannot run on the synchronous path;
+    /// call <see cref="ToResultAsync"/> instead so their results are not silently discarded.
+    /// </exception>
     public GuardResult ToResult()
     {
+        ThrowIfAsyncRulesPending();
         return _errors.Count == 0 ? GuardResult.Success() : GuardResult.Failure(_errors);
     }
 
     /// <summary>
     /// Throws if validation failed.
     /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when asynchronous rules are pending; call <see cref="ThrowIfInvalidAsync"/> instead.
+    /// </exception>
     public T ThrowIfInvalid()
     {
+        ThrowIfAsyncRulesPending();
         if (_errors.Count > 0)
         {
             throw new AggregateValidationException(_errors);
@@ -165,7 +291,98 @@ public sealed class ObjectValidator<T> where T : class
     /// <summary>
     /// Returns the validated object if valid.
     /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when asynchronous rules are pending; call <see cref="BuildAsync"/> instead.
+    /// </exception>
     public T Build() => ThrowIfInvalid();
+
+    /// <summary>
+    /// Runs every rule -- the synchronous rules already collected plus the deferred asynchronous
+    /// rules -- and returns the merged <see cref="GuardResult"/>.
+    /// </summary>
+    /// <param name="cancellationToken">
+    /// A token observed before and during each async rule. Cancellation is honored: an
+    /// <see cref="OperationCanceledException"/> propagates to the caller rather than being recorded
+    /// as a validation error.
+    /// </param>
+    /// <returns>A successful result when all rules pass, otherwise the accumulated errors.</returns>
+    /// <remarks>
+    /// <para>
+    /// <b>Aggregation.</b> Synchronous errors collected during the fluent chain are surfaced first,
+    /// then async rules run and append into the same list, so sync and async failures arrive in a
+    /// single <see cref="GuardResult"/>.
+    /// </para>
+    /// <para>
+    /// <b>Short-circuit parity.</b> A strict validator (<see cref="Validate.ForStrict{T}(T)"/>)
+    /// throws <see cref="AggregateValidationException"/> on the first failure -- including the first
+    /// async failure, after which no further async rules run -- exactly matching the synchronous
+    /// strict path. A non-strict validator (<see cref="Validate.For{T}(T)"/>) runs every rule and
+    /// aggregates all failures.
+    /// </para>
+    /// </remarks>
+    public async Task<GuardResult> ToResultAsync(CancellationToken cancellationToken = default)
+    {
+        // Strict mode: any sync error already collected would have thrown at registration time, so
+        // reaching here in strict mode means the sync rules passed. Defensive parity all the same.
+        if (_throwOnFirstError && _errors.Count > 0)
+        {
+            throw new AggregateValidationException(_errors);
+        }
+
+        if (_asyncRules is not null)
+        {
+            foreach (var rule in _asyncRules)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var error = await rule(cancellationToken).ConfigureAwait(false);
+                if (error is null)
+                {
+                    continue;
+                }
+
+                _errors.Add(error);
+
+                if (_throwOnFirstError)
+                {
+                    throw new AggregateValidationException(_errors);
+                }
+            }
+        }
+
+        return _errors.Count == 0 ? GuardResult.Success() : GuardResult.Failure(_errors);
+    }
+
+    /// <summary>
+    /// Awaits all rules and throws <see cref="AggregateValidationException"/> if any error was
+    /// produced; otherwise returns the validated instance. The async counterpart to
+    /// <see cref="ThrowIfInvalid"/>.
+    /// </summary>
+    /// <param name="cancellationToken">A token observed before and during each async rule.</param>
+    public async Task<T> ThrowIfInvalidAsync(CancellationToken cancellationToken = default)
+    {
+        var result = await ToResultAsync(cancellationToken).ConfigureAwait(false);
+        result.ThrowIfInvalid();
+        return _instance;
+    }
+
+    /// <summary>
+    /// The async counterpart to <see cref="Build"/>: awaits all rules and returns the validated
+    /// instance, throwing <see cref="AggregateValidationException"/> on failure.
+    /// </summary>
+    /// <param name="cancellationToken">A token observed before and during each async rule.</param>
+    public Task<T> BuildAsync(CancellationToken cancellationToken = default) =>
+        ThrowIfInvalidAsync(cancellationToken);
+
+    private void ThrowIfAsyncRulesPending()
+    {
+        if (HasAsyncRules)
+        {
+            throw new InvalidOperationException(
+                "This validator has asynchronous rules pending. Resolve it with ToResultAsync, " +
+                "BuildAsync, or ThrowIfInvalidAsync so async rule results are not discarded.");
+        }
+    }
 
     private static Func<T, TProperty> GetOrCompileAccessor<TProperty>(
         Expression<Func<T, TProperty>> selector, string propertyName)

--- a/src/Moongazing.OrionGuard/Moongazing.OrionGuard.csproj
+++ b/src/Moongazing.OrionGuard/Moongazing.OrionGuard.csproj
@@ -16,7 +16,7 @@
 		<OutputType>Library</OutputType>
 
 		<PackageId>OrionGuard</PackageId>
-		<Version>6.5.30</Version>
+		<Version>6.6.0</Version>
 		<Authors>Tunahan Ali Ozturk</Authors>
 		<Company>Tunahan Ali Ozturk</Company>
 		<GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/tests/Moongazing.OrionGuard.Tests/ObjectValidatorAsyncTests.cs
+++ b/tests/Moongazing.OrionGuard.Tests/ObjectValidatorAsyncTests.cs
@@ -367,6 +367,84 @@ public class ObjectValidatorAsyncTests
 
     #endregion
 
+    #region Idempotent Async Terminal
+
+    [Fact]
+    public async Task ToResultAsync_CalledTwice_ShouldYieldSameErrors_AndRunPredicateOnce()
+    {
+        var user = new User { Email = "taken@example.com" };
+        var invocations = 0;
+
+        var validator = Validate.For(user)
+            .MustAsync(u => u.Email, (email, _) =>
+            {
+                invocations++;
+                return Async(false);
+            }, "Email already in use", "EMAIL_TAKEN");
+
+        var first = await validator.ToResultAsync();
+        var second = await validator.ToResultAsync();
+
+        // Same single error set on both calls -- no accumulation across repeated terminal calls.
+        var e1 = Assert.Single(first.Errors);
+        var e2 = Assert.Single(second.Errors);
+        Assert.Equal("EMAIL_TAKEN", e1.ErrorCode);
+        Assert.Equal("EMAIL_TAKEN", e2.ErrorCode);
+
+        // The async predicate (and any I/O side effect inside it) runs exactly once.
+        Assert.Equal(1, invocations);
+    }
+
+    [Fact]
+    public async Task ThrowIfInvalidAsync_AfterToResultAsync_ShouldStaySingleError_AndNotRerunPredicate()
+    {
+        var user = new User { Email = "taken@example.com" };
+        var invocations = 0;
+
+        var validator = Validate.For(user)
+            .MustAsync(u => u.Email, (email, _) =>
+            {
+                invocations++;
+                return Async(false);
+            }, "Email already in use", "EMAIL_TAKEN");
+
+        var result = await validator.ToResultAsync();
+        Assert.Single(result.Errors);
+
+        var ex = await Assert.ThrowsAsync<AggregateValidationException>(
+            () => validator.ThrowIfInvalidAsync());
+
+        // The exception carries the SAME single error, not duplicates, and the predicate is not re-run.
+        Assert.Single(ex.Errors);
+        Assert.Equal(1, invocations);
+    }
+
+    [Fact]
+    public async Task ToResultAsync_CalledTwice_ShouldAggregateSyncAndAsync_WithoutDuplicating()
+    {
+        var user = new User { Email = "taken@example.com", Username = null };
+        var invocations = 0;
+
+        var validator = Validate.For(user)
+            .NotEmpty(u => u.Username)
+            .MustAsync(u => u.Email, (email, _) =>
+            {
+                invocations++;
+                return Async(false);
+            }, "Email already in use", "EMAIL_TAKEN");
+
+        var first = await validator.ToResultAsync();
+        var second = await validator.ToResultAsync();
+
+        Assert.Equal(2, first.Errors.Count);
+        Assert.Equal(2, second.Errors.Count);
+        Assert.Equal("Username", second.Errors[0].ParameterName);
+        Assert.Equal("EMAIL_TAKEN", second.Errors[1].ErrorCode);
+        Assert.Equal(1, invocations);
+    }
+
+    #endregion
+
     #region WhenAsync Conditional
 
     [Fact]

--- a/tests/Moongazing.OrionGuard.Tests/ObjectValidatorAsyncTests.cs
+++ b/tests/Moongazing.OrionGuard.Tests/ObjectValidatorAsyncTests.cs
@@ -1,0 +1,417 @@
+using Moongazing.OrionGuard.Core;
+
+namespace Moongazing.OrionGuard.Tests;
+
+/// <summary>
+/// Tests for the asynchronous validation pipeline added to <see cref="ObjectValidator{T}"/>:
+/// async rule pass/fail, cancellation, mixed sync+async aggregation, and short-circuit parity
+/// with the synchronous strict path.
+/// </summary>
+public class ObjectValidatorAsyncTests
+{
+    private sealed class User
+    {
+        public string? Email { get; set; }
+        public string? Username { get; set; }
+        public int Age { get; set; }
+    }
+
+    private static Task<bool> Async(bool value) => Task.FromResult(value);
+
+    #region Async Rule Pass / Fail
+
+    [Fact]
+    public async Task MustAsync_ShouldReturnValid_WhenAsyncRulePasses()
+    {
+        var user = new User { Email = "free@example.com" };
+
+        var result = await Validate.For(user)
+            .MustAsync(u => u.Email, (email, _) => Async(true), "Email already in use", "EMAIL_TAKEN")
+            .ToResultAsync();
+
+        Assert.True(result.IsValid);
+    }
+
+    [Fact]
+    public async Task MustAsync_ShouldFail_WhenAsyncRuleFails()
+    {
+        var user = new User { Email = "taken@example.com" };
+
+        var result = await Validate.For(user)
+            .MustAsync(u => u.Email, (email, _) => Async(false), "Email already in use", "EMAIL_TAKEN")
+            .ToResultAsync();
+
+        Assert.True(result.IsInvalid);
+        var error = Assert.Single(result.Errors);
+        Assert.Equal("Email", error.ParameterName);
+        Assert.Equal("Email already in use", error.Message);
+        Assert.Equal("EMAIL_TAKEN", error.ErrorCode);
+    }
+
+    [Fact]
+    public async Task MustAsync_ShouldDefaultErrorCode_WhenNoneSupplied()
+    {
+        var user = new User { Email = "x@example.com" };
+
+        var result = await Validate.For(user)
+            .MustAsync(u => u.Email, (email, _) => Async(false), "bad")
+            .ToResultAsync();
+
+        var error = Assert.Single(result.Errors);
+        Assert.Equal("ASYNC_PREDICATE", error.ErrorCode);
+    }
+
+    [Fact]
+    public async Task MustAsync_InstanceLevel_ShouldFail_WhenPredicateFails()
+    {
+        var user = new User { Email = "a@b.com", Username = "a" };
+
+        var result = await Validate.For(user)
+            .MustAsync(
+                (u, _) => Async(false),
+                "Email and username combination is taken",
+                "COMBO",
+                "COMBO_TAKEN")
+            .ToResultAsync();
+
+        Assert.True(result.IsInvalid);
+        var error = Assert.Single(result.Errors);
+        Assert.Equal("COMBO", error.ParameterName);
+        Assert.Equal("COMBO_TAKEN", error.ErrorCode);
+    }
+
+    [Fact]
+    public async Task MustAsync_ShouldPassActualPropertyValue_ToPredicate()
+    {
+        var user = new User { Email = "hello@world.com" };
+        string? observed = null;
+
+        await Validate.For(user)
+            .MustAsync(u => u.Email, (email, _) =>
+            {
+                observed = email;
+                return Async(true);
+            }, "bad")
+            .ToResultAsync();
+
+        Assert.Equal("hello@world.com", observed);
+    }
+
+    #endregion
+
+    #region Cancellation
+
+    [Fact]
+    public async Task ToResultAsync_ShouldHonorCancellation_BeforeRuleRuns()
+    {
+        var user = new User { Email = "x@example.com" };
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var ranRule = false;
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+            await Validate.For(user)
+                .MustAsync(u => u.Email, (email, _) =>
+                {
+                    ranRule = true;
+                    return Async(true);
+                }, "bad")
+                .ToResultAsync(cts.Token));
+
+        Assert.False(ranRule);
+    }
+
+    [Fact]
+    public async Task ToResultAsync_ShouldPropagateCancellation_FromInsideRule()
+    {
+        var user = new User { Email = "x@example.com" };
+        using var cts = new CancellationTokenSource();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+            await Validate.For(user)
+                .MustAsync(u => u.Email, async (email, ct) =>
+                {
+                    cts.Cancel();
+                    ct.ThrowIfCancellationRequested();
+                    return await Async(true);
+                }, "bad")
+                .ToResultAsync(cts.Token));
+    }
+
+    [Fact]
+    public async Task ToResultAsync_ShouldNotConvertCancellation_IntoValidationError()
+    {
+        var user = new User { Email = "x@example.com" };
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var validator = Validate.For(user)
+            .MustAsync(u => u.Email, (email, _) => Async(false), "bad");
+
+        // Cancellation must surface as OperationCanceledException, never be swallowed into a result.
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            async () => await validator.ToResultAsync(cts.Token));
+    }
+
+    #endregion
+
+    #region Mixed Sync + Async Aggregation
+
+    [Fact]
+    public async Task ToResultAsync_ShouldAggregate_SyncAndAsyncFailures()
+    {
+        var user = new User { Email = "taken@example.com", Username = null, Age = -1 };
+
+        var result = await Validate.For(user)
+            .NotEmpty(u => u.Username)                                  // sync failure
+            .Must(u => u.Age, age => age > 0, "Age must be positive")  // sync failure
+            .MustAsync(u => u.Email, (email, _) => Async(false), "Email already in use", "EMAIL_TAKEN")
+            .ToResultAsync();
+
+        Assert.True(result.IsInvalid);
+        Assert.Equal(3, result.Errors.Count);
+        Assert.Contains(result.Errors, e => e.ParameterName == "Username");
+        Assert.Contains(result.Errors, e => e.Message == "Age must be positive");
+        Assert.Contains(result.Errors, e => e.ErrorCode == "EMAIL_TAKEN");
+    }
+
+    [Fact]
+    public async Task ToResultAsync_ShouldSurfaceSyncErrorsFirst_ThenAsync()
+    {
+        var user = new User { Email = "taken@example.com", Username = null };
+
+        var result = await Validate.For(user)
+            .NotEmpty(u => u.Username)
+            .MustAsync(u => u.Email, (email, _) => Async(false), "Email already in use", "EMAIL_TAKEN")
+            .ToResultAsync();
+
+        Assert.Equal(2, result.Errors.Count);
+        Assert.Equal("Username", result.Errors[0].ParameterName);
+        Assert.Equal("EMAIL_TAKEN", result.Errors[1].ErrorCode);
+    }
+
+    [Fact]
+    public async Task ToResultAsync_ShouldAggregate_MultipleAsyncFailures()
+    {
+        var user = new User { Email = "taken@example.com", Username = "taken" };
+
+        var result = await Validate.For(user)
+            .MustAsync(u => u.Email, (email, _) => Async(false), "Email taken", "EMAIL")
+            .MustAsync(u => u.Username, (name, _) => Async(false), "Username taken", "USERNAME")
+            .ToResultAsync();
+
+        Assert.Equal(2, result.Errors.Count);
+        Assert.Contains(result.Errors, e => e.ErrorCode == "EMAIL");
+        Assert.Contains(result.Errors, e => e.ErrorCode == "USERNAME");
+    }
+
+    [Fact]
+    public async Task ToResultAsync_ShouldReturnSuccess_WhenSyncAndAsyncAllPass()
+    {
+        var user = new User { Email = "free@example.com", Username = "available", Age = 30 };
+
+        var result = await Validate.For(user)
+            .NotEmpty(u => u.Username)
+            .Must(u => u.Age, age => age > 0, "Age must be positive")
+            .MustAsync(u => u.Email, (email, _) => Async(true), "Email taken")
+            .MustAsync(u => u.Username, (name, _) => Async(true), "Username taken")
+            .ToResultAsync();
+
+        Assert.True(result.IsValid);
+    }
+
+    #endregion
+
+    #region Short-Circuit Parity With Sync Strict Path
+
+    [Fact]
+    public async Task ToResultAsync_Strict_ShouldThrow_OnFirstAsyncFailure()
+    {
+        var user = new User { Email = "taken@example.com", Username = "taken" };
+
+        await Assert.ThrowsAsync<AggregateValidationException>(async () =>
+            await Validate.ForStrict(user)
+                .MustAsync(u => u.Email, (email, _) => Async(false), "Email taken", "EMAIL")
+                .MustAsync(u => u.Username, (name, _) => Async(false), "Username taken", "USERNAME")
+                .ToResultAsync());
+    }
+
+    [Fact]
+    public async Task ToResultAsync_Strict_ShouldNotRunRulesAfterFirstFailure()
+    {
+        var user = new User { Email = "taken@example.com", Username = "taken" };
+        var secondRuleRan = false;
+
+        await Assert.ThrowsAsync<AggregateValidationException>(async () =>
+            await Validate.ForStrict(user)
+                .MustAsync(u => u.Email, (email, _) => Async(false), "Email taken", "EMAIL")
+                .MustAsync(u => u.Username, (name, _) =>
+                {
+                    secondRuleRan = true;
+                    return Async(false);
+                }, "Username taken", "USERNAME")
+                .ToResultAsync());
+
+        // Strict short-circuit: the second async rule must never execute, matching the sync path.
+        Assert.False(secondRuleRan);
+    }
+
+    [Fact]
+    public async Task ToResultAsync_NonStrict_ShouldRunAllRules_AndAggregate()
+    {
+        var user = new User { Email = "taken@example.com", Username = "taken" };
+        var secondRuleRan = false;
+
+        var result = await Validate.For(user)
+            .MustAsync(u => u.Email, (email, _) => Async(false), "Email taken", "EMAIL")
+            .MustAsync(u => u.Username, (name, _) =>
+            {
+                secondRuleRan = true;
+                return Async(false);
+            }, "Username taken", "USERNAME")
+            .ToResultAsync();
+
+        Assert.True(secondRuleRan);
+        Assert.Equal(2, result.Errors.Count);
+    }
+
+    [Fact]
+    public async Task BuildAsync_Strict_ShouldReturnInstance_WhenAllRulesPass()
+    {
+        var user = new User { Email = "free@example.com" };
+
+        var built = await Validate.ForStrict(user)
+            .MustAsync(u => u.Email, (email, _) => Async(true), "Email taken")
+            .BuildAsync();
+
+        Assert.Same(user, built);
+    }
+
+    #endregion
+
+    #region Async Terminals
+
+    [Fact]
+    public async Task ThrowIfInvalidAsync_ShouldThrow_WhenInvalid()
+    {
+        var user = new User { Email = "taken@example.com" };
+
+        await Assert.ThrowsAsync<AggregateValidationException>(async () =>
+            await Validate.For(user)
+                .MustAsync(u => u.Email, (email, _) => Async(false), "Email taken")
+                .ThrowIfInvalidAsync());
+    }
+
+    [Fact]
+    public async Task ThrowIfInvalidAsync_ShouldReturnInstance_WhenValid()
+    {
+        var user = new User { Email = "free@example.com" };
+
+        var returned = await Validate.For(user)
+            .MustAsync(u => u.Email, (email, _) => Async(true), "Email taken")
+            .ThrowIfInvalidAsync();
+
+        Assert.Same(user, returned);
+    }
+
+    [Fact]
+    public async Task ToResultAsync_ShouldSucceed_WhenNoAsyncRulesRegistered()
+    {
+        var user = new User { Username = "ok", Age = 20 };
+
+        var result = await Validate.For(user)
+            .NotEmpty(u => u.Username)
+            .Must(u => u.Age, age => age > 0, "Age must be positive")
+            .ToResultAsync();
+
+        Assert.True(result.IsValid);
+    }
+
+    #endregion
+
+    #region Sync Terminal Guard When Async Rules Pending
+
+    [Fact]
+    public void ToResult_ShouldThrow_WhenAsyncRulesPending()
+    {
+        var user = new User { Email = "x@example.com" };
+
+        var validator = Validate.For(user)
+            .MustAsync(u => u.Email, (email, _) => Async(true), "bad");
+
+        Assert.Throws<InvalidOperationException>(() => validator.ToResult());
+    }
+
+    [Fact]
+    public void ThrowIfInvalid_ShouldThrow_WhenAsyncRulesPending()
+    {
+        var user = new User { Email = "x@example.com" };
+
+        var validator = Validate.For(user)
+            .MustAsync(u => u.Email, (email, _) => Async(true), "bad");
+
+        Assert.Throws<InvalidOperationException>(() => validator.ThrowIfInvalid());
+    }
+
+    [Fact]
+    public void Build_ShouldThrow_WhenAsyncRulesPending()
+    {
+        var user = new User { Email = "x@example.com" };
+
+        var validator = Validate.For(user)
+            .MustAsync(u => u.Email, (email, _) => Async(true), "bad");
+
+        Assert.Throws<InvalidOperationException>(() => validator.Build());
+    }
+
+    #endregion
+
+    #region WhenAsync Conditional
+
+    [Fact]
+    public async Task WhenAsync_ShouldRegisterRules_WhenConditionTrue()
+    {
+        var user = new User { Email = "taken@example.com" };
+
+        var result = await Validate.For(user)
+            .WhenAsync(true, v => v.MustAsync(u => u.Email, (email, _) => Async(false), "Email taken"))
+            .ToResultAsync();
+
+        Assert.True(result.IsInvalid);
+    }
+
+    [Fact]
+    public async Task WhenAsync_ShouldSkipRules_WhenConditionFalse()
+    {
+        var user = new User { Email = "taken@example.com" };
+
+        var result = await Validate.For(user)
+            .WhenAsync(false, v => v.MustAsync(u => u.Email, (email, _) => Async(false), "Email taken"))
+            .ToResultAsync();
+
+        Assert.True(result.IsValid);
+    }
+
+    #endregion
+
+    #region Argument Validation
+
+    [Fact]
+    public void MustAsync_ShouldThrow_WhenSelectorIsNull()
+    {
+        var user = new User();
+        Assert.Throws<ArgumentNullException>(() =>
+            Validate.For(user).MustAsync<string?>(null!, (e, _) => Async(true), "bad"));
+    }
+
+    [Fact]
+    public void MustAsync_ShouldThrow_WhenPredicateIsNull()
+    {
+        var user = new User();
+        Assert.Throws<ArgumentNullException>(() =>
+            Validate.For(user).MustAsync(u => u.Email, null!, "bad"));
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary

Adds a first-class **asynchronous validation pipeline** to `ObjectValidator<T>` (the `Validate.For(...)` / `Validate.ForStrict(...)` fluent object validator), so rules that must perform I/O (a database uniqueness check, a remote lookup) participate in the same guard pipeline as the synchronous rules. The synchronous API is fully intact and remains source- and binary-compatible.

### Feature: async validation path

- `MustAsync<TProperty>(selector, Func<TProperty, CancellationToken, Task<bool>>, message, errorCode?)` registers a property-scoped async rule; `MustAsync(Func<T, CancellationToken, Task<bool>>, message, parameterName, errorCode?)` registers an instance-scoped async rule. Default error code is `ASYNC_PREDICATE`.
- `WhenAsync(condition, configure)` conditionally registers async rules, mirroring the sync `When` overload.
- `ToResultAsync(CancellationToken)` runs the synchronous rules already collected during the fluent chain plus the deferred async rules, surfacing sync errors first and appending async errors into the **same** `GuardResult`. `BuildAsync` / `ThrowIfInvalidAsync` are the async counterparts of `Build` / `ThrowIfInvalid`.
- **Short-circuit parity with the sync path:** a strict validator (`ForStrict`) throws `AggregateValidationException` on the first failure (including the first async failure, after which no further async rules run); a non-strict validator (`For`) runs every rule and aggregates all failures.
- **Cancellation honored:** the token is observed before and during each async rule and `OperationCanceledException` propagates rather than being recorded as a validation error.
- The sync terminals (`ToResult` / `Build` / `ThrowIfInvalid`) now throw `InvalidOperationException` when async rules are pending, so async results are never silently discarded.

### Fix

- `ObjectValidator<T>.NotNull<TProperty>` was constrained to `where TProperty : class`, forcing callers validating a nullable reference (e.g. `string?`) to eat CS8634/CS8621 nullability warnings despite null-checking a nullable being the method's exact purpose. Relaxed to `class?`. Source- and binary-compatible (the emitted IL constraint is unchanged; only the compile-time nullability annotation is relaxed). This also clears pre-existing warnings in the test project.

### Versions

All **15** package csproj files set to `<Version>6.6.0</Version>`. Note: `Moongazing.OrionGuard.Generators` had drifted to `6.5.17`; it is brought up to `6.6.0` along with the other 14 so the family is versioned together. No `<Version>6.5.30</Version>` remains under `src/`.

### Tests (per framework)

Source libraries multi-target `net8.0;net9.0;net10.0`; test projects target `net10.0`. Full suite green:

| Project | Passed | Skipped |
|---|---|---|
| Moongazing.OrionGuard.Tests (incl. 26 new async tests) | 576 | 0 |
| EntityFrameworkCore.Tests | 125 | 0 |
| Outbox.Dashboard.Tests | 33 | 0 |
| Outbox.SqlServerBroker.Tests | 15 | 0 |
| Outbox.PostgresNotify.Tests | 14 | 0 |
| Generators.Tests | 12 | 0 |
| Testing.Tests | 11 | 0 |
| Locks.Redis.Tests | 11 | 4 (Redis integration, env-gated) |
| AspNetCore.Tests | 7 | 0 |
| **Total** | **804** | **4** |

0 failures. Zero code warnings (CS/CA); src packages build clean under `TreatWarningsAsErrors`. The only build warnings are pre-existing `NU1900/NU1903` NuGet audit advisories for a transitive `SQLitePCLRaw.lib.e_sqlite3` dependency in the EF Core test and demo projects (not shippable packages, already in the src `NoWarn` set, out of scope per packaging constraints).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes v6.6.0

* **New Features**
  * Added first-class async validation rules with fluent `MustAsync` and conditional `WhenAsync`.
  * Introduced async terminals: `ToResultAsync`, `ThrowIfInvalidAsync`, and `BuildAsync`, including strict vs non-strict behavior.
  * Async validation honors cancellation (cancellation propagates rather than becoming a validation error).

* **Bug Fixes**
  * Improved nullable reference property support for `NotNull` validation.

* **Tests**
  * Expanded async validation coverage (aggregation, strict short-circuiting, cancellation, and terminal behavior).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->