### PR TITLE
docs: showcase v6.6 async validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,29 @@ validator.Validate(user, RuleSet.Default, RuleSet.Create);
 validator.Validate(user, RuleSet.Update);
 ```
 
+### Async Validation (NEW in v6.6)
+
+Rules that need I/O, such as a uniqueness check against a database or a remote lookup,
+join the same pipeline as the synchronous rules and are awaited together. The cancellation
+token flows through, and the async terminal is idempotent: awaiting the result more than
+once returns the same errors and runs each async rule only once.
+
+```csharp
+var result = await Validate.For(input)
+    .Property(u => u.Email, g => g.NotNull().Email())
+    .Property(u => u.Password, g => g.NotNull().MinLength(8))
+    .MustAsync(u => u.Email, IsEmailAvailableAsync, "Email is already registered.", "EMAIL_TAKEN")
+    .ToResultAsync(cancellationToken);
+
+// Or throw on the first failure, awaiting the I/O rules:
+var validated = await Validate.For(input)
+    .MustAsync(u => u.Email, IsEmailAvailableAsync, "Email is already registered.")
+    .ThrowIfInvalidAsync(cancellationToken);
+```
+
+Synchronous and asynchronous rules can be mixed freely; the synchronous `Validate(...)`
+and `ToResult()` paths are unchanged.
+
 ---
 
 ## ASP.NET Core Integration
@@ -542,7 +565,7 @@ services.AddOrionGuardExceptionFactory<MyExceptionFactory>();
 
 OrionGuard publishes a public, twelve-month forward roadmap covering the next minor releases
 through **v7.0.0 (Q2 2027)**. See [docs/ROADMAP.md](docs/ROADMAP.md) for the next-12-months
-view (v6.5.0 family integration, v6.6.0 migration tooling, v6.7.0 production excellence,
+view (v6.5.0 family integration, v6.6.0 asynchronous validation, v6.7.0 production excellence,
 v7.0.0 API freeze) plus the deep tier backlog of every item under consideration.
 
 If something on the roadmap matters to you, open an issue with the `roadmap` label. Real

--- a/README.md
+++ b/README.md
@@ -377,8 +377,11 @@ var validated = await Validate.For(input)
     .ThrowIfInvalidAsync(cancellationToken);
 ```
 
-Synchronous and asynchronous rules can be mixed freely; the synchronous `Validate(...)`
-and `ToResult()` paths are unchanged.
+Synchronous and asynchronous rules can be mixed freely. Once a validator has any `MustAsync`
+rule registered, finish it with an async terminal (`ToResultAsync`, `BuildAsync`, or
+`ThrowIfInvalidAsync`); the synchronous `ToResult()` / `Build()` terminals throw
+`InvalidOperationException` rather than silently skipping the pending async rules. Validators
+with no async rules keep using the synchronous `Validate(...)` and `ToResult()` paths unchanged.
 
 ---
 

--- a/demo/Moongazing.OrionGuard.Demo/Services/RegistrationService.cs
+++ b/demo/Moongazing.OrionGuard.Demo/Services/RegistrationService.cs
@@ -31,4 +31,28 @@ public class RegistrationService
             .Property(u => u.Username, g => g.NotNull().Length(3, 30))
             .ToResult();
     }
+
+    // v6.6 - Asynchronous validation. A rule that needs I/O (here an email-uniqueness
+    // lookup) joins the same pipeline as the synchronous rules and is awaited together,
+    // with the cancellation token flowing through. The terminal is idempotent: awaiting
+    // the result more than once returns the same errors and runs the lookup only once.
+    public Task<GuardResult> ValidateWithResultAsync(UserInput input, CancellationToken cancellationToken = default)
+    {
+        return Validate.For(input)
+            .Property(u => u.Email, g => g.NotNull().NotEmpty().Email())
+            .Property(u => u.Password, g => g.NotNull().MinLength(8))
+            .Property(u => u.Username, g => g.NotNull().Length(3, 30))
+            .MustAsync(u => u.Email, IsEmailAvailableAsync, "Email is already registered.", "EMAIL_TAKEN")
+            .ToResultAsync(cancellationToken);
+    }
+
+    // Stands in for a database or remote lookup; returns true when the email is still free.
+    private static async Task<bool> IsEmailAvailableAsync(string email, CancellationToken cancellationToken)
+    {
+        await Task.Delay(10, cancellationToken).ConfigureAwait(false);
+        return !TakenEmails.Contains(email);
+    }
+
+    private static readonly HashSet<string> TakenEmails =
+        new(StringComparer.OrdinalIgnoreCase) { "taken@example.com" };
 }


### PR DESCRIPTION
Adds an async validation example (ValidateWithResultAsync with MustAsync email-uniqueness check) to the demo RegistrationService, a README 'Async Validation (NEW in v6.6)' section, and corrects the roadmap line for v6.6.0. Docs/demo only; no library or version change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an “Async Validation (NEW in v6.6)” guide with examples showing how async and sync rules run together, cancellation token propagation, and idempotent re-await behavior
  * Clarified that mixing async rules requires using an async terminal, otherwise an error is thrown
  * Updated the Roadmap wording to “asynchronous validation”
* **New Features**
  * Added an async validation entry point to the demo registration flow, including an async email-availability check with optional cancellation support
<!-- end of auto-generated comment: release notes by coderabbit.ai -->