### PR TITLE
chore: self-deriving diagnostics meter versions (6.6.1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 ##
 ## Get latest from https://github.com/github/gitignore/blob/master/VisualStudio.gitignore
 
+# Claude Code local files
+.claude/
+
 # User-specific files
 *.rsuser
 *.suo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to OrionGuard will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.6.1] - 2026-06-20
+
+### Changed
+
+- All diagnostics meter versions now derive from the package version automatically. Each assembly that constructs a `Meter` resolves the instrumentation version from its own `AssemblyInformationalVersion` (build metadata stripped) instead of a hardcoded literal, so the meter version always equals the package version and can no longer drift. This aligns several previously-stale meter versions (`6.0.0`, `6.4.0`, `6.5.13`, `6.5.16`) with the current package version.
+
 ## [6.6.0] - 2026-06-19
 
 ### Added

--- a/src/Moongazing.OrionGuard.AspNetCore/Moongazing.OrionGuard.AspNetCore.csproj
+++ b/src/Moongazing.OrionGuard.AspNetCore/Moongazing.OrionGuard.AspNetCore.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.AspNetCore</PackageId>
-    <Version>6.6.0</Version>
+    <Version>6.6.1</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>ASP.NET Core integration for OrionGuard validation library. Provides middleware, Minimal API endpoint filters, MVC action filters, and RFC 9457 ProblemDetails support.</Description>
     <PackageTags>guard;validation;aspnetcore;middleware;minimal-api;problemdetails</PackageTags>

--- a/src/Moongazing.OrionGuard.Blazor/Moongazing.OrionGuard.Blazor.csproj
+++ b/src/Moongazing.OrionGuard.Blazor/Moongazing.OrionGuard.Blazor.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Blazor</PackageId>
-    <Version>6.6.0</Version>
+    <Version>6.6.1</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Blazor integration for OrionGuard validation library. Provides EditForm validation, custom validation components, and data annotations interop.</Description>
     <PackageTags>guard;validation;blazor;editform;component;wasm;server</PackageTags>

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Moongazing.OrionGuard.EntityFrameworkCore.csproj
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Moongazing.OrionGuard.EntityFrameworkCore.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.EntityFrameworkCore</PackageId>
-    <Version>6.6.0</Version>
+    <Version>6.6.1</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>EF Core integration for OrionGuard. Provides a SaveChanges interceptor that dispatches domain events from AggregateRoot&lt;TId&gt; instances after commit (Inline mode) or via a transactional outbox (Outbox mode) consumed by a hosted background worker. Includes W3C trace context propagation across the outbox boundary.</Description>
     <PackageTags>guard;validation;ddd;domain-events;outbox;entity-framework-core;efcore;aggregate-root</PackageTags>

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Archival/OutboxArchivalDiagnostics.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/Archival/OutboxArchivalDiagnostics.cs
@@ -13,7 +13,7 @@ public static class OutboxArchivalDiagnostics
     /// <summary>Meter name used by the archival sinks.</summary>
     public const string MeterName = "Moongazing.OrionGuard.Outbox.Archival";
 
-    private static readonly Meter Meter = new(MeterName, "6.5.13");
+    private static readonly Meter Meter = new(MeterName, MeterVersion.Value);
 
     /// <summary>
     /// Bytes written to an archive sink per <see cref="IOutboxArchiveSink.WriteAsync"/>

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/MeterVersion.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/MeterVersion.cs
@@ -1,0 +1,27 @@
+using System.Reflection;
+
+namespace Moongazing.OrionGuard.EntityFrameworkCore.Outbox;
+
+/// <summary>
+/// Derives the diagnostics instrumentation version (used for <see cref="System.Diagnostics.Metrics.Meter"/>
+/// and <see cref="System.Diagnostics.ActivitySource"/>) from THIS assembly's own version so the meter
+/// version can never drift away from the package version it ships in.
+/// </summary>
+internal static class MeterVersion
+{
+    /// <summary>The resolved version string (the package version, build-metadata stripped).</summary>
+    public static string Value { get; } = Resolve();
+
+    private static string Resolve()
+    {
+        var asm = typeof(MeterVersion).Assembly;
+        var info = asm.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+        if (!string.IsNullOrEmpty(info))
+        {
+            var plus = info.IndexOf('+');
+            return plus >= 0 ? info[..plus] : info;
+        }
+
+        return asm.GetName().Version?.ToString(3) ?? "0.0.0";
+    }
+}

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/OutboxDispatcherDiagnostics.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/OutboxDispatcherDiagnostics.cs
@@ -13,7 +13,7 @@ public static class OutboxDispatcherDiagnostics
     /// <summary>Meter name used by the dispatcher.</summary>
     public const string MeterName = "Moongazing.OrionGuard.Outbox.Dispatcher";
 
-    private static readonly Meter Meter = new(MeterName, "6.5.16");
+    private static readonly Meter Meter = new(MeterName, MeterVersion.Value);
 
     /// <summary>
     /// Per-row dispatch lag: <c>now - OccurredOnUtc</c> at the moment the dispatcher

--- a/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/OutboxDispatcherHostedService.cs
+++ b/src/Moongazing.OrionGuard.EntityFrameworkCore/Outbox/OutboxDispatcherHostedService.cs
@@ -27,7 +27,7 @@ namespace Moongazing.OrionGuard.EntityFrameworkCore.Outbox;
 /// </remarks>
 public sealed class OutboxDispatcherHostedService : BackgroundService
 {
-    private static readonly ActivitySource OutboxActivitySource = new("Moongazing.OrionGuard.DomainEvents", "6.4.0");
+    private static readonly ActivitySource OutboxActivitySource = new("Moongazing.OrionGuard.DomainEvents", MeterVersion.Value);
 
     private readonly OutboxOptions options;
     private readonly IServiceScopeFactory scopeFactory;

--- a/src/Moongazing.OrionGuard.Generators/Moongazing.OrionGuard.Generators.csproj
+++ b/src/Moongazing.OrionGuard.Generators/Moongazing.OrionGuard.Generators.csproj
@@ -8,7 +8,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>CS1591</NoWarn>
     <PackageId>OrionGuard.Generators</PackageId>
-    <Version>6.6.0</Version>
+    <Version>6.6.1</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Source generator for OrionGuard. Generates [GenerateValidator] validators, [StronglyTypedId&lt;TValue&gt;] strongly-typed id types (EF Core ValueConverter, System.Text.Json JsonConverter, TypeConverter companions), and supports NativeAOT-compatible reflection-free workflows.</Description>
     <PackageTags>guard;validation;source-generator;roslyn;nativeaot;codegen;ddd;strongly-typed-id</PackageTags>

--- a/src/Moongazing.OrionGuard.Grpc/Moongazing.OrionGuard.Grpc.csproj
+++ b/src/Moongazing.OrionGuard.Grpc/Moongazing.OrionGuard.Grpc.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Grpc</PackageId>
-    <Version>6.6.0</Version>
+    <Version>6.6.1</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>gRPC integration for OrionGuard validation library. Provides server interceptor for automatic request validation in gRPC services.</Description>
     <PackageTags>guard;validation;grpc;interceptor;protobuf;microservices</PackageTags>

--- a/src/Moongazing.OrionGuard.Locks.Redis/Moongazing.OrionGuard.Locks.Redis.csproj
+++ b/src/Moongazing.OrionGuard.Locks.Redis/Moongazing.OrionGuard.Locks.Redis.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Locks.Redis</PackageId>
-    <Version>6.6.0</Version>
+    <Version>6.6.1</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Redis-backed IDistributedLock for OrionGuard.EntityFrameworkCore's outbox dispatcher. Bridges OrionGuard's IDistributedLock contract to the OrionLock.Redis backend so multi-instance outbox workers can share a Redis-coordinated lease instead of the default SkipLocked DB lock.</Description>
     <PackageTags>guard;outbox;distributed-lock;redis;orionlock;entity-framework-core;efcore</PackageTags>

--- a/src/Moongazing.OrionGuard.MediatR/Moongazing.OrionGuard.MediatR.csproj
+++ b/src/Moongazing.OrionGuard.MediatR/Moongazing.OrionGuard.MediatR.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.MediatR</PackageId>
-    <Version>6.6.0</Version>
+    <Version>6.6.1</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>MediatR integration for OrionGuard validation library. Provides ValidationBehavior pipeline behavior for automatic request validation in CQRS pipelines.</Description>
     <PackageTags>guard;validation;mediatr;cqrs;pipeline;behavior</PackageTags>

--- a/src/Moongazing.OrionGuard.OpenTelemetry/DomainEvents/OrionGuardDomainEventTelemetry.cs
+++ b/src/Moongazing.OrionGuard.OpenTelemetry/DomainEvents/OrionGuardDomainEventTelemetry.cs
@@ -15,8 +15,8 @@ public static class OrionGuardDomainEventTelemetry
     /// <summary>The Meter name registered for domain-event metrics.</summary>
     public const string MeterName = "Moongazing.OrionGuard.DomainEvents";
 
-    internal static readonly ActivitySource ActivitySource = new(ActivitySourceName, "6.4.0");
-    internal static readonly Meter Meter = new(MeterName, "6.4.0");
+    internal static readonly ActivitySource ActivitySource = new(ActivitySourceName, MeterVersion.Value);
+    internal static readonly Meter Meter = new(MeterName, MeterVersion.Value);
 
     internal static readonly Counter<long> EventsDispatched = Meter.CreateCounter<long>(
         "orionguard.domain_events.dispatched", unit: "events", description: "Total domain events dispatched");

--- a/src/Moongazing.OrionGuard.OpenTelemetry/MeterVersion.cs
+++ b/src/Moongazing.OrionGuard.OpenTelemetry/MeterVersion.cs
@@ -1,0 +1,27 @@
+using System.Reflection;
+
+namespace Moongazing.OrionGuard.OpenTelemetry;
+
+/// <summary>
+/// Derives the diagnostics instrumentation version (used for <see cref="System.Diagnostics.Metrics.Meter"/>
+/// and <see cref="System.Diagnostics.ActivitySource"/>) from THIS assembly's own version so the meter
+/// version can never drift away from the package version it ships in.
+/// </summary>
+internal static class MeterVersion
+{
+    /// <summary>The resolved version string (the package version, build-metadata stripped).</summary>
+    public static string Value { get; } = Resolve();
+
+    private static string Resolve()
+    {
+        var asm = typeof(MeterVersion).Assembly;
+        var info = asm.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+        if (!string.IsNullOrEmpty(info))
+        {
+            var plus = info.IndexOf('+');
+            return plus >= 0 ? info[..plus] : info;
+        }
+
+        return asm.GetName().Version?.ToString(3) ?? "0.0.0";
+    }
+}

--- a/src/Moongazing.OrionGuard.OpenTelemetry/Moongazing.OrionGuard.OpenTelemetry.csproj
+++ b/src/Moongazing.OrionGuard.OpenTelemetry/Moongazing.OrionGuard.OpenTelemetry.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.OpenTelemetry</PackageId>
-    <Version>6.6.0</Version>
+    <Version>6.6.1</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>OpenTelemetry integration for OrionGuard validation library. Provides validation metrics (success/failure rates, latency) and distributed tracing spans.</Description>
     <PackageTags>guard;validation;opentelemetry;metrics;tracing;observability</PackageTags>

--- a/src/Moongazing.OrionGuard.OpenTelemetry/OrionGuardInstrumentation.cs
+++ b/src/Moongazing.OrionGuard.OpenTelemetry/OrionGuardInstrumentation.cs
@@ -11,8 +11,8 @@ public static class OrionGuardInstrumentation
     public const string ActivitySourceName = "Moongazing.OrionGuard";
     public const string MeterName = "Moongazing.OrionGuard";
 
-    internal static readonly ActivitySource ActivitySource = new(ActivitySourceName, "6.0.0");
-    internal static readonly Meter Meter = new(MeterName, "6.0.0");
+    internal static readonly ActivitySource ActivitySource = new(ActivitySourceName, MeterVersion.Value);
+    internal static readonly Meter Meter = new(MeterName, MeterVersion.Value);
 
     internal static readonly Counter<long> ValidationsTotal = Meter.CreateCounter<long>(
         "orionguard.validations.total",

--- a/src/Moongazing.OrionGuard.Outbox.Dashboard/Moongazing.OrionGuard.Outbox.Dashboard.csproj
+++ b/src/Moongazing.OrionGuard.Outbox.Dashboard/Moongazing.OrionGuard.Outbox.Dashboard.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904;AD0001</NoWarn>
     <PackageId>OrionGuard.Outbox.Dashboard</PackageId>
-    <Version>6.6.0</Version>
+    <Version>6.6.1</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Outbox operator dashboard for OrionGuard. Maps an authorized listing of failed / poisoned messages from the consumer's DbContext to an ASP.NET Core endpoint group, plus POST /{id}/replay and POST /{id}/discard mutation endpoints (v6.5.5) with an optional OnMutation audit hook.</Description>
     <PackageTags>guard;outbox;dashboard;aspnetcore;poisoned-messages;dead-letter</PackageTags>

--- a/src/Moongazing.OrionGuard.Outbox.PostgresNotify/Moongazing.OrionGuard.Outbox.PostgresNotify.csproj
+++ b/src/Moongazing.OrionGuard.Outbox.PostgresNotify/Moongazing.OrionGuard.Outbox.PostgresNotify.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Outbox.PostgresNotify</PackageId>
-    <Version>6.6.0</Version>
+    <Version>6.6.1</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Postgres LISTEN/NOTIFY backed IOutboxWakeSignal for OrionGuard.EntityFrameworkCore. Replaces the v6.5.1 polling fallback with an event-driven wake on every committed outbox row when the consumer's database is PostgreSQL. Falls back to polling cleanly when the LISTEN connection is unreachable.</Description>
     <PackageTags>guard;outbox;postgres;npgsql;listen;notify;push;dispatch;entity-framework-core;efcore</PackageTags>

--- a/src/Moongazing.OrionGuard.Outbox.SqlServerBroker/Moongazing.OrionGuard.Outbox.SqlServerBroker.csproj
+++ b/src/Moongazing.OrionGuard.Outbox.SqlServerBroker/Moongazing.OrionGuard.Outbox.SqlServerBroker.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Outbox.SqlServerBroker</PackageId>
-    <Version>6.6.0</Version>
+    <Version>6.6.1</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>SQL Server Service Broker backed IOutboxWakeSignal for OrionGuard.EntityFrameworkCore. Sibling to OrionGuard.Outbox.PostgresNotify (v6.5.2) for the SQL Server provider. Replaces the v6.5.1 polling-only fallback with an event-driven wake on every committed outbox row via Service Broker's queueing primitives.</Description>
     <PackageTags>guard;outbox;sqlserver;service-broker;push;dispatch;entity-framework-core;efcore</PackageTags>

--- a/src/Moongazing.OrionGuard.SignalR/Moongazing.OrionGuard.SignalR.csproj
+++ b/src/Moongazing.OrionGuard.SignalR/Moongazing.OrionGuard.SignalR.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.SignalR</PackageId>
-    <Version>6.6.0</Version>
+    <Version>6.6.1</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>SignalR integration for OrionGuard validation library. Provides Hub filter for automatic method parameter validation.</Description>
     <PackageTags>guard;validation;signalr;realtime;hub;filter</PackageTags>

--- a/src/Moongazing.OrionGuard.Swagger/Moongazing.OrionGuard.Swagger.csproj
+++ b/src/Moongazing.OrionGuard.Swagger/Moongazing.OrionGuard.Swagger.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Swagger</PackageId>
-    <Version>6.6.0</Version>
+    <Version>6.6.1</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Swagger/OpenAPI integration for OrionGuard. Auto-generates OpenAPI constraints from OrionGuard validation attributes.</Description>
     <PackageTags>guard;validation;swagger;openapi;swashbuckle</PackageTags>

--- a/src/Moongazing.OrionGuard.Testing/Moongazing.OrionGuard.Testing.csproj
+++ b/src/Moongazing.OrionGuard.Testing/Moongazing.OrionGuard.Testing.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591;NU1900;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageId>OrionGuard.Testing</PackageId>
-    <Version>6.6.0</Version>
+    <Version>6.6.1</Version>
     <Authors>Tunahan Ali Ozturk</Authors>
     <Description>Testing helpers for OrionGuard. Provides DomainEventCapture and InMemoryDomainEventDispatcher with framework-agnostic assertions (no xUnit / NUnit / FluentAssertions dependency). Works with any test runner.</Description>
     <PackageTags>guard;validation;testing;ddd;domain-events;assertions;test-helpers</PackageTags>

--- a/src/Moongazing.OrionGuard/Moongazing.OrionGuard.csproj
+++ b/src/Moongazing.OrionGuard/Moongazing.OrionGuard.csproj
@@ -16,7 +16,7 @@
 		<OutputType>Library</OutputType>
 
 		<PackageId>OrionGuard</PackageId>
-		<Version>6.6.0</Version>
+		<Version>6.6.1</Version>
 		<Authors>Tunahan Ali Ozturk</Authors>
 		<Company>Tunahan Ali Ozturk</Company>
 		<GeneratePackageOnBuild>false</GeneratePackageOnBuild>


### PR DESCRIPTION
## Summary

Makes every `System.Diagnostics.Metrics.Meter` (and the co-located `ActivitySource`) version self-deriving from its own assembly version, so diagnostics versions can never drift away from the package version again.

Previously several meters were hardcoded at stale versions (`6.0.0`, `6.4.0`, `6.5.13`, `6.5.16`) while the package shipped at `6.6.0`.

### Changes

- Added one internal `MeterVersion` helper per owning assembly. Each resolves the version from THAT assembly's `AssemblyInformationalVersionAttribute` (build metadata after `+` stripped, falling back to `AssemblyName.Version`). No project reads another project's version.
  - `Moongazing.OrionGuard.OpenTelemetry/MeterVersion.cs`
  - `Moongazing.OrionGuard.EntityFrameworkCore/Outbox/MeterVersion.cs`
- Replaced all hardcoded diagnostics version literals with `MeterVersion.Value`:
  - **4 Meters aligned**: `OrionGuardInstrumentation` (6.0.0), `OrionGuardDomainEventTelemetry` (6.4.0), `OutboxDispatcherDiagnostics` (6.5.16), `OutboxArchivalDiagnostics` (6.5.13).
  - **3 co-located ActivitySources aligned** in the same instrumentation files (`OrionGuardInstrumentation`, `OrionGuardDomainEventTelemetry`, `OutboxDispatcherHostedService`), which drift identically.
- All meter/source versions now resolve to the package version (`6.6.1` after this bump).

### Version bump

- Bumped `<Version>` from `6.6.0` to `6.6.1` in all **15** `src/*` csproj files (PATCH). A grep for `6.6.0` under `src/` now returns nothing.
- Prepended CHANGELOG `## [6.6.1] - 2026-06-20` under `### Changed`.
- Added `.claude/` to `.gitignore`.

### Tests

`dotnet test -c Release` — all test assemblies pass on net10.0 (the test host TFM); src libraries build warning-clean across net8.0/net9.0/net10.0 under `TreatWarningsAsErrors`.

- Failed: 0 across all assemblies.
- Passed: 807 (579 core + 125 EFCore + 33 Dashboard + 15 SqlServerBroker + 14 PostgresNotify + 12 Generators + 11 Testing + 11 Locks.Redis + 7 AspNetCore).
- Skipped: 4 (Redis integration tests, env-gated).

No test asserted a hardcoded meter version string; the existing `MeterListener` tests subscribe by instrument name and are unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed hardcoded diagnostic meter versions that could drift from the actual package version. Meter versions now automatically derive from the package version to maintain alignment.

* **Chores**
  * Bumped all packages to v6.6.1.
  * Updated `.gitignore` to exclude local development files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->